### PR TITLE
chore(common): Add op.InsertResult and Set.InsertNew

### DIFF
--- a/common/collections/set.go
+++ b/common/collections/set.go
@@ -4,6 +4,9 @@ import (
 	"cmp"
 	"iter"
 	"sort"
+
+	"github.com/typesanitizer/happygo/common/assert"
+	"github.com/typesanitizer/happygo/common/core/op"
 )
 
 // Set is a basic mutable set.
@@ -17,11 +20,21 @@ func NewSet[T comparable]() Set[T] {
 }
 
 // Insert adds value to the set.
-// It returns true if a value was inserted.
-func (s *Set[T]) Insert(value T) bool {
-	before := len(s.values)
+func (s *Set[T]) Insert(value T) op.InsertResult {
+	if _, ok := s.values[value]; ok {
+		return op.KeptOld
+	}
 	s.values[value] = struct{}{}
-	return len(s.values) != before
+	return op.InsertedNew
+}
+
+// InsertNew adds value to the set.
+//
+// Pre-condition: value is not already present.
+func (s *Set[T]) InsertNew(value T) {
+	_, ok := s.values[value]
+	assert.Preconditionf(!ok, "set already contains value %v", value)
+	s.values[value] = struct{}{}
 }
 
 // Contains reports whether value is in the set.

--- a/common/collections/set_test.go
+++ b/common/collections/set_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"testing"
 
+	"github.com/typesanitizer/happygo/common/assert"
 	"github.com/typesanitizer/happygo/common/check"
 )
 
@@ -11,8 +12,20 @@ func TestInsert(t *testing.T) {
 	h.Parallel()
 
 	s := NewSet[string]()
-	h.Assertf(s.Insert("a"), "first insert should return true")
-	h.Assertf(!s.Insert("a"), "duplicate insert should return false")
+	h.Assertf(s.Insert("a").AsBool(), "first insert should report a new value")
+	h.Assertf(!s.Insert("a").AsBool(), "duplicate insert should report an existing value")
+}
+
+func TestInsertNew(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	s := NewSet[string]()
+	s.InsertNew("a")
+	want := assert.AssertionError{Fmt: "precondition violation: set already contains value %v", Args: []any{"a"}}
+	h.AssertPanicsWith(want, func() {
+		s.InsertNew("a")
+	})
 }
 
 func TestContains(t *testing.T) {
@@ -20,7 +33,7 @@ func TestContains(t *testing.T) {
 	h.Parallel()
 
 	s := NewSet[int]()
-	s.Insert(1)
+	s.InsertNew(1)
 	h.Assertf(s.Contains(1), "set should contain inserted value")
 	h.Assertf(!s.Contains(2), "set should not contain non-inserted value")
 }
@@ -30,9 +43,9 @@ func TestValuesNonDet(t *testing.T) {
 	h.Parallel()
 
 	s := NewSet[int]()
-	s.Insert(1)
-	s.Insert(2)
-	s.Insert(3)
+	s.InsertNew(1)
+	s.InsertNew(2)
+	s.InsertNew(3)
 
 	seen := map[int]bool{}
 	for v := range s.ValuesNonDet() {

--- a/common/core/op/op.go
+++ b/common/core/op/op.go
@@ -1,0 +1,19 @@
+// Package op provides small operation-result newtypes for APIs where a named
+// boolean result is clearer than a raw bool.
+//
+// NOTE: Avoid adding newtypes if an operation can return data appropriately.
+// For example, a remove operation on a map-like type should return an Option of
+// the old value.
+package op
+
+// InsertResult reports whether an insert added a new value or kept an existing one.
+type InsertResult bool
+
+const (
+	InsertedNew InsertResult = true
+	KeptOld     InsertResult = false
+)
+
+func (res InsertResult) AsBool() bool {
+	return bool(res)
+}

--- a/common/fsx/fsx_test.go
+++ b/common/fsx/fsx_test.go
@@ -29,14 +29,14 @@ func TestReadDirBatched(t *testing.T) {
 			name := fmt.Sprintf("file-%03d.txt", i)
 			fileRel := parentDir.JoinComponents(name)
 			h.NoErrorf(repoFS.WriteFile(fileRel, []byte("data"), 0o644), "WriteFile(%q)", fileRel)
-			want.Insert(name)
+			want.InsertNew(name)
 		}
 
 		got := collections.NewSet[string]()
 		for entryRes := range repoFS.ReadDir(parentDir) {
 			entry := Do(entryRes.Get())(h)
 			name := entry.BaseName()
-			h.Assertf(got.Insert(name), "duplicate entry %q from ReadDir(%q)", name, parentDir)
+			got.InsertNew(name)
 
 			info := Do(entry.Info())(h)
 			h.Assertf(info.Name() == name, "Info(%q).Name() = %q, want %q", name, info.Name(), name)

--- a/misc/internal/config/validate.go
+++ b/misc/internal/config/validate.go
@@ -42,7 +42,7 @@ func validateForkedFolders(forkedFoldersJSON []ForkedFolderJSON) (map[string]For
 			err = errorx.Join(err, errorx.Wrapf("nostack", parseErr, "forked_folders[%q]", forkedFolderJSON.Folder))
 			continue
 		}
-		if !forkedRepos.Insert(githubRepo) {
+		if !forkedRepos.Insert(githubRepo).AsBool() {
 			err = errorx.Join(err, errorx.Newf("nostack", "forked_folders has duplicate gh_project %q", githubRepo))
 			continue
 		}

--- a/misc/mappings_test.go
+++ b/misc/mappings_test.go
@@ -103,7 +103,7 @@ func TestWorkspaceConfig(t *testing.T) {
 
 		configSet := collections.NewSet[string]()
 		for _, f := range configFolders {
-			configSet.Insert(f)
+			configSet.InsertNew(f)
 		}
 
 		excludedSet := collections.NewSet[string]()
@@ -112,7 +112,7 @@ func TestWorkspaceConfig(t *testing.T) {
 			h.Assertf(ok, "linter exclusion path %q must start with ^", p)
 			folder, ok = strings.CutSuffix(folder, "/")
 			h.Assertf(ok, "linter exclusion path %q must end with /", p)
-			excludedSet.Insert(folder)
+			excludedSet.InsertNew(folder)
 		}
 
 		h.Assertf(excludedSet.IsSubsetOf(&configSet),


### PR DESCRIPTION
These are for better readability at call-sites,
on an as-needed basis.