### PR TITLE
fix(ci): Fix stale Go build cache

### DIFF
--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -27,10 +27,23 @@ runs:
     # Cache the build artifacts from the stdlib build
     # so that downstream operations don't need to rebuild
     # parts of the stdlib.
+    #
+    # On pushes to main, save + restore cache so it stays fresh.
     - uses: actions/cache@v5
+      if: github.event_name == 'push'
       with:
         path: .cache/go-build
-        key: go-cache-${{ inputs.toolchain }}-${{ inputs.os }}
+        key: go-cache-${{ inputs.toolchain }}-${{ inputs.os }}-${{ github.sha }}
+        restore-keys: |
+          go-cache-${{ inputs.toolchain }}-${{ inputs.os }}-
+    # On PRs, restore cache read-only (no save) to avoid bloat.
+    - uses: actions/cache/restore@v5
+      if: github.event_name != 'push'
+      with:
+        path: .cache/go-build
+        key: go-cache-${{ inputs.toolchain }}-${{ inputs.os }}-${{ github.sha }}
+        restore-keys: |
+          go-cache-${{ inputs.toolchain }}-${{ inputs.os }}-
     - name: Build (unix)
       if: runner.os != 'Windows'
       shell: bash


### PR DESCRIPTION
The build cache used a static key, so once created it never updated. This changes
pushes to main to save a SHA-suffixed cache (with prefix fallback for restore),
and PRs to use read-only restore to avoid cache bloat from branches.