### PR TITLE
chore(misc): Add fsx and result packages and use in happydo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules/
 
 # Accidentally built binaries at the root
 /happydo
+/misc/happydo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,8 @@ linters:
               desc: "use common/logx instead of log/slog"
             - pkg: "github.com/charmbracelet/log"
               desc: "use common/logx instead of charmbracelet/log directly"
+            - pkg: "github.com/spf13/afero"
+              desc: "use common/fsx instead of spf13/afero directly"
     importas:
       no-unaliased: true
       alias:

--- a/common/collections/set.go
+++ b/common/collections/set.go
@@ -49,7 +49,7 @@ func (s *Set[T]) IsSubsetOf(bigger *Set[T]) bool {
 }
 
 // SortedValues returns the elements of a set with an ordered element type in sorted order.
-func SortedValues[T cmp.Ordered](s *Set[T]) []T {
+func SortedValues[T cmp.Ordered](s Set[T]) []T {
 	values := make([]T, 0, s.Len())
 	for v := range s.values {
 		values = append(values, v)

--- a/common/core/pathx/pathx.go
+++ b/common/core/pathx/pathx.go
@@ -59,18 +59,6 @@ func (p AbsPath) MkdirAll(perm os.FileMode) error {
 	return os.MkdirAll(p.value, perm)
 }
 
-// MkdirTemp creates a temporary directory inside p.
-//
-// Pre-condition: pattern contains no path separators.
-func (p AbsPath) MkdirTemp(pattern string) (AbsPath, error) {
-	assert.Preconditionf(hasNoPathSeparator(pattern), "pattern contains path separator: %q", pattern)
-	dir, err := os.MkdirTemp(p.value, pattern)
-	if err != nil {
-		return AbsPath{}, err
-	}
-	return NewAbsPath(dir), nil
-}
-
 func (p AbsPath) RemoveAll() error {
 	return os.RemoveAll(p.value)
 }
@@ -116,7 +104,7 @@ func (p AbsPath) JoinComponents(pathElems ...string) AbsPath {
 	parts := make([]string, 0, len(pathElems)+1)
 	parts = append(parts, p.value)
 	for _, elem := range pathElems {
-		assert.Preconditionf(hasNoPathSeparator(elem), "path element contains separator: %q", elem)
+		assert.Preconditionf(!HasPathSeparators(elem), "path element contains separator: %q", elem)
 		parts = append(parts, elem)
 	}
 	return NewAbsPath(filepath.Join(parts...))
@@ -148,6 +136,23 @@ func NewRelPath(path string) RelPath {
 
 func (p RelPath) String() string {
 	return p.value
+}
+
+func (p RelPath) Join(rel RelPath) RelPath {
+	return NewRelPath(filepath.Join(p.value, rel.value))
+}
+
+// JoinComponents joins individual path components onto p.
+//
+// Pre-condition: no element contains a path separator.
+func (p RelPath) JoinComponents(pathElems ...string) RelPath {
+	parts := make([]string, 0, len(pathElems)+1)
+	parts = append(parts, p.value)
+	for _, elem := range pathElems {
+		assert.Preconditionf(!HasPathSeparators(elem), "path element contains separator: %q", elem)
+		parts = append(parts, elem)
+	}
+	return NewRelPath(filepath.Join(parts...))
 }
 
 func (p RelPath) Components() iter.Seq[string] {
@@ -209,16 +214,17 @@ func (p RelPath) lexicallyContainsUnix() bool {
 	return true
 }
 
-func hasNoPathSeparator(s string) bool {
+// HasPathSeparators reports whether s contains any path separators.
+func HasPathSeparators(s string) bool {
 	if runtime.GOOS == "windows" {
 		for i := range len(s) {
 			if s[i] == '\\' || s[i] == '/' {
-				return false
+				return true
 			}
 		}
-		return true
+		return false
 	}
-	return !strings.Contains(s, "/")
+	return strings.Contains(s, "/")
 }
 
 type RootRelPath struct {
@@ -240,4 +246,9 @@ func (p RootRelPath) String() string {
 
 func (p RootRelPath) AsAbsPath() AbsPath {
 	return p.root.Join(p.value)
+}
+
+// Rel returns the anchored relative portion of p, discarding the root.
+func (p RootRelPath) Rel() RelPath {
+	return p.value
 }

--- a/common/core/pathx/pathx_test.go
+++ b/common/core/pathx/pathx_test.go
@@ -1,9 +1,11 @@
 package pathx_test
 
 import (
+	"fmt"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"pgregory.net/rapid"
@@ -13,6 +15,7 @@ import (
 	. "github.com/typesanitizer/happygo/common/check/prelude"
 	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/core/pathx/pathx_testkit"
+	"github.com/typesanitizer/happygo/common/errorx"
 )
 
 func TestMakeRelativeTo(t *testing.T) {
@@ -125,7 +128,6 @@ func TestRelPathComponents(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		h.Run(tt.path, func(h check.Harness) {
 			got := make([]string, 0)
 			for c := range pathx.NewRelPath(tt.path).Components() {
@@ -152,7 +154,6 @@ func TestLexicallyContains(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		h.Run(tt.path, func(h check.Harness) {
 			got := root.LexicallyContains(pathx.NewRelPath(tt.path))
 			h.Assertf(got == tt.want, "LexicallyContains(%q) = %v, want %v", tt.path, got, tt.want)
@@ -177,6 +178,59 @@ func TestRootRelPathBasics(t *testing.T) {
 	rootRelPath := pathx.NewRootRelPath(root, rel)
 	check.AssertSame(h, rel.String(), rootRelPath.String(), "RootRelPath.String()")
 	check.AssertSame(h, root.Join(rel).String(), rootRelPath.AsAbsPath().String(), "RootRelPath.AsAbsPath()")
+	check.AssertSame(h, rel.String(), rootRelPath.Rel().String(), "RootRelPath.Rel()")
+}
+
+// TestPathFormatting verifies that the path types implement [fmt.Stringer]
+// so `%s` / `%q` format them by their String() value, letting callers of
+// fmt.Sprintf and errorx.Wrapf pass path types directly without .String().
+func TestPathFormatting(t *testing.T) {
+	h := check.New(t)
+
+	sep := string(filepath.Separator)
+	absStr := sep + filepath.Join("tmp", "x")
+	relStr := filepath.Join("a", "b")
+	rootRelStr := relStr // RootRelPath.String() returns just the relative portion.
+
+	abs := pathx.NewAbsPath(absStr)
+	rel := pathx.NewRelPath(relStr)
+	rootRel := pathx.NewRootRelPath(abs, rel)
+
+	tests := []struct {
+		name      string
+		value     fmt.Stringer
+		want      string
+		wantQuote string
+	}{
+		{name: "AbsPath", value: abs, want: absStr, wantQuote: `"` + absStr + `"`},
+		{name: "RelPath", value: rel, want: relStr, wantQuote: `"` + relStr + `"`},
+		{name: "RootRelPath", value: rootRel, want: rootRelStr, wantQuote: `"` + rootRelStr + `"`},
+	}
+
+	baseErr := errorx.Newf("nostack", "base")
+
+	for _, tt := range tests {
+		h.Run(tt.name, func(h check.Harness) {
+			h.Parallel()
+
+			var sBuilder strings.Builder
+			_, err := fmt.Fprintf(&sBuilder, "%s", tt.value)
+			h.NoErrorf(err, "fmt.Fprintf %%s")
+			gotS := sBuilder.String()
+			gotQ := fmt.Sprintf("%q", tt.value)
+
+			gotErrS := errorx.Wrapf("nostack", baseErr, "path: %s", tt.value).Error()
+			wantErrS := "path: " + tt.want + ": base"
+
+			gotErrQ := errorx.Wrapf("nostack", baseErr, "path: %q", tt.value).Error()
+			wantErrQ := "path: " + tt.wantQuote + ": base"
+
+			check.AssertSame(h, tt.want, gotS, "fmt.Sprintf %s")
+			check.AssertSame(h, tt.wantQuote, gotQ, "fmt.Sprintf %q")
+			check.AssertSame(h, wantErrS, gotErrS, "errorx.Wrapf %s")
+			check.AssertSame(h, wantErrQ, gotErrQ, "errorx.Wrapf %q")
+		})
+	}
 }
 
 func TestResolveAbsPath(t *testing.T) {
@@ -198,31 +252,36 @@ func TestRejectsEmptyPaths(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		h.Run(tt.name, func(h check.Harness) {
 			h.AssertPanicsWith(want, tt.call)
 		})
 	}
 }
 
-func TestMkdirTempRejectsPathSeparatorInPattern(t *testing.T) {
+func TestHasPathSeparators(t *testing.T) {
 	h := check.New(t)
-	root := pathx.NewAbsPath(t.TempDir())
 
-	patterns := []string{"a/b"}
-	if runtime.GOOS == "windows" {
-		patterns = append(patterns, `a\b`)
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "empty", value: "", want: false},
+		{name: "plain", value: "abc", want: false},
+		{name: "slash", value: "a/b", want: true},
 	}
-	for _, pattern := range patterns {
-		pattern := pattern
-		h.Run(pattern, func(h check.Harness) {
-			want := assert.AssertionError{
-				Fmt:  "precondition violation: pattern contains path separator: %q",
-				Args: []any{pattern},
-			}
-			h.AssertPanicsWith(want, func() {
-				_, _ = root.MkdirTemp(pattern)
-			})
+	if runtime.GOOS == "windows" {
+		tests = append(tests, struct {
+			name  string
+			value string
+			want  bool
+		}{name: "backslash", value: `a\b`, want: true})
+	}
+
+	for _, tt := range tests {
+		h.Run(tt.name, func(h check.Harness) {
+			got := pathx.HasPathSeparators(tt.value)
+			h.Assertf(got == tt.want, "HasPathSeparators(%q) = %v, want %v", tt.value, got, tt.want)
 		})
 	}
 }

--- a/common/core/result.go
+++ b/common/core/result.go
@@ -1,0 +1,21 @@
+package core
+
+import "github.com/typesanitizer/happygo/common/core/result"
+
+// Result holds either a value of type T or an error.
+//
+// Use [Success] or [Failure] to construct one. A Failure always carries a
+// non-nil error; a Success has a nil error.
+type Result[T any] = result.Result[T]
+
+// Success returns a Result containing value.
+func Success[T any](value T) Result[T] {
+	return result.Success(value)
+}
+
+// Failure returns a Result containing err.
+//
+// Pre-condition: err is non-nil.
+func Failure[T any](err error) Result[T] {
+	return result.Failure[T](err)
+}

--- a/common/core/result/result.go
+++ b/common/core/result/result.go
@@ -1,0 +1,40 @@
+// Package result provides a generic Result[T] type holding either a value or
+// an error.
+package result
+
+import "github.com/typesanitizer/happygo/common/assert"
+
+// Result holds either a value of type T or an error.
+//
+// Use [Success] or [Failure] to construct one. A Failure always carries a
+// non-nil error; a Success has a nil error.
+type Result[T any] struct {
+	value T
+	err   error
+}
+
+// Success returns a Result containing value.
+func Success[T any](value T) Result[T] {
+	return Result[T]{value: value, err: nil}
+}
+
+// Failure returns a Result containing err.
+//
+// Pre-condition: err is non-nil.
+func Failure[T any](err error) Result[T] {
+	assert.Preconditionf(err != nil, "Failure called with nil error")
+	var zero T
+	return Result[T]{value: zero, err: err}
+}
+
+// Get returns the contained value and error.
+// If r is a Success, err is nil.
+// If r is a Failure, err is non-nil and the value is the zero value of T.
+func (r Result[T]) Get() (T, error) {
+	return r.value, r.err
+}
+
+// ErrOrNil returns the contained error, or nil if r is a Success.
+func (r Result[T]) ErrOrNil() error {
+	return r.err
+}

--- a/common/core/result/result_test.go
+++ b/common/core/result/result_test.go
@@ -1,0 +1,46 @@
+package result_test
+
+import (
+	"testing"
+
+	"github.com/typesanitizer/happygo/common/assert"
+	"github.com/typesanitizer/happygo/common/check"
+	. "github.com/typesanitizer/happygo/common/core/result"
+	"github.com/typesanitizer/happygo/common/errorx"
+)
+
+func TestResult(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("Success", func(h check.Harness) {
+		h.Parallel()
+
+		r := Success(42)
+		h.Assertf(r.ErrOrNil() == nil, "Success.ErrOrNil() should be nil")
+		v, err := r.Get()
+		h.Assertf(v == 42 && err == nil, "Get() = (%d, %v), want (42, nil)", v, err)
+	})
+
+	h.Run("Failure", func(h check.Harness) {
+		h.Parallel()
+
+		want := errorx.New("nostack", "boom")
+		r := Failure[int](want)
+		h.Assertf(r.ErrOrNil() == want, "Failure.ErrOrNil() = %v, want %v", r.ErrOrNil(), want)
+		v, err := r.Get()
+		h.Assertf(v == 0 && err == want, "Get() = (%d, %v), want (0, %v)", v, err, want)
+	})
+
+	h.Run("FailureNilPanics", func(h check.Harness) {
+		h.Parallel()
+
+		wantPanic := assert.AssertionError{
+			Fmt:  "precondition violation: Failure called with nil error",
+			Args: nil,
+		}
+		h.AssertPanicsWith(wantPanic, func() {
+			_ = Failure[int](nil)
+		})
+	})
+}

--- a/common/fsx/fsx.go
+++ b/common/fsx/fsx.go
@@ -1,0 +1,193 @@
+// Package fsx provides a rooted filesystem wrapper over [afero.Fs] that
+// operates on [RelPath] values anchored at a repo-root [AbsPath].
+//
+// The goal is to keep pure path operations in [pathx] while routing all
+// filesystem effects through this package, so typed paths stay internal and
+// string conversion is confined to the filesystem boundary.
+package fsx
+
+import (
+	"io"
+	iofs "io/fs" //nolint:depguard // fsx is the designated wrapper
+	"iter"
+	"os"
+
+	"github.com/spf13/afero" //nolint:depguard // fsx is the designated wrapper
+
+	"github.com/typesanitizer/happygo/common/assert"
+	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/pathx"
+	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/iterx"
+)
+
+const readDirBatchSize = 32
+
+// File is an open file handle returned by [FS.Open] and similar methods.
+// It is an alias for [afero.File] so callers need not import afero directly.
+type File = afero.File
+
+// DirEntry is a single entry returned by [FS.ReadDir].
+type DirEntry interface {
+	// BaseName returns just the basename component of the entry.
+	BaseName() string
+	IsDir() bool
+	Info() (os.FileInfo, error)
+}
+
+type dirEntry struct {
+	entry iofs.DirEntry
+}
+
+func (e dirEntry) BaseName() string {
+	return e.entry.Name()
+}
+
+func (e dirEntry) IsDir() bool {
+	return e.entry.IsDir()
+}
+
+func (e dirEntry) Info() (os.FileInfo, error) {
+	return e.entry.Info()
+}
+
+// FS is a rooted filesystem wrapper. All methods operate on paths relative
+// to Root().
+type FS struct {
+	// Stored separately because afero.BasePathFs does not expose its configured
+	// root path back to callers, but fsx needs to provide Root().
+	root AbsPath
+	base afero.Fs
+}
+
+// OS returns an FS backed by the host operating system rooted at root.
+func OS(root AbsPath) (FS, error) {
+	return newRootedFS(root, afero.NewOsFs())
+}
+
+// MemMap returns an in-memory FS rooted at root.
+func MemMap(root AbsPath) (FS, error) {
+	backing := afero.NewMemMapFs()
+	if err := backing.MkdirAll(root.String(), 0o755); err != nil {
+		return FS{}, errorx.Wrapf("+stacks", err, "create fs root %s", root)
+	}
+	return newRootedFS(root, backing)
+}
+
+func newRootedFS(root AbsPath, backing afero.Fs) (FS, error) {
+	info, err := backing.Stat(root.String())
+	if err != nil {
+		return FS{}, errorx.Wrapf("+stacks", err, "stat fs root %s", root)
+	}
+	if !info.IsDir() {
+		return FS{}, errorx.Newf("nostack", "fs root %s is not a directory", root)
+	}
+	return FS{root: root, base: afero.NewBasePathFs(backing, root.String())}, nil
+}
+
+// Root returns the absolute path this FS is rooted at.
+func (fs FS) Root() AbsPath {
+	return fs.root
+}
+
+// Stat returns file info for the given root-relative path.
+func (fs FS) Stat(rel RelPath) (os.FileInfo, error) {
+	return fs.base.Stat(rel.String())
+}
+
+// ReadDir iterates over directory entries at the given root-relative path.
+//
+// Errors produced mid-iteration are surfaced as [Failure] elements
+// rather than being returned eagerly. Callers should stop iterating on the
+// first failure.
+func (fs FS) ReadDir(rel RelPath) iter.Seq[Result[DirEntry]] {
+	return iterx.Map(iterx.Unbatch(fs.readDirBatches(rel)), func(entryRes Result[iofs.DirEntry]) Result[DirEntry] {
+		entry, err := entryRes.Get()
+		if err != nil {
+			return Failure[DirEntry](err)
+		}
+		return Success[DirEntry](dirEntry{entry: entry})
+	})
+}
+
+func (fs FS) readDirBatches(rel RelPath) iter.Seq[Result[[]iofs.DirEntry]] {
+	return func(yield func(Result[[]iofs.DirEntry]) bool) {
+		f, err := fs.base.Open(rel.String())
+		if err != nil {
+			yield(Failure[[]iofs.DirEntry](err))
+			return
+		}
+		defer func() {
+			_ = f.Close()
+		}()
+
+		rdf, ok := f.(iofs.ReadDirFile)
+		assert.Invariantf(ok, "open(%q) returned %T, want fs.ReadDirFile", rel, f)
+
+		for {
+			entries, err := rdf.ReadDir(readDirBatchSize)
+			if len(entries) > 0 {
+				if !yield(Success(entries)) {
+					return
+				}
+			}
+			// For n > 0, ReadDirFile guarantees that an empty batch comes with a
+			// non-nil error. Yield any entries before inspecting err so a final
+			// short batch is not dropped if an implementation returns it with EOF,
+			// then stop immediately on EOF rather than calling ReadDir again.
+			switch err {
+			case nil:
+				assert.Invariantf(len(entries) > 0,
+					"ReadDir(%q) returned an empty batch without EOF", rel)
+			case io.EOF:
+				return
+			default:
+				yield(Failure[[]iofs.DirEntry](err))
+				return
+			}
+		}
+	}
+}
+
+// Open opens the file at the given root-relative path for reading.
+func (fs FS) Open(rel RelPath) (File, error) {
+	return fs.base.Open(rel.String())
+}
+
+// ReadFile reads the file at the given root-relative path.
+func (fs FS) ReadFile(rel RelPath) ([]byte, error) {
+	return afero.ReadFile(fs.base, rel.String())
+}
+
+// WriteFile writes data to the file at the given root-relative path.
+func (fs FS) WriteFile(rel RelPath, data []byte, perm os.FileMode) error {
+	return afero.WriteFile(fs.base, rel.String(), data, perm)
+}
+
+// MkdirAll creates the directory at the given root-relative path along with
+// any necessary parents.
+func (fs FS) MkdirAll(rel RelPath, perm os.FileMode) error {
+	return fs.base.MkdirAll(rel.String(), perm)
+}
+
+// MkdirTemp creates a new temporary directory inside dir (root-relative)
+// whose name begins with pattern, and returns the resulting root-relative path.
+//
+// Pre-condition: pattern is non-empty and contains no path separators.
+func (fs FS) MkdirTemp(dir RelPath, pattern string) (RelPath, error) {
+	assert.Preconditionf(pattern != "", "pattern is empty")
+	assert.Preconditionf(!pathx.HasPathSeparators(pattern), "pattern contains path separator: %q", pattern)
+	// afero.TempDir returns filepath.Join(dir, pattern+rand) relative to fs.base,
+	// so the returned path is already root-relative rather than just a basename.
+	tmpDir, err := afero.TempDir(fs.base, dir.String(), pattern)
+	if err != nil {
+		return RelPath{}, err
+	}
+	return NewRelPath(tmpDir), nil
+}
+
+// RemoveAll removes the file or directory at the given root-relative path
+// along with any children it contains.
+func (fs FS) RemoveAll(rel RelPath) error {
+	return fs.base.RemoveAll(rel.String())
+}

--- a/common/fsx/fsx_test.go
+++ b/common/fsx/fsx_test.go
@@ -1,0 +1,78 @@
+package fsx
+
+import (
+	"fmt"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/typesanitizer/happygo/common/assert"
+	"github.com/typesanitizer/happygo/common/check"
+	. "github.com/typesanitizer/happygo/common/check/prelude"
+	"github.com/typesanitizer/happygo/common/collections"
+	. "github.com/typesanitizer/happygo/common/core"
+)
+
+func TestReadDirBatched(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	repoFS := Do(OS(NewAbsPath(t.TempDir())))(h)
+
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		entryCount := rapid.IntRange(0, readDirBatchSize*3).Draw(t, "entry_count")
+		parentDir := Do(repoFS.MkdirTemp(NewRelPath("."), "entries-"))(h)
+
+		want := collections.NewSet[string]()
+		for i := range entryCount {
+			name := fmt.Sprintf("file-%03d.txt", i)
+			fileRel := parentDir.JoinComponents(name)
+			h.NoErrorf(repoFS.WriteFile(fileRel, []byte("data"), 0o644), "WriteFile(%q)", fileRel)
+			want.Insert(name)
+		}
+
+		got := collections.NewSet[string]()
+		for entryRes := range repoFS.ReadDir(parentDir) {
+			entry := Do(entryRes.Get())(h)
+			name := entry.BaseName()
+			h.Assertf(got.Insert(name), "duplicate entry %q from ReadDir(%q)", name, parentDir)
+
+			info := Do(entry.Info())(h)
+			h.Assertf(info.Name() == name, "Info(%q).Name() = %q, want %q", name, info.Name(), name)
+			h.Assertf(!entry.IsDir(), "ReadDir(%q) returned directory entry %q, want file", parentDir, name)
+			h.Assertf(!info.IsDir(), "Info(%q).IsDir() = true, want false", name)
+		}
+
+		check.AssertSame(h, collections.SortedValues(want), collections.SortedValues(got), "ReadDir entries")
+	})
+}
+
+func TestReadDirOnFileReturnsError(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	repoFS := Do(OS(NewAbsPath(t.TempDir())))(h)
+
+	fileRel := NewRelPath("file.txt")
+	h.NoErrorf(repoFS.WriteFile(fileRel, []byte("data"), 0o644), "WriteFile(%q)", fileRel)
+
+	gotAny := false
+	for entryRes := range repoFS.ReadDir(fileRel) {
+		gotAny = true
+		_, err := entryRes.Get()
+		h.Assertf(err != nil, "ReadDir(%q) unexpectedly succeeded", fileRel)
+	}
+	h.Assertf(gotAny, "ReadDir(%q) produced no result", fileRel)
+}
+
+func TestMkdirTempRejectsEmptyPattern(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	repoFS := Do(OS(NewAbsPath(t.TempDir())))(h)
+	want := assert.AssertionError{Fmt: "precondition violation: pattern is empty", Args: nil}
+	h.AssertPanicsWith(want, func() {
+		_, _ = repoFS.MkdirTemp(NewRelPath("."), "")
+	})
+}

--- a/common/iterx/iterx.go
+++ b/common/iterx/iterx.go
@@ -1,6 +1,10 @@
 package iterx
 
-import "iter"
+import (
+	"iter"
+
+	"github.com/typesanitizer/happygo/common/core/result"
+)
 
 // Collect accumulates all values from an iterator into a slice.
 func Collect[T any](seq iter.Seq[T]) []T {
@@ -9,4 +13,34 @@ func Collect[T any](seq iter.Seq[T]) []T {
 		result = append(result, v)
 	}
 	return result
+}
+
+// Map transforms each value in seq with f.
+func Map[T any, U any](seq iter.Seq[T], f func(T) U) iter.Seq[U] {
+	return func(yield func(U) bool) {
+		for v := range seq {
+			if !yield(f(v)) {
+				return
+			}
+		}
+	}
+}
+
+// Unbatch flattens an iterator of batched results into an iterator of element
+// results, preserving failures.
+func Unbatch[T any](seq iter.Seq[result.Result[[]T]]) iter.Seq[result.Result[T]] {
+	return func(yield func(result.Result[T]) bool) {
+		for batchRes := range seq {
+			batch, err := batchRes.Get()
+			if err != nil {
+				yield(result.Failure[T](err))
+				return
+			}
+			for _, item := range batch {
+				if !yield(result.Success(item)) {
+					return
+				}
+			}
+		}
+	}
 }

--- a/docs/style-guides/go.md
+++ b/docs/style-guides/go.md
@@ -7,6 +7,35 @@ This guide applies to non-forked folders only (for example, `common/`, `meta/`, 
 - Group order: stdlib, third-party, monorepo (`github.com/typesanitizer/happygo/...`).
 - `github.com/typesanitizer/happygo/common/core` should be imported with `.`.
 
+## Naming
+
+### Avoid negation in names
+
+```go
+type ABC struct {
+    xyzDisabled bool // ❌
+}
+
+func HasNoPathSeparators(p string) bool // ❌
+```
+
+Use positive naming, letting the caller handle negation.
+
+```go
+type ABC struct {
+    xyzEnabled bool // ✔️
+}
+
+func HasPathSeparators(p string) bool // ✔️
+```
+
+**Q**: Won't this lead to potential bugs with default initialization
+or higher verbosity when the more common desired setting is `true`?
+
+**A**: If that kind of default initialization is desired, expose a helper
+function. Higher verbosity is not a reason to reduce readability.
+Overall the risk of confusing code due to double negations is higher.
+
 ## 'Type-unique' arguments bundled as first parameter
 
 Examples:

--- a/misc/cmd/happydo/list.go
+++ b/misc/cmd/happydo/list.go
@@ -10,13 +10,14 @@ import (
 
 	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
 	"github.com/typesanitizer/happygo/common/logx"
 	"github.com/typesanitizer/happygo/misc/internal/config"
 )
 
-func loadWorkspaceConfig(repoRoot AbsPath) (_ config.WorkspaceConfig, retErr error) {
-	path := repoRoot.JoinComponents("misc", "repo-configuration.json").String()
-	f, err := os.Open(path)
+func loadWorkspaceConfig(repoFS fsx.FS) (_ config.WorkspaceConfig, retErr error) {
+	path := NewRelPath("misc/repo-configuration.json")
+	f, err := repoFS.Open(path)
 	if err != nil {
 		return config.WorkspaceConfig{}, errorx.Wrapf("+stacks", err, "open %s", path)
 	}
@@ -48,8 +49,8 @@ const (
 
 // Workspace provides operations over the repository root using the repo configuration.
 type Workspace struct {
-	RepoRoot AbsPath
-	Config   config.WorkspaceConfig
+	FS     fsx.FS
+	Config config.WorkspaceConfig
 }
 
 func newWorkspaceFromGit() (Workspace, error) {
@@ -58,8 +59,12 @@ func newWorkspaceFromGit() (Workspace, error) {
 		return Workspace{}, errorx.Wrapf("nostack", err, "determine git repository root")
 	}
 	repoRoot := NewAbsPath(strings.TrimSpace(string(out)))
-	wsConfig, err := loadWorkspaceConfig(repoRoot)
-	return Workspace{RepoRoot: repoRoot, Config: wsConfig}, err
+	repoFS, err := fsx.OS(repoRoot)
+	if err != nil {
+		return Workspace{}, errorx.Wrapf("+stacks", err, "open repo filesystem at %s", repoRoot)
+	}
+	wsConfig, err := loadWorkspaceConfig(repoFS)
+	return Workspace{FS: repoFS, Config: wsConfig}, err
 }
 
 type ListOptions struct {
@@ -91,18 +96,19 @@ func (w Workspace) listGoModules(logger *logx.Logger, out io.Writer, provenance 
 }
 
 func (w Workspace) goModules(logger *logx.Logger, provenance ListProvenance) ([]string, error) {
-	entries, err := os.ReadDir(w.RepoRoot.String())
-	if err != nil {
-		return nil, errorx.Wrapf("+stacks", err, "read directory %s", w.RepoRoot.String())
-	}
-
+	rootRel := NewRelPath(".")
 	var folders []string
-	for _, entry := range entries {
+	for entryRes := range w.FS.ReadDir(rootRel) {
+		entry, err := entryRes.Get()
+		if err != nil {
+			return nil, errorx.Wrapf("+stacks", err, "read directory %s", w.FS.Root())
+		}
 		if !entry.IsDir() {
 			continue
 		}
-		name := entry.Name()
-		if _, err := os.Stat(w.RepoRoot.JoinComponents(name, "go.mod").String()); err != nil {
+		name := entry.BaseName()
+		goModRel := rootRel.JoinComponents(name, "go.mod")
+		if _, err := w.FS.Stat(goModRel); err != nil {
 			if !os.IsNotExist(err) {
 				logger.Warn("stat go.mod", "dir", name, "err", err)
 			}

--- a/misc/cmd/happydo/list_test.go
+++ b/misc/cmd/happydo/list_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/typesanitizer/happygo/common/check"
+	. "github.com/typesanitizer/happygo/common/check/prelude"
 	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/fsx"
 	"github.com/typesanitizer/happygo/common/logx"
 	"github.com/typesanitizer/happygo/misc/internal/config"
 )
@@ -24,8 +26,10 @@ func TestList(t *testing.T) {
 		"file.txt":     "not a dir\n",
 	})
 
+	repoFS := Do(fsx.OS(NewAbsPath(root)))(h)
+
 	ws := Workspace{
-		RepoRoot: NewAbsPath(root),
+		FS: repoFS,
 		Config: config.WorkspaceConfig{
 			ForkedFolders: map[string]config.ForkedFolder{
 				"beta": {Folder: "beta", GitHubRepo: "example/beta"},

--- a/misc/cmd/happydo/sync_branch.go
+++ b/misc/cmd/happydo/sync_branch.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"os"
 	"strings"
 
 	"github.com/typesanitizer/happygo/common/assert"
 	"github.com/typesanitizer/happygo/common/cmdx"
 	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
 	"github.com/typesanitizer/happygo/common/logx"
 )
 
@@ -25,17 +25,17 @@ type remoteRef struct {
 func (ws Workspace) runSyncBranch(ctx logx.LogCtx, projects []string, options RunSyncBranchOptions) (err error) {
 	assert.Precondition(len(projects) > 0, "must sync 1+ projects")
 	baseBranch := options.Base.ValueOr("main")
-	fetchBaseCmd := cmdx.New("git", "fetch", "origin", baseBranch).In(ws.RepoRoot)
+	fetchBaseCmd := cmdx.New("git", "fetch", "origin", baseBranch).In(ws.FS.Root())
 	if _, err := fetchBaseCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
 		return err
 	}
-	worktreeDir, cleanup, err := createSyncWorktree(ctx, ws.RepoRoot, baseBranch)
+	worktreeDir, cleanup, err := createSyncWorktree(ctx, ws.FS, baseBranch)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		if options.Persist {
-			ctx.Info("persisting sync worktree", "worktree", worktreeDir.String())
+			ctx.Info("persisting sync worktree", "worktree", ws.FS.Root().Join(worktreeDir).String())
 			return
 		}
 		err = errorx.Join(err, cleanup())
@@ -53,25 +53,26 @@ func (ws Workspace) runSyncBranch(ctx logx.LogCtx, projects []string, options Ru
 }
 
 func runSyncBranchProject(
-	ctx logx.LogCtx, ws Workspace, project string, worktreeDir AbsPath, baseBranch string, push bool,
+	ctx logx.LogCtx, ws Workspace, project string, worktreeDir RelPath, baseBranch string, push bool,
 ) error {
+	worktreeAbs := ws.FS.Root().Join(worktreeDir)
 	syncBranch := syncBranchPrefix + project
 	ctx.Info(
 		"syncing",
 		"project", project, "branch", syncBranch,
-		"worktree", worktreeDir.String(), "base", baseBranch,
+		"worktree", worktreeAbs.String(), "base", baseBranch,
 	)
-	if err := resetWorktreeToBase(ctx, worktreeDir, baseBranch); err != nil {
+	if err := resetWorktreeToBase(ctx, worktreeAbs, baseBranch); err != nil {
 		return errorx.Wrapf("nostack", err, "reset worktree to base %q", baseBranch)
 	}
-	if err := deleteLocalBranchIfPresent(ctx, worktreeDir, syncBranch); err != nil {
+	if err := deleteLocalBranchIfPresent(ctx, worktreeAbs, syncBranch); err != nil {
 		return errorx.Wrapf("nostack", err, "delete local branch %q", syncBranch)
 	}
-	checkoutCmd := cmdx.New("git", "checkout", "-B", syncBranch).In(worktreeDir)
+	checkoutCmd := cmdx.New("git", "checkout", "-B", syncBranch).In(worktreeAbs)
 	if _, err := checkoutCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
 		return err
 	}
-	if err := ws.runUpdate(ctx, worktreeDir, baseBranch, []string{project}); err != nil {
+	if err := ws.runUpdate(ctx, worktreeAbs, baseBranch, []string{project}); err != nil {
 		return err
 	}
 	if !push {
@@ -79,7 +80,7 @@ func runSyncBranchProject(
 		return nil
 	}
 
-	remoteHead, err := findRemoteBranchHeadRef(ctx, worktreeDir, syncBranch)
+	remoteHead, err := findRemoteBranchHeadRef(ctx, worktreeAbs, syncBranch)
 	if err != nil {
 		return errorx.Wrapf("nostack", err, "find remote head ref for %q", syncBranch)
 	}
@@ -87,7 +88,7 @@ func runSyncBranchProject(
 	ctx.Info("pushing sync branch", "project", project, "branch", syncBranch)
 	// See SYNC(id: gha-permissions).
 	pushCmd := cmdx.New("git", "push", forceWithLeaseArg, "origin", syncBranch+":"+syncBranch).
-		In(worktreeDir)
+		In(worktreeAbs)
 	if _, err := pushCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
 		return err
 	}
@@ -165,15 +166,15 @@ func formatLease(branch string, remoteHead Option[remoteRef]) string {
 }
 
 func createSyncWorktree(
-	ctx logx.LogCtx, repoRoot AbsPath, base string,
-) (AbsPath, func() error, error) {
-	tmpRoot := repoRoot.JoinComponents(".cache", "tmp")
-	if err := tmpRoot.MkdirAll(0o755); err != nil {
-		return AbsPath{}, nil, errorx.Wrapf("+stacks", err, "create temp root %q", tmpRoot)
+	ctx logx.LogCtx, repoFS fsx.FS, base string,
+) (RelPath, func() error, error) {
+	tmpRoot := NewRelPath(".cache").JoinComponents("tmp")
+	if err := repoFS.MkdirAll(tmpRoot, 0o755); err != nil {
+		return RelPath{}, nil, errorx.Wrapf("+stacks", err, "create temp root %s", tmpRoot)
 	}
-	worktreeDir, err := tmpRoot.MkdirTemp("meta-sync-")
+	worktreeDir, err := repoFS.MkdirTemp(tmpRoot, "meta-sync-")
 	if err != nil {
-		return AbsPath{}, nil, errorx.Wrapf("+stacks", err, "create sync worktree")
+		return RelPath{}, nil, errorx.Wrapf("+stacks", err, "create sync worktree")
 	}
 
 	worktreeAdded := false
@@ -181,29 +182,30 @@ func createSyncWorktree(
 		var cleanupErr error
 		if worktreeAdded {
 			removeCmd := cmdx.New("git", "worktree", "remove", "--force", worktreeDir.String()).
-				In(repoRoot)
+				In(repoFS.Root())
 			if _, removeErr := removeCmd.Run(ctx, cmdx.RunOptionsDefault()); removeErr != nil {
 				cleanupErr = errorx.Join(cleanupErr, removeErr)
 			}
 		}
-		if removeErr := os.RemoveAll(worktreeDir.String()); removeErr != nil {
+		if removeErr := repoFS.RemoveAll(worktreeDir); removeErr != nil {
 			cleanupErr = errorx.Join(cleanupErr,
-				errorx.Wrapf("+stacks", removeErr, "remove %q", worktreeDir.String()))
+				errorx.Wrapf("+stacks", removeErr, "remove %s", worktreeDir))
 		}
 		return cleanupErr
 	}
 
 	ctx.Info("adding detached sync worktree", "base", base, "worktree", worktreeDir.String())
 	addCmd := cmdx.New("git", "worktree", "add", "--quiet", "--detach", worktreeDir.String(), "origin/"+base).
-		In(repoRoot)
+		In(repoFS.Root())
 	if _, err := addCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
-		return AbsPath{}, nil, errorx.Join(err, cleanup())
+		return RelPath{}, nil, errorx.Join(err, cleanup())
 	}
 	worktreeAdded = true
 
-	detachCmd := cmdx.New("git", "checkout", "--detach", "origin/"+base).In(worktreeDir)
+	detachCmd := cmdx.New("git", "checkout", "--detach", "origin/"+base).
+		In(repoFS.Root().Join(worktreeDir))
 	if _, err := detachCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
-		return AbsPath{}, nil, errorx.Join(err, cleanup())
+		return RelPath{}, nil, errorx.Join(err, cleanup())
 	}
 	ctx.Info("worktree ready for sync", "worktree", worktreeDir.String(), "base", base)
 	return worktreeDir, cleanup, nil

--- a/misc/cmd/happydo/sync_pr.go
+++ b/misc/cmd/happydo/sync_pr.go
@@ -62,7 +62,7 @@ func (ws Workspace) runSyncPR(ctx logx.LogCtx, projects []string, options RunSyn
 	assert.Precondition(len(projects) > 0, "must sync 1+ projects")
 	base := options.Base.ValueOr("main")
 	for _, project := range projects {
-		if err := runSyncPRProject(ctx, ws.RepoRoot, project, base); err != nil {
+		if err := runSyncPRProject(ctx, ws.FS.Root(), project, base); err != nil {
 			return err
 		}
 	}
@@ -70,7 +70,6 @@ func (ws Workspace) runSyncPR(ctx logx.LogCtx, projects []string, options RunSyn
 }
 
 func runSyncPRProject(ctx logx.LogCtx, repoRoot AbsPath, project string, base string) error {
-
 	syncBranch := syncBranchPrefix + project
 	fetchCmd := cmdx.New("git", "fetch", "origin", syncBranch).In(repoRoot)
 	if _, err := fetchCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {

--- a/misc/internal/config/validate.go
+++ b/misc/internal/config/validate.go
@@ -106,7 +106,7 @@ func validateBranchMappings(mappingsJSON []BranchMappingJSON, forkedRepos collec
 			}
 		}
 
-		for _, forkedRepo := range collections.SortedValues(&forkedRepos) {
+		for _, forkedRepo := range collections.SortedValues(forkedRepos) {
 			if _, ok := upstreamMap.ByGitHubRepo[forkedRepo]; !ok {
 				err = errorx.Join(err, errorx.Newf("nostack", "branch mapping %q missing upstream project %q", mappingJSON.LocalBranch, forkedRepo))
 			}


### PR DESCRIPTION
It's useful to be have a virtual filesystem abstraction
so that we can have fast tests without actually writing
to the filesystem. We reuse spf13/afero with our own
wrapper package, similar to how we wrap other third-party
packages.