### PR TITLE
fix(go): Skip TestGdbAutotmpTypes on Windows

### DIFF
--- a/go/src/runtime/runtime-gdb_test.go
+++ b/go/src/runtime/runtime-gdb_test.go
@@ -589,6 +589,14 @@ func TestGdbAutotmpTypes(t *testing.T) {
 	checkGdbVersion(t)
 	checkPtraceScope(t)
 
+	// NOTE(happygo): LUCI Windows builders skip this test because gdb
+	// is not on PATH (checkGdbVersion skips with "error executing gdb").
+	// However, GHA Windows runners have gdb (via MSYS2), which causes
+	// the test to run and then time out.
+	if runtime.GOOS == "windows" {
+		t.Skip("gdb tests not run on Windows upstream; times out on GHA")
+	}
+
 	if runtime.GOOS == "aix" && testing.Short() {
 		t.Skip("TestGdbAutotmpTypes is too slow on aix/ppc64")
 	}


### PR DESCRIPTION
LUCI Windows builders don't have gdb on PATH, so checkGdbVersion
skips this test immediately. GHA Windows runners have gdb via MSYS2,
causing the test to run and time out (3m43s observed).

Skip explicitly on Windows to match upstream behavior.

Fixes #36