### PR TITLE
fix(delve): Narrow arm64 stepping branch to Go 1.26 only

### DIFF
--- a/delve/pkg/proc/stepping_test.go
+++ b/delve/pkg/proc/stepping_test.go
@@ -1127,7 +1127,7 @@ func TestRangeOverFuncNext(t *testing.T) {
 		// depends on the toolchain version used to compile the
 		// fixtures, not the toolchain version used to compile
 		// delve's own test packages.
-		if goversion.ProducerAfterOrEqual(p.BinInfo().Producer(), 1, 26) && runtime.GOARCH == "arm64" {
+		if goversion.ProducerAfterOrEqual(p.BinInfo().Producer(), 1, 26) && !goversion.ProducerAfterOrEqual(p.BinInfo().Producer(), 1, 27) && runtime.GOARCH == "arm64" {
 			t.Run("TestGotoA1", func(t *testing.T) {
 				testseq2intl(t, fixture, grp, p, nil, []seqTest{
 					funcBreak(t, "main.TestGotoA1"),


### PR DESCRIPTION
On Go 1.27+, arm64 stepping for TestGotoA1 (in TestRangeOverFuncNextInlined)
matches the non-arm64 sequence again, so the arm64-specific branch should
only apply to Go 1.26. Upstream delve workaround: https://github.com/go-delve/delve/pull/4254.