### PR TITLE
feat(errorx): Add functions to get the root cause

### DIFF
--- a/common/check/check.go
+++ b/common/check/check.go
@@ -122,8 +122,9 @@ func (h Harness) T() *testing.T {
 }
 
 // AssertSame compares want and got using cmp.Diff and fails with a diff if they differ.
-func AssertSame[T any](h BasicHarness, want, got T, what string) {
-	if diff := cmp.Diff(want, got); diff != "" {
+// Additional cmp options may be provided to customize comparison.
+func AssertSame[T any](h BasicHarness, want, got T, what string, opts ...cmp.Option) {
+	if diff := cmp.Diff(want, got, opts...); diff != "" {
 		h.Assertf(false, "%s mismatch (-want +got):\n%s", what, diff)
 	}
 }

--- a/common/errorx/errorx.go
+++ b/common/errorx/errorx.go
@@ -8,6 +8,7 @@ import (
 
 	cockroach "github.com/cockroachdb/errors" //nolint:depguard // In designated wrapper package
 	"github.com/typesanitizer/happygo/common/assert"
+	. "github.com/typesanitizer/happygo/common/core"
 )
 
 // IncludeStackTrace controls whether a stack trace is captured when creating an error.
@@ -55,5 +56,150 @@ func Wrapf(ist IncludeStackTrace, err error, format string, args ...any) error {
 		return cockroach.WrapWithDepthf(1, err, format, args...)
 	default:
 		return assert.PanicUnknownCase[error](ist)
+	}
+}
+
+const NESTING_LIMIT = 1000
+
+// RootCauseResult represents one of two cases:
+//
+//  1. Root cause: A root cause was found by following a linear chain
+//     from the original error (this may be the original error itself).
+//  2. Multi-error: When traversing the error tree, a multi-error with
+//     2 or more sub-errors was hit. In this case, it is not generally
+//     correct to mark one of the errors as the root cause.
+//  3. Hit nesting limit (~rare): Traversal hit [NESTING_LIMIT] iterations.
+//     This generally indicates a bug somewhere.
+//
+// The case can be checked using HitNestingLimit() and HitMultiError().
+type RootCauseResult struct {
+	// Logically, there are two cases.
+	// 1. We hit a multi-error with 2+ causes when traversing the error tree.
+	//    If this is the case, hitMultiError will be set to non-nil with that
+	//    multi-error.
+	// 2. We didn't hit a multi-error. In this case rootCause will be set to
+	//    a non-nil error.
+	rootCause       error
+	hitMultiError   error
+	hitNestingLimit bool
+}
+
+func (r RootCauseResult) HitNestingLimit() bool {
+	return r.hitNestingLimit
+}
+
+// HitMultiError returns whether an error tree traversal hit a multi-error with
+// 2 or more sub-errors.
+func (r RootCauseResult) HitMultiError() bool {
+	return !r.hitNestingLimit && r.hitMultiError != nil
+}
+
+// GetMultiError returns the first multi-error found during error tree traversal.
+//
+// Pre-condition: This result must be a multi-error.
+func (r RootCauseResult) GetMultiError() error {
+	assert.Preconditionf(!r.hitNestingLimit, "requesting multi-error but hit nesting limit %v during traversal", NESTING_LIMIT)
+	assert.Preconditionf(r.hitMultiError != nil, "requesting multi-error but found root cause: %v", r.rootCause)
+	return r.hitMultiError
+}
+
+// GetRootCause returns a non-nil root cause.
+//
+// Pre-condition: This result must not be a multi-error.
+func (r RootCauseResult) GetRootCause() error {
+	assert.Preconditionf(!r.hitNestingLimit, "requesting root cause but hit nesting limit %v during traversal", NESTING_LIMIT)
+	assert.Preconditionf(!r.HitMultiError(), "requesting root cause despite hitting multi-error: %v", r.hitMultiError)
+	return r.rootCause
+}
+
+// GetRootCause traverses the provided error tree, and gets the underlying
+// root cause, if one can be found by following a chain of wrapper errors.
+//
+// If there is a "fork" in the tree (i.e. a multi-error with 2 or more
+// sub-errors is found), then that multi-error is returned instead.
+//
+// The tree traversal is based on the following methods:
+//   - Unwrap() []error
+//   - Unwrap() error
+//   - Cause() error
+//
+// Pre-condition: err != nil
+func GetRootCause(err error) RootCauseResult {
+	assert.Precondition(err != nil, "trying to get root cause for nil error")
+	cur := err
+	for range NESTING_LIMIT {
+		switch e := cur.(type) {
+		case interface{ Unwrap() []error }:
+			errList := e.Unwrap()
+			switch len(errList) {
+			case 0:
+				return RootCauseResult{rootCause: cur, hitMultiError: nil, hitNestingLimit: false}
+			case 1:
+				cur = errList[0]
+				continue
+			default:
+				return RootCauseResult{rootCause: nil, hitMultiError: cur, hitNestingLimit: false}
+			}
+		case interface{ Unwrap() error }:
+			inner := e.Unwrap()
+			if inner != nil {
+				cur = inner
+				continue
+			}
+			return RootCauseResult{rootCause: cur, hitMultiError: nil, hitNestingLimit: false}
+		case interface{ Cause() error }:
+			inner := e.Cause()
+			if inner != nil {
+				cur = inner
+				continue
+			}
+			return RootCauseResult{rootCause: cur, hitMultiError: nil, hitNestingLimit: false}
+		default:
+			return RootCauseResult{rootCause: cur, hitMultiError: nil, hitNestingLimit: false}
+		}
+	}
+	return RootCauseResult{rootCause: nil, hitMultiError: nil, hitNestingLimit: true}
+}
+
+// GetRootCauseAs is similar to GetRootCause except that it tries to cast
+// the root cause (if one was found) to the type parameter.
+//
+// Pre-condition: err != nil, and err's nesting does not exceed [NESTING_LIMIT].
+func GetRootCauseAs[T error](err error) Option[T] {
+	r := GetRootCause(err)
+	assert.Precondition(!r.HitNestingLimit(), "hit nesting limit during traversal; cannot cast root cause")
+	if r.HitMultiError() {
+		return None[T]()
+	}
+	v, ok := r.GetRootCause().(T)
+	return NewOption(v, ok)
+}
+
+// GetRootCauseAsValue is similar to GetRootCause except that it tries to compare
+// the root cause (if one was found) to the reference error value.
+//
+// Comparison is done with Is(error) bool on err, if available.
+// If Is(error) bool is unavailable, comparison is done using ==.
+//
+// Returns false if a multi-error was hit, or if the comparison fails.
+//
+// Pre-conditions: err != nil, reference != nil, and err's nesting does not exceed [NESTING_LIMIT].
+//
+// CAUTION: reference should generally not have Error() with a value receiver,
+// unless it is guaranteed to be comparable. Otherwise, it's possible for
+// comparison to == to panic (e.g. if the type contains slices).
+func GetRootCauseAsValue(err error, reference error) bool {
+	assert.Precondition(reference != nil, "expected non-nil reference error")
+	r := GetRootCause(err)
+	assert.Precondition(!r.HitNestingLimit(), "hit nesting limit during traversal; cannot cast root cause")
+	if r.HitMultiError() {
+		return false
+	}
+	rc := r.GetRootCause()
+	switch rct := rc.(type) {
+	case interface{ Is(error) bool }:
+		return rct.Is(reference)
+	default:
+		return rc == reference
 	}
 }

--- a/common/errorx/errorx_test.go
+++ b/common/errorx/errorx_test.go
@@ -1,0 +1,257 @@
+package errorx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/typesanitizer/happygo/common/assert"
+	"github.com/typesanitizer/happygo/common/check"
+)
+
+//nolint:exhaustruct // concise test expectations for RootCauseResult are clearer here
+func TestGetRootCause(t *testing.T) {
+	rootCauseResultCmpOpts := []cmp.Option{
+		cmp.AllowUnexported(RootCauseResult{}),
+		cmp.Comparer(func(x, y error) bool {
+			return x == y
+		}),
+	}
+
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("basic tests", func(h check.Harness) {
+		sentinel := New("nostack", "sentinel")
+
+		leaf1 := &errorNode{val: 1, inner: nil}
+		leaf2 := &errorNode{val: 2, inner: nil}
+
+		fork12 := &errorNode{val: 12, inner: []error{leaf1, leaf2}}
+		twoSentinels := &errorNode{val: 99, inner: []error{sentinel, sentinel}}
+		wrappedLeaf1 := Wrapf("nostack", leaf1, "wrapping")
+		causedLeaf1 := &errorWithCause{inner: leaf1}
+
+		wrappedEmpty := &errorWithUnwrap{inner: nil}
+		causedEmpty := &errorWithCause{inner: nil}
+
+		chain12 := &errorNode{val: 1, inner: []error{leaf2}}
+
+		type TestCase struct {
+			name     string
+			input    error
+			expected RootCauseResult
+		}
+
+		testCases := []TestCase{
+			{
+				name:     "sentinel",
+				input:    sentinel,
+				expected: RootCauseResult{rootCause: sentinel},
+			},
+			{
+				name:     "simple leaf",
+				input:    leaf1,
+				expected: RootCauseResult{rootCause: leaf1},
+			},
+			{
+				name:     "hitting multi error",
+				input:    fork12,
+				expected: RootCauseResult{hitMultiError: fork12},
+			},
+			{
+				name:     "no notion of equality checking/coalescing on hitting multi-errors",
+				input:    twoSentinels,
+				expected: RootCauseResult{hitMultiError: twoSentinels},
+			},
+			{
+				name:     "root cause found in chain",
+				input:    chain12,
+				expected: RootCauseResult{rootCause: leaf2},
+			},
+			{
+				name:     "root cause found after wrapping (via Unwrap())",
+				input:    wrappedLeaf1,
+				expected: RootCauseResult{rootCause: leaf1},
+			},
+			{
+				name:     "root cause found after wrapping (via Cause())",
+				input:    causedLeaf1,
+				expected: RootCauseResult{rootCause: leaf1},
+			},
+			{
+				name:     "root cause is prior if Unwrap() == nil",
+				input:    wrappedEmpty,
+				expected: RootCauseResult{rootCause: wrappedEmpty},
+			},
+			{
+				name:     "root cause is prior if Cause() == nil",
+				input:    causedEmpty,
+				expected: RootCauseResult{rootCause: causedEmpty},
+			},
+		}
+
+		for _, tc := range testCases {
+			h.Run(tc.name, func(h check.Harness) {
+				h.Parallel()
+
+				got := GetRootCause(tc.input)
+				check.AssertSame(h, tc.expected, got, "root cause result", rootCauseResultCmpOpts...)
+			})
+		}
+	})
+
+	h.Run("nesting limit", func(h check.Harness) {
+		h.Parallel()
+
+		got := GetRootCause(makeTooDeepError())
+		h.Assertf(got.HitNestingLimit(), "errors nested %d times; should exceed limit %d", NESTING_LIMIT+1, NESTING_LIMIT)
+	})
+
+	h.Run("cycle hits nesting limit", func(h check.Harness) {
+		h.Parallel()
+
+		cycle := &errorNode{val: 1, inner: nil}
+		cycle.inner = []error{cycle}
+
+		got := GetRootCause(cycle)
+		h.Assertf(got.HitNestingLimit(), "cycle should hit nesting limit")
+	})
+}
+
+func TestGetRootCauseAs(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("basic tests", func(h check.Harness) {
+		h.Parallel()
+
+		leaf := &errorNode{val: 1, inner: nil}
+		wrapped := &errorWithUnwrap{inner: leaf}
+		fork := &errorNode{val: 20, inner: []error{leaf, New("nostack", "other")}}
+
+		gotLeaf, ok := GetRootCauseAs[*errorNode](wrapped).Get()
+		h.Assertf(ok, "should find a matching root cause")
+		h.Assertf(gotLeaf == leaf, "returned the wrong root cause")
+
+		_, ok = GetRootCauseAs[*errorWithUnwrap](wrapped).Get()
+		h.Assertf(!ok, "should return None for a mismatched root type")
+
+		_, ok = GetRootCauseAs[*errorNode](fork).Get()
+		h.Assertf(!ok, "should return None on multi-error")
+	})
+
+	h.Run("panic tests", func(h check.Harness) {
+		h.Parallel()
+
+		want := assert.AssertionError{Fmt: "precondition violation: %s", Args: []any{"hit nesting limit during traversal; cannot cast root cause"}}
+		h.AssertPanicsWith(want, func() {
+			_ = GetRootCauseAs[*errorNode](makeTooDeepError())
+		})
+	})
+}
+
+func TestGetRootCauseAsValue(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("basic tests", func(h check.Harness) {
+		h.Parallel()
+
+		leaf := &errorNode{val: 1, inner: nil}
+		otherLeaf := &errorNode{val: 1, inner: nil}
+		fork := &errorNode{val: 20, inner: []error{leaf, otherLeaf}}
+
+		h.Assertf(GetRootCauseAsValue(leaf, leaf), "should match the exact root cause value")
+		h.Assertf(!GetRootCauseAsValue(leaf, otherLeaf), "should reject a different comparable value")
+		h.Assertf(!GetRootCauseAsValue(fork, leaf), "should return false on multi-error")
+
+		matching := errorWithIs{tag: "match", xs: []int{1}}
+		matchingRef := errorWithIs{tag: "match", xs: []int{2}}
+		nonMatchingRef := errorWithIs{tag: "other", xs: []int{1}}
+		h.Assertf(GetRootCauseAsValue(matching, matchingRef), "should consult Is(error) when available")
+		h.Assertf(!GetRootCauseAsValue(matching, nonMatchingRef), "should return false when Is(error) says no")
+	})
+
+	h.Run("panic tests", func(h check.Harness) {
+		h.Parallel()
+
+		h.AssertPanicsWith(assert.AssertionError{Fmt: "precondition violation: %s", Args: []any{"expected non-nil reference error"}}, func() {
+			_ = GetRootCauseAsValue(New("nostack", "sentinel"), nil)
+		})
+		h.AssertPanicsWith(assert.AssertionError{Fmt: "precondition violation: %s", Args: []any{"hit nesting limit during traversal; cannot cast root cause"}}, func() {
+			_ = GetRootCauseAsValue(makeTooDeepError(), New("nostack", "sentinel"))
+		})
+	})
+}
+
+type errorNode struct {
+	val   int
+	inner []error
+}
+
+func (e *errorNode) Error() string {
+	if len(e.inner) == 0 {
+		return fmt.Sprintf("Err{%d}", e.val)
+	}
+	return fmt.Sprintf("Err{val: %d, inner: %v}", e.val, e.inner)
+}
+
+func (e *errorNode) Unwrap() []error {
+	return e.inner
+}
+
+type errorWithUnwrap struct {
+	inner error
+}
+
+func (e *errorWithUnwrap) Error() string {
+	if e.inner == nil {
+		return "errorWithUnwrap"
+	}
+	return "errorWithUnwrap: " + e.inner.Error()
+}
+
+func (e *errorWithUnwrap) Unwrap() error {
+	return e.inner
+}
+
+type errorWithCause struct {
+	inner error
+}
+
+func (e *errorWithCause) Error() string {
+	if e.inner == nil {
+		return "errorWithCause"
+	}
+	return "errorWithCause: " + e.inner.Error()
+}
+
+func (e *errorWithCause) Cause() error {
+	return e.inner
+}
+
+type errorWithIs struct {
+	tag string
+	xs  []int
+}
+
+func (e errorWithIs) Error() string {
+	return fmt.Sprintf("errorWithIs(%s)", e.tag)
+}
+
+func (e errorWithIs) Is(target error) bool {
+	t, ok := target.(errorWithIs)
+	return ok && e.tag == t.tag
+}
+
+func makeTooDeepError() error {
+	base := New("nostack", "sentinel")
+	var err error
+	for i := range NESTING_LIMIT {
+		err = &errorNode{val: i + 1, inner: []error{base}}
+		base = err
+	}
+	return err
+}


### PR DESCRIPTION
Unlike cockroachdb/errors, which tries to unwrap things
across multi-errors, I think it generally doesn't make
sense to do so, so we separate out the linear chain/root cause
case from the general tree/DAG case.