### PR TITLE
chore(check): Add prelude.Do helper & use it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,10 +21,10 @@ linters:
     - unused
   exclusions:
     rules:
-      # common/core is designed for dot-import usage.
+      # common/core and common/check/prelude are designed for dot-import usage.
       - linters: [staticcheck]
         text: "ST1001"
-        source: 'common/core'
+        source: 'common/core|common/check/prelude'
       - linters: [forbidigo]
         path: ^common/core/pathx/pathx.go$
         source: 'os\.(MkdirAll|MkdirTemp)'
@@ -54,7 +54,7 @@ linters:
     importas:
       no-unaliased: true
       alias:
-        - pkg: github.com/typesanitizer/happygo/common/core
+        - pkg: github.com/typesanitizer/happygo/common/(core|check/prelude)
           alias: .
     exhaustruct:
       # NOTE: Even with allow-empty-returns: false, exhaustruct unconditionally

--- a/common/check/prelude/prelude.go
+++ b/common/check/prelude/prelude.go
@@ -1,0 +1,20 @@
+// Package prelude provides terse test helpers intended for dot-import in tests.
+package prelude
+
+import "github.com/typesanitizer/happygo/common/check"
+
+// Do turns a (T, error) pair into a harness-applied extractor.
+func Do[T any](value T, err error) func(check.BasicHarness) T {
+	return func(h check.BasicHarness) T {
+		h.NoErrorf(err, "unexpected error")
+		return value
+	}
+}
+
+// DoMsg turns a (T, error) pair into a harness-applied extractor with a custom error message.
+func DoMsg[T any](value T, err error) func(check.BasicHarness, string, ...any) T {
+	return func(h check.BasicHarness, msg string, args ...any) T {
+		h.NoErrorf(err, msg, args...)
+		return value
+	}
+}

--- a/common/core/pathx/pathx_test.go
+++ b/common/core/pathx/pathx_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/typesanitizer/happygo/common/assert"
 	"github.com/typesanitizer/happygo/common/check"
+	. "github.com/typesanitizer/happygo/common/check/prelude"
 	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/core/pathx/pathx_testkit"
 )
@@ -180,8 +181,7 @@ func TestRootRelPathBasics(t *testing.T) {
 
 func TestResolveAbsPath(t *testing.T) {
 	h := check.New(t)
-	_, err := pathx.ResolveAbsPath(".")
-	h.NoErrorf(err, "ResolveAbsPath(.)")
+	_ = Do(pathx.ResolveAbsPath("."))(h)
 }
 
 func TestRejectsEmptyPaths(t *testing.T) {

--- a/misc/cmd/happydo/sync_branch_test.go
+++ b/misc/cmd/happydo/sync_branch_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/typesanitizer/happygo/common/check"
+	. "github.com/typesanitizer/happygo/common/check/prelude"
 	. "github.com/typesanitizer/happygo/common/core"
 )
 
@@ -65,7 +66,7 @@ func TestParseSingleRemoteRef(t *testing.T) {
 					"got error %q, want substring %q", err.Error(), tt.wantErr)
 				return
 			}
-			h.NoErrorf(err, "parseSingleRemoteRef")
+			got = Do(got, err)(h)
 			h.Assertf(got == tt.want, "got %#v, want %#v", got, tt.want)
 		})
 	}

--- a/misc/internal/config/validate_test.go
+++ b/misc/internal/config/validate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/typesanitizer/happygo/common/check"
+	. "github.com/typesanitizer/happygo/common/check/prelude"
 )
 
 func validConfig() WorkspaceConfigJSON {
@@ -162,8 +163,7 @@ func TestValidateSuccess(t *testing.T) {
 	h.Parallel()
 
 	cfg := validConfig()
-	rc, err := cfg.Validate()
-	h.NoErrorf(err, "validate config")
+	rc := Do(cfg.Validate())(h)
 	h.Assertf(len(rc.ForkedFolders) == 2, "expected 2 forked folders, got %d", len(rc.ForkedFolders))
 	h.Assertf(len(rc.BranchMappings.ByLocalBranch) == 1, "expected 1 branch mapping, got %d", len(rc.BranchMappings.ByLocalBranch))
 }

--- a/misc/mappings_test.go
+++ b/misc/mappings_test.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/typesanitizer/happygo/common/check"
+	. "github.com/typesanitizer/happygo/common/check/prelude"
 	"github.com/typesanitizer/happygo/common/collections"
 	"github.com/typesanitizer/happygo/common/iterx"
 	"github.com/typesanitizer/happygo/misc/internal/config"
@@ -21,17 +22,15 @@ func TestWorkspaceConfig(t *testing.T) {
 	h := check.New(t)
 	h.Parallel()
 
-	f, err := os.Open("repo-configuration.json")
-	h.NoErrorf(err, "opening repo-configuration.json")
+	f := DoMsg(os.Open("repo-configuration.json"))(h, "opening repo-configuration.json")
 	t.Cleanup(func() { _ = f.Close() })
 
-	wsConfig, err := config.Load(f)
-	h.NoErrorf(err, "loading repo configuration")
+	wsConfig := Do(config.Load(f))(h)
 
 	configFolders := collections.SortedMapKeys(wsConfig.ForkedFolders)
 
-	repoRootBytes, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	h.NoErrorf(err, "resolving repo root")
+	repoRootBytes := DoMsg(exec.Command("git", "rev-parse", "--show-toplevel").Output())(h,
+		"resolving repo root")
 	repoRoot := strings.TrimSpace(string(repoRootBytes))
 
 	forkedProjects := map[string]config.GitHubRepo{
@@ -62,8 +61,8 @@ func TestWorkspaceConfig(t *testing.T) {
 	h.Run("WorkflowProjectChoices", func(h check.Harness) {
 		h.Parallel()
 
-		workflowBytes, err := os.ReadFile(filepath.Join(repoRoot, ".github/workflows/upstream-sync.yml"))
-		h.NoErrorf(err, "reading upstream-sync.yml")
+		workflowBytes := DoMsg(os.ReadFile(filepath.Join(repoRoot, ".github/workflows/upstream-sync.yml")))(h,
+			"reading upstream-sync.yml")
 
 		var workflow struct {
 			On struct {
@@ -90,8 +89,8 @@ func TestWorkspaceConfig(t *testing.T) {
 	h.Run("LinterExclusions", func(h check.Harness) {
 		h.Parallel()
 
-		lintBytes, err := os.ReadFile(filepath.Join(repoRoot, ".golangci.yml"))
-		h.NoErrorf(err, "reading .golangci.yml")
+		lintBytes := DoMsg(os.ReadFile(filepath.Join(repoRoot, ".golangci.yml")))(h,
+			"reading .golangci.yml")
 
 		var lintCfg struct {
 			Linters struct {


### PR DESCRIPTION
Add a small dot-importable test helper for unwrapping `(T, error)` pairs via a `BasicHarness`, and use it at a few low-signal test call sites where `NoErrorf` messages were mostly boilerplate.