### PR TITLE
feat(cmdx): Make subprocess invocation a capability

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,24 @@ linters:
               desc: "use common/logx instead of charmbracelet/log directly"
             - pkg: "github.com/spf13/afero"
               desc: "use common/fsx instead of spf13/afero directly"
+        NoDirectOsExec:
+          files:
+            - $all
+            - "!**/common/syscaps/*.go"
+            - "!**/common/envx/envx_path/*.go"
+          list-mode: lax
+          deny:
+            - pkg: "os/exec$"
+              desc: "use cmdx abstractions instead of os/exec directly; only common/syscaps and common/envx/envx_path are allowed to import it"
+        NoDirectSyscaps:
+          files:
+            - $all
+            - "!**/main.go"
+            - "!$test"
+          list-mode: lax
+          deny:
+            - pkg: "github.com/typesanitizer/happygo/common/syscaps$"
+              desc: "ambient system capabilities should only be accessed via common/syscaps at program edges or in tests"
     importas:
       no-unaliased: true
       alias:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Code Style
 
-Follow `doc/style-guides/go.md` for Go code conventions (import ordering, etc.).
+Follow `docs/style-guides/go.md` for Go code conventions (import ordering, etc.).
 
 ## Commit Hygiene for PRs
 

--- a/common/cmdx/run.go
+++ b/common/cmdx/run.go
@@ -1,22 +1,17 @@
 package cmdx
 
 import (
-	"bytes"
-	"io"
-	"os"
-	"os/exec"
-
-	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/envx"
 	"github.com/typesanitizer/happygo/common/logx"
 )
 
-// RunOptions configures Cmd.Run behavior.
+// RunOptions configures BaseRunner.Run behavior.
 type RunOptions struct {
 	CaptureStdout bool
-	TransformEnv  func([]string) []string
+	TransformEnv  func(envx.Env) envx.Env
 }
 
-// RunOptionsDefault returns default options for Cmd.Run.
+// RunOptionsDefault returns default options for BaseRunner.Run.
 func RunOptionsDefault() RunOptions {
 	return RunOptions{CaptureStdout: false, TransformEnv: nil}
 }
@@ -27,44 +22,30 @@ func (o RunOptions) WithCaptureStdout() RunOptions {
 	return o
 }
 
-func (cmd Cmd) Run(ctx logx.LogCtx, options RunOptions) (string, error) {
-	dir, hasDir := cmd.dir.Get()
-	if hasDir {
-		ctx.Debug("running command", "cmd", cmd, "dir", dir.String())
-	} else {
-		ctx.Debug("running command", "cmd", cmd)
-	}
-
-	stdout, stderr := ctx.CmdLoggers(cmd)
-	defer logx.FlushLogWriter(stdout)
-	defer logx.FlushLogWriter(stderr)
-
-	execCmd := exec.CommandContext(ctx, cmd.name, cmd.args...)
-	if hasDir {
-		execCmd.Dir = dir.String()
-	}
-	if options.TransformEnv != nil {
-		execCmd.Env = options.TransformEnv(os.Environ())
-	}
-
-	var capturedOutput bytes.Buffer
-	if options.CaptureStdout {
-		execCmd.Stdout = io.MultiWriter(stdout, &capturedOutput)
-	} else {
-		execCmd.Stdout = stdout
-	}
-	execCmd.Stderr = stderr
-
-	if err := execCmd.Run(); err != nil {
-		return capturedOutput.String(), errorx.Wrapf("+stacks", err, "%s", cmd)
-	}
-	return capturedOutput.String(), nil
+// BaseRunner executes a single command.
+//
+// Run is intended for non-streaming use cases. If we later need streaming
+// capture, we can add a lower-level API and implement Run on top of it.
+type BaseRunner interface {
+	// Run runs a command.
+	//
+	// The first return value is the captured stdout. There may be stdout
+	// even in the presence of errors. Stdout is only captured if
+	// options.CaptureStdout is true.
+	Run(_ logx.LogCtx, _ Cmd, options RunOptions) (string, error)
 }
 
-// ExecAll runs each command sequentially with default options, stopping at the first error.
-func ExecAll(ctx logx.LogCtx, cmds ...Cmd) error {
+// Runner executes single commands and sequential command lists.
+type Runner interface {
+	BaseRunner
+	// ExecAll runs cmds sequentially with default options, stopping at
+	// the first error.
+	ExecAll(_ logx.LogCtx, cmds ...Cmd) error
+}
+
+func BaseRunnerExecAll(runner BaseRunner, ctx logx.LogCtx, cmds ...Cmd) error {
 	for _, cmd := range cmds {
-		if _, err := cmd.Run(ctx, RunOptionsDefault()); err != nil {
+		if _, err := runner.Run(ctx, cmd, RunOptionsDefault()); err != nil {
 			return err
 		}
 	}

--- a/common/fsx/fsx.go
+++ b/common/fsx/fsx.go
@@ -18,10 +18,9 @@ import (
 	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/internal/constants"
 	"github.com/typesanitizer/happygo/common/iterx"
 )
-
-const readDirBatchSize = 32
 
 // File is an open file handle returned by [FS.Open] and similar methods.
 // It is an alias for [afero.File] so callers need not import afero directly.
@@ -60,21 +59,19 @@ type FS struct {
 	base afero.Fs
 }
 
-// OS returns an FS backed by the host operating system rooted at root.
-func OS(root AbsPath) (FS, error) {
-	return newRootedFS(root, afero.NewOsFs())
-}
-
 // MemMap returns an in-memory FS rooted at root.
 func MemMap(root AbsPath) (FS, error) {
 	backing := afero.NewMemMapFs()
 	if err := backing.MkdirAll(root.String(), 0o755); err != nil {
 		return FS{}, errorx.Wrapf("+stacks", err, "create fs root %s", root)
 	}
-	return newRootedFS(root, backing)
+	return NewRootedFS(root, backing)
 }
 
-func newRootedFS(root AbsPath, backing afero.Fs) (FS, error) {
+// NewRootedFS returns an FS rooted at root and backed by backing.
+//
+// Pre-condition: root must already exist in backing and be a directory.
+func NewRootedFS(root AbsPath, backing afero.Fs) (FS, error) {
 	info, err := backing.Stat(root.String())
 	if err != nil {
 		return FS{}, errorx.Wrapf("+stacks", err, "stat fs root %s", root)
@@ -125,7 +122,7 @@ func (fs FS) readDirBatches(rel RelPath) iter.Seq[Result[[]iofs.DirEntry]] {
 		assert.Invariantf(ok, "open(%q) returned %T, want fs.ReadDirFile", rel, f)
 
 		for {
-			entries, err := rdf.ReadDir(readDirBatchSize)
+			entries, err := rdf.ReadDir(constants.ReadDirBatchSize)
 			if len(entries) > 0 {
 				if !yield(Success(entries)) {
 					return

--- a/common/internal/constants/constants.go
+++ b/common/internal/constants/constants.go
@@ -1,0 +1,5 @@
+// Package constants collects shared internal constants.
+package constants
+
+// ReadDirBatchSize is the number of directory entries fsx reads per batch.
+const ReadDirBatchSize = 32

--- a/common/syscaps/syscaps.go
+++ b/common/syscaps/syscaps.go
@@ -1,0 +1,85 @@
+// Package syscaps provides controlled access to ambient system capabilities.
+package syscaps
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/afero" //nolint:depguard // syscaps is the ambient-authority boundary
+
+	"github.com/typesanitizer/happygo/common/assert"
+	"github.com/typesanitizer/happygo/common/cmdx"
+	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/pair"
+	"github.com/typesanitizer/happygo/common/envx"
+	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/logx"
+)
+
+// Env returns the current process environment.
+func Env() envx.Env {
+	return envx.NewIgnoringDupes(func(yield func(pair.KeyValue[string, string]) bool) {
+		for _, entry := range os.Environ() { //nolint:forbidigo // syscaps is the ambient-authority boundary
+			key, value, ok := strings.Cut(entry, "=")
+			assert.Postconditionf(ok, "os.Environ entry missing '=': %q", entry)
+			if !yield(pair.NewKeyValue(key, value)) {
+				return
+			}
+		}
+	})
+}
+
+// FS returns a rooted filesystem backed by the host operating system.
+func FS(root AbsPath) (fsx.FS, error) {
+	return fsx.NewRootedFS(root, afero.NewOsFs())
+}
+
+// CmdRunner executes commands using ambient system capabilities.
+type CmdRunner struct {
+	Env envx.Env
+}
+
+func (runner CmdRunner) Run(ctx logx.LogCtx, cmd cmdx.Cmd, options cmdx.RunOptions) (string, error) {
+	dir, hasDir := cmd.Dir().Get()
+	if hasDir {
+		ctx.Debug("running command", "cmd", cmd, "dir", dir.String())
+	} else {
+		ctx.Debug("running command", "cmd", cmd)
+	}
+
+	stdout, stderr := ctx.CmdLoggers(cmd)
+	defer logx.FlushLogWriter(stdout)
+	defer logx.FlushLogWriter(stderr)
+
+	argv := cmd.Argv()
+	execCmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	if hasDir {
+		execCmd.Dir = dir.String()
+	}
+	if options.TransformEnv != nil {
+		execCmd.Env = options.TransformEnv(runner.Env).Entries()
+	} else {
+		execCmd.Env = runner.Env.Entries()
+	}
+
+	var capturedOutput bytes.Buffer
+	if options.CaptureStdout {
+		execCmd.Stdout = io.MultiWriter(stdout, &capturedOutput)
+	} else {
+		execCmd.Stdout = stdout
+	}
+	execCmd.Stderr = stderr
+
+	if err := execCmd.Run(); err != nil {
+		return capturedOutput.String(), errorx.Wrapf("+stacks", err, "%s", cmd)
+	}
+	return capturedOutput.String(), nil
+}
+
+func (runner CmdRunner) ExecAll(ctx logx.LogCtx, cmds ...cmdx.Cmd) error {
+	return cmdx.BaseRunnerExecAll(runner, ctx, cmds...)
+}

--- a/common/syscaps/syscaps_test.go
+++ b/common/syscaps/syscaps_test.go
@@ -1,4 +1,4 @@
-package fsx
+package syscaps_test
 
 import (
 	"fmt"
@@ -11,17 +11,19 @@ import (
 	. "github.com/typesanitizer/happygo/common/check/prelude"
 	"github.com/typesanitizer/happygo/common/collections"
 	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/internal/constants"
+	"github.com/typesanitizer/happygo/common/syscaps"
 )
 
-func TestReadDirBatched(t *testing.T) {
+func TestFSReadDirBatched(t *testing.T) {
 	h := check.New(t)
 	h.Parallel()
 
-	repoFS := Do(OS(NewAbsPath(t.TempDir())))(h)
+	repoFS := Do(syscaps.FS(NewAbsPath(t.TempDir())))(h)
 
 	rapid.Check(h.T(), func(t *rapid.T) {
 		h := check.NewBasic(t)
-		entryCount := rapid.IntRange(0, readDirBatchSize*3).Draw(t, "entry_count")
+		entryCount := rapid.IntRange(0, constants.ReadDirBatchSize*3).Draw(t, "entry_count")
 		parentDir := Do(repoFS.MkdirTemp(NewRelPath("."), "entries-"))(h)
 
 		want := collections.NewSet[string]()
@@ -48,11 +50,11 @@ func TestReadDirBatched(t *testing.T) {
 	})
 }
 
-func TestReadDirOnFileReturnsError(t *testing.T) {
+func TestFSReadDirOnFileReturnsError(t *testing.T) {
 	h := check.New(t)
 	h.Parallel()
 
-	repoFS := Do(OS(NewAbsPath(t.TempDir())))(h)
+	repoFS := Do(syscaps.FS(NewAbsPath(t.TempDir())))(h)
 
 	fileRel := NewRelPath("file.txt")
 	h.NoErrorf(repoFS.WriteFile(fileRel, []byte("data"), 0o644), "WriteFile(%q)", fileRel)
@@ -66,11 +68,11 @@ func TestReadDirOnFileReturnsError(t *testing.T) {
 	h.Assertf(gotAny, "ReadDir(%q) produced no result", fileRel)
 }
 
-func TestMkdirTempRejectsEmptyPattern(t *testing.T) {
+func TestFSMkdirTempRejectsEmptyPattern(t *testing.T) {
 	h := check.New(t)
 	h.Parallel()
 
-	repoFS := Do(OS(NewAbsPath(t.TempDir())))(h)
+	repoFS := Do(syscaps.FS(NewAbsPath(t.TempDir())))(h)
 	want := assert.AssertionError{Fmt: "precondition violation: pattern is empty", Args: nil}
 	h.AssertPanicsWith(want, func() {
 		_, _ = repoFS.MkdirTemp(NewRelPath("."), "")

--- a/misc/cmd/happydo/list.go
+++ b/misc/cmd/happydo/list.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"sort"
-	"strings"
 
 	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/errorx"
@@ -46,26 +44,6 @@ const (
 	ListProvenance_FirstParty
 	ListProvenance_Forked
 )
-
-// Workspace provides operations over the repository root using the repo configuration.
-type Workspace struct {
-	FS     fsx.FS
-	Config config.WorkspaceConfig
-}
-
-func newWorkspaceFromGit() (Workspace, error) {
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return Workspace{}, errorx.Wrapf("nostack", err, "determine git repository root")
-	}
-	repoRoot := NewAbsPath(strings.TrimSpace(string(out)))
-	repoFS, err := fsx.OS(repoRoot)
-	if err != nil {
-		return Workspace{}, errorx.Wrapf("+stacks", err, "open repo filesystem at %s", repoRoot)
-	}
-	wsConfig, err := loadWorkspaceConfig(repoFS)
-	return Workspace{FS: repoFS, Config: wsConfig}, err
-}
 
 type ListOptions struct {
 	Type       ListType

--- a/misc/cmd/happydo/list_test.go
+++ b/misc/cmd/happydo/list_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/typesanitizer/happygo/common/check"
 	. "github.com/typesanitizer/happygo/common/check/prelude"
 	. "github.com/typesanitizer/happygo/common/core"
-	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/envx"
 	"github.com/typesanitizer/happygo/common/logx"
+	"github.com/typesanitizer/happygo/common/syscaps"
 	"github.com/typesanitizer/happygo/misc/internal/config"
 )
 
@@ -26,10 +27,11 @@ func TestList(t *testing.T) {
 		"file.txt":     "not a dir\n",
 	})
 
-	repoFS := Do(fsx.OS(NewAbsPath(root)))(h)
+	repoFS := Do(syscaps.FS(NewAbsPath(root)))(h)
 
 	ws := Workspace{
-		FS: repoFS,
+		FS:     repoFS,
+		Runner: syscaps.CmdRunner{Env: envx.Empty()},
 		Config: config.WorkspaceConfig{
 			ForkedFolders: map[string]config.ForkedFolder{
 				"beta": {Folder: "beta", GitHubRepo: "example/beta"},

--- a/misc/cmd/happydo/main.go
+++ b/misc/cmd/happydo/main.go
@@ -2,23 +2,55 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/typesanitizer/happygo/common/cmdx"
 	"github.com/typesanitizer/happygo/common/collections"
 	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
 	"github.com/typesanitizer/happygo/common/logx"
+	"github.com/typesanitizer/happygo/common/syscaps"
+	"github.com/typesanitizer/happygo/misc/internal/config"
 )
 
 const syncBranchPrefix = "merge-bot/sync/"
 
+// Workspace provides operations over the repository root using the repo configuration.
+type Workspace struct {
+	FS     fsx.FS
+	Config config.WorkspaceConfig
+	Runner cmdx.Runner
+}
+
+func newWorkspaceFromGit(runner cmdx.Runner) (Workspace, error) {
+	repoRootCmd := cmdx.New("git", "rev-parse", "--show-toplevel")
+	ctx := logx.NewLogCtx(context.Background(), logx.NewLogger(io.Discard, logx.ColorSupport_Disable))
+	out, err := runner.Run(ctx, repoRootCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
+	if err != nil {
+		return Workspace{}, errorx.Wrapf("nostack", err, "determine git repository root")
+	}
+	repoRoot := NewAbsPath(strings.TrimSpace(out))
+	repoFS, err := syscaps.FS(repoRoot)
+	if err != nil {
+		return Workspace{}, errorx.Wrapf("+stacks", err, "open repo filesystem at %s", repoRoot)
+	}
+	wsConfig, err := loadWorkspaceConfig(repoFS)
+	return Workspace{FS: repoFS, Config: wsConfig, Runner: runner}, err
+}
+
 func main() {
 	logger := logx.NewLogger(os.Stderr, logx.ColorSupport_AutoDetect)
-	getWorkspace := sync.OnceValues(newWorkspaceFromGit)
+	runner := syscaps.CmdRunner{Env: syscaps.Env()}
+	getWorkspace := sync.OnceValues(func() (Workspace, error) {
+		return newWorkspaceFromGit(runner)
+	})
 	app := &cli.Command{
 		Name:  "meta",
 		Usage: "Perform workspace-related administrative tasks",

--- a/misc/cmd/happydo/sync_branch.go
+++ b/misc/cmd/happydo/sync_branch.go
@@ -22,14 +22,16 @@ type remoteRef struct {
 	SHA  string
 }
 
-func (ws Workspace) runSyncBranch(ctx logx.LogCtx, projects []string, options RunSyncBranchOptions) (err error) {
+func (ws Workspace) runSyncBranch(
+	ctx logx.LogCtx, projects []string, options RunSyncBranchOptions,
+) (err error) {
 	assert.Precondition(len(projects) > 0, "must sync 1+ projects")
 	baseBranch := options.Base.ValueOr("main")
 	fetchBaseCmd := cmdx.New("git", "fetch", "origin", baseBranch).In(ws.FS.Root())
-	if _, err := fetchBaseCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
+	if _, err := ws.Runner.Run(ctx, fetchBaseCmd, cmdx.RunOptionsDefault()); err != nil {
 		return err
 	}
-	worktreeDir, cleanup, err := createSyncWorktree(ctx, ws.FS, baseBranch)
+	worktreeDir, cleanup, err := createSyncWorktree(ctx, ws.Runner, ws.FS, baseBranch)
 	if err != nil {
 		return err
 	}
@@ -53,7 +55,8 @@ func (ws Workspace) runSyncBranch(ctx logx.LogCtx, projects []string, options Ru
 }
 
 func runSyncBranchProject(
-	ctx logx.LogCtx, ws Workspace, project string, worktreeDir RelPath, baseBranch string, push bool,
+	ctx logx.LogCtx, ws Workspace,
+	project string, worktreeDir RelPath, baseBranch string, push bool,
 ) error {
 	worktreeAbs := ws.FS.Root().Join(worktreeDir)
 	syncBranch := syncBranchPrefix + project
@@ -62,14 +65,14 @@ func runSyncBranchProject(
 		"project", project, "branch", syncBranch,
 		"worktree", worktreeAbs.String(), "base", baseBranch,
 	)
-	if err := resetWorktreeToBase(ctx, worktreeAbs, baseBranch); err != nil {
+	if err := resetWorktreeToBase(ctx, ws.Runner, worktreeAbs, baseBranch); err != nil {
 		return errorx.Wrapf("nostack", err, "reset worktree to base %q", baseBranch)
 	}
-	if err := deleteLocalBranchIfPresent(ctx, worktreeAbs, syncBranch); err != nil {
+	if err := deleteLocalBranchIfPresent(ctx, ws.Runner, worktreeAbs, syncBranch); err != nil {
 		return errorx.Wrapf("nostack", err, "delete local branch %q", syncBranch)
 	}
 	checkoutCmd := cmdx.New("git", "checkout", "-B", syncBranch).In(worktreeAbs)
-	if _, err := checkoutCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
+	if _, err := ws.Runner.Run(ctx, checkoutCmd, cmdx.RunOptionsDefault()); err != nil {
 		return err
 	}
 	if err := ws.runUpdate(ctx, worktreeAbs, baseBranch, []string{project}); err != nil {
@@ -80,7 +83,7 @@ func runSyncBranchProject(
 		return nil
 	}
 
-	remoteHead, err := findRemoteBranchHeadRef(ctx, worktreeAbs, syncBranch)
+	remoteHead, err := findRemoteBranchHeadRef(ctx, ws.Runner, worktreeAbs, syncBranch)
 	if err != nil {
 		return errorx.Wrapf("nostack", err, "find remote head ref for %q", syncBranch)
 	}
@@ -89,23 +92,25 @@ func runSyncBranchProject(
 	// See SYNC(id: gha-permissions).
 	pushCmd := cmdx.New("git", "push", forceWithLeaseArg, "origin", syncBranch+":"+syncBranch).
 		In(worktreeAbs)
-	if _, err := pushCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
+	if _, err := ws.Runner.Run(ctx, pushCmd, cmdx.RunOptionsDefault()); err != nil {
 		return err
 	}
 	return nil
 }
 
-func resetWorktreeToBase(ctx logx.LogCtx, worktreeDir AbsPath, base string) error {
-	return cmdx.ExecAll(ctx,
+func resetWorktreeToBase(ctx logx.LogCtx, runner cmdx.Runner, worktreeDir AbsPath, base string) error {
+	return runner.ExecAll(ctx,
 		cmdx.New("git", "checkout", "--detach", "origin/"+base).In(worktreeDir),
 		cmdx.New("git", "reset", "--hard", "origin/"+base).In(worktreeDir),
 		cmdx.New("git", "clean", "-fd").In(worktreeDir),
 	)
 }
 
-func deleteLocalBranchIfPresent(ctx logx.LogCtx, worktreeDir AbsPath, branch string) error {
+func deleteLocalBranchIfPresent(
+	ctx logx.LogCtx, runner cmdx.BaseRunner, worktreeDir AbsPath, branch string,
+) error {
 	listCmd := cmdx.New("git", "branch", "--list", branch).In(worktreeDir)
-	out, err := listCmd.Run(ctx, cmdx.RunOptionsDefault().WithCaptureStdout())
+	out, err := runner.Run(ctx, listCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return err
 	}
@@ -113,18 +118,18 @@ func deleteLocalBranchIfPresent(ctx logx.LogCtx, worktreeDir AbsPath, branch str
 		return nil
 	}
 	deleteCmd := cmdx.New("git", "branch", "-D", branch).In(worktreeDir)
-	_, err = deleteCmd.Run(ctx, cmdx.RunOptionsDefault())
+	_, err = runner.Run(ctx, deleteCmd, cmdx.RunOptionsDefault())
 	return err
 }
 
 func findRemoteBranchHeadRef(
-	ctx logx.LogCtx, worktreeDir AbsPath, branch string,
+	ctx logx.LogCtx, runner cmdx.BaseRunner, worktreeDir AbsPath, branch string,
 ) (Option[remoteRef], error) {
 	assert.Precondition(branch != "", "branch must be non-empty")
 
 	branchRef := "refs/heads/" + branch
 	lsRemoteCmd := cmdx.New("git", "ls-remote", "--heads", "origin", branchRef).In(worktreeDir)
-	out, err := lsRemoteCmd.Run(ctx, cmdx.RunOptionsDefault().WithCaptureStdout())
+	out, err := runner.Run(ctx, lsRemoteCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return None[remoteRef](), err
 	}
@@ -166,7 +171,7 @@ func formatLease(branch string, remoteHead Option[remoteRef]) string {
 }
 
 func createSyncWorktree(
-	ctx logx.LogCtx, repoFS fsx.FS, base string,
+	ctx logx.LogCtx, runner cmdx.BaseRunner, repoFS fsx.FS, base string,
 ) (RelPath, func() error, error) {
 	tmpRoot := NewRelPath(".cache").JoinComponents("tmp")
 	if err := repoFS.MkdirAll(tmpRoot, 0o755); err != nil {
@@ -183,7 +188,7 @@ func createSyncWorktree(
 		if worktreeAdded {
 			removeCmd := cmdx.New("git", "worktree", "remove", "--force", worktreeDir.String()).
 				In(repoFS.Root())
-			if _, removeErr := removeCmd.Run(ctx, cmdx.RunOptionsDefault()); removeErr != nil {
+			if _, removeErr := runner.Run(ctx, removeCmd, cmdx.RunOptionsDefault()); removeErr != nil {
 				cleanupErr = errorx.Join(cleanupErr, removeErr)
 			}
 		}
@@ -197,14 +202,14 @@ func createSyncWorktree(
 	ctx.Info("adding detached sync worktree", "base", base, "worktree", worktreeDir.String())
 	addCmd := cmdx.New("git", "worktree", "add", "--quiet", "--detach", worktreeDir.String(), "origin/"+base).
 		In(repoFS.Root())
-	if _, err := addCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
+	if _, err := runner.Run(ctx, addCmd, cmdx.RunOptionsDefault()); err != nil {
 		return RelPath{}, nil, errorx.Join(err, cleanup())
 	}
 	worktreeAdded = true
 
 	detachCmd := cmdx.New("git", "checkout", "--detach", "origin/"+base).
 		In(repoFS.Root().Join(worktreeDir))
-	if _, err := detachCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
+	if _, err := runner.Run(ctx, detachCmd, cmdx.RunOptionsDefault()); err != nil {
 		return RelPath{}, nil, errorx.Join(err, cleanup())
 	}
 	ctx.Info("worktree ready for sync", "worktree", worktreeDir.String(), "base", base)

--- a/misc/cmd/happydo/sync_pr.go
+++ b/misc/cmd/happydo/sync_pr.go
@@ -62,49 +62,53 @@ func (ws Workspace) runSyncPR(ctx logx.LogCtx, projects []string, options RunSyn
 	assert.Precondition(len(projects) > 0, "must sync 1+ projects")
 	base := options.Base.ValueOr("main")
 	for _, project := range projects {
-		if err := runSyncPRProject(ctx, ws.FS.Root(), project, base); err != nil {
+		if err := runSyncPRProject(ctx, ws.Runner, ws.FS.Root(), project, base); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func runSyncPRProject(ctx logx.LogCtx, repoRoot AbsPath, project string, base string) error {
+func runSyncPRProject(
+	ctx logx.LogCtx,
+	runner cmdx.BaseRunner,
+	repoRoot AbsPath, project string, base string,
+) error {
 	syncBranch := syncBranchPrefix + project
 	fetchCmd := cmdx.New("git", "fetch", "origin", syncBranch).In(repoRoot)
-	if _, err := fetchCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
+	if _, err := runner.Run(ctx, fetchCmd, cmdx.RunOptionsDefault()); err != nil {
 		return err
 	}
 	// The push in sync-branch is a no-op when upstream hasn't changed,
 	// but sync-pr still runs unconditionally. Skip PR creation/updates
 	// when the sync branch has no diff vs base to avoid noisy re-edits.
 	diffCmd := cmdx.New("git", "diff", "--quiet", "origin/"+base+"...origin/"+syncBranch).In(repoRoot)
-	if _, err := diffCmd.Run(ctx, cmdx.RunOptionsDefault()); err == nil {
+	if _, err := runner.Run(ctx, diffCmd, cmdx.RunOptionsDefault()); err == nil {
 		ctx.Info("no diff between base and sync branch, skipping",
 			"project", project, "base", base, "branch", syncBranch)
 		return nil
 	}
-	headSHA, err := cmdx.New("git", "rev-parse", "origin/"+syncBranch).In(repoRoot).
-		Run(ctx, cmdx.RunOptionsDefault().WithCaptureStdout())
+	headSHACmd := cmdx.New("git", "rev-parse", "origin/"+syncBranch).In(repoRoot)
+	headSHA, err := runner.Run(ctx, headSHACmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return err
 	}
 	headSHA = strings.TrimSpace(headSHA)
-	metadata, err := subtreeMetadataForSyncHead(ctx, repoRoot, project, headSHA)
+	metadata, err := subtreeMetadataForSyncHead(ctx, runner, repoRoot, project, headSHA)
 	if err != nil {
 		return err
 	}
-	existingPR, err := findOpenPR(ctx, repoRoot, base, syncBranch)
+	existingPR, err := findOpenPR(ctx, runner, repoRoot, base, syncBranch)
 	if err != nil {
 		return err
 	}
 	projectLabel := "project/" + project
 	ensureSyncLabels := func() error {
-		if err := ensureLabelExists(ctx, repoRoot, projectLabel,
+		if err := ensureLabelExists(ctx, runner, repoRoot, projectLabel,
 			"1d76db", "Project-specific sync updates"); err != nil {
 			return err
 		}
-		if err := ensureLabelExists(ctx, repoRoot, "upstream-sync",
+		if err := ensureLabelExists(ctx, runner, repoRoot, "upstream-sync",
 			"6e7781", "Automated upstream sync updates"); err != nil {
 			return err
 		}
@@ -125,7 +129,7 @@ func runSyncPRProject(ctx logx.LogCtx, repoRoot AbsPath, project string, base st
 			"--title", title, "--body", body,
 			"--add-label", projectLabel, "--add-label", "upstream-sync",
 		).In(repoRoot)
-		if _, err := editPRCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
+		if _, err := runner.Run(ctx, editPRCmd, cmdx.RunOptionsDefault()); err != nil {
 			return err
 		}
 	} else {
@@ -137,10 +141,10 @@ func runSyncPRProject(ctx logx.LogCtx, repoRoot AbsPath, project string, base st
 			"--title", title, "--body", body,
 			"--label", projectLabel, "--label", "upstream-sync",
 		).In(repoRoot)
-		if _, err := createPRCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
+		if _, err := runner.Run(ctx, createPRCmd, cmdx.RunOptionsDefault()); err != nil {
 			return err
 		}
-		created, err := findOpenPR(ctx, repoRoot, base, syncBranch)
+		created, err := findOpenPR(ctx, runner, repoRoot, base, syncBranch)
 		if err != nil {
 			return err
 		}
@@ -159,16 +163,16 @@ func runSyncPRProject(ctx logx.LogCtx, repoRoot AbsPath, project string, base st
 		"--subject", title, "--body", mergeBody,
 		"--match-head-commit", headSHA,
 	).In(repoRoot)
-	if _, err := mergePRCmd.Run(ctx, cmdx.RunOptionsDefault()); err != nil {
+	if _, err := runner.Run(ctx, mergePRCmd, cmdx.RunOptionsDefault()); err != nil {
 		return err
 	}
 	return nil
 }
 
 func findOpenPR(
-	ctx logx.LogCtx, repoRoot AbsPath, base string, head string,
+	ctx logx.LogCtx, runner cmdx.BaseRunner, repoRoot AbsPath, base string, head string,
 ) (Option[int], error) {
-	prs, err := listOpenPRs(ctx, repoRoot, base, head)
+	prs, err := listOpenPRs(ctx, runner, repoRoot, base, head)
 	if err != nil {
 		return None[int](), err
 	}
@@ -184,14 +188,15 @@ func findOpenPR(
 }
 
 func subtreeMetadataForSyncHead(
-	ctx logx.LogCtx, repoRoot AbsPath, project string, headSHA string,
+	ctx logx.LogCtx, runner cmdx.BaseRunner,
+	repoRoot AbsPath, project string, headSHA string,
 ) (subtreeMetadata, error) {
 	assert.Precondition(project != "", "project must be non-empty")
 	assert.Precondition(headSHA != "", "headSHA must be non-empty")
 
 	var emptyMetadata subtreeMetadata
-	parentsOut, err := cmdx.New("git", "show", "--no-patch", "--format=%P", headSHA).In(repoRoot).
-		Run(ctx, cmdx.RunOptionsDefault().WithCaptureStdout())
+	parentsCmd := cmdx.New("git", "show", "--no-patch", "--format=%P", headSHA).In(repoRoot)
+	parentsOut, err := runner.Run(ctx, parentsCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return emptyMetadata, err
 	}
@@ -209,14 +214,14 @@ func subtreeMetadataForSyncHead(
 }
 
 func listOpenPRs(
-	ctx logx.LogCtx, repoRoot AbsPath, base string, head string,
+	ctx logx.LogCtx, runner cmdx.BaseRunner, repoRoot AbsPath, base string, head string,
 ) ([]ListOpenPRsData, error) {
 	listPRsCmd := cmdx.New(
 		"gh", "pr", "list",
 		"--state", "open", "--base", base, "--head", head,
 		"--json", "number,url",
 	).In(repoRoot)
-	out, err := listPRsCmd.Run(ctx, cmdx.RunOptionsDefault().WithCaptureStdout())
+	out, err := runner.Run(ctx, listPRsCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +233,8 @@ func listOpenPRs(
 }
 
 func ensureLabelExists(
-	ctx logx.LogCtx, repoRoot AbsPath, name string, color string, description string,
+	ctx logx.LogCtx, runner cmdx.BaseRunner,
+	repoRoot AbsPath, name string, color string, description string,
 ) error {
 	assert.Precondition(name != "", "name must be non-empty")
 	assert.Precondition(color != "", "color must be non-empty")
@@ -238,7 +244,7 @@ func ensureLabelExists(
 		"gh", "label", "list",
 		"--search", name, "--json", "name", "--limit", "100",
 	).In(repoRoot)
-	out, err := listLabelsCmd.Run(ctx, cmdx.RunOptionsDefault().WithCaptureStdout())
+	out, err := runner.Run(ctx, listLabelsCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return err
 	}
@@ -261,7 +267,7 @@ func ensureLabelExists(
 		"gh", "label", "create", name,
 		"--color", color, "--description", description,
 	).In(repoRoot)
-	_, err = createLabelCmd.Run(ctx, cmdx.RunOptionsDefault())
+	_, err = runner.Run(ctx, createLabelCmd, cmdx.RunOptionsDefault())
 	return err
 }
 

--- a/misc/cmd/happydo/update.go
+++ b/misc/cmd/happydo/update.go
@@ -19,7 +19,7 @@ func (ws Workspace) runUpdate(ctx logx.LogCtx, dir AbsPath, localBranch string, 
 		subtreePullCmd := cmdx.New(
 			"git", "subtree", "pull", "--prefix", project, upstreamURL, upstream.Branch,
 		).In(dir)
-		stdout, err := subtreePullCmd.Run(ctx, cmdx.RunOptionsDefault().WithCaptureStdout())
+		stdout, err := ws.Runner.Run(ctx, subtreePullCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 		if err != nil {
 			if stdout != "" {
 				ctx.Info("subtree pull stdout", "output", stdout)

--- a/misc/mappings_test.go
+++ b/misc/mappings_test.go
@@ -3,7 +3,6 @@ package misc_test
 import (
 	"maps"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/typesanitizer/happygo/common/check"
 	. "github.com/typesanitizer/happygo/common/check/prelude"
 	"github.com/typesanitizer/happygo/common/collections"
+	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/iterx"
 	"github.com/typesanitizer/happygo/misc/internal/config"
 )
@@ -29,9 +29,7 @@ func TestWorkspaceConfig(t *testing.T) {
 
 	configFolders := collections.SortedMapKeys(wsConfig.ForkedFolders)
 
-	repoRootBytes := DoMsg(exec.Command("git", "rev-parse", "--show-toplevel").Output())(h,
-		"resolving repo root")
-	repoRoot := strings.TrimSpace(string(repoRootBytes))
+	repoRoot := DoMsg(pathx.ResolveAbsPath(".."))(h, "resolving repo root").String()
 
 	forkedProjects := map[string]config.GitHubRepo{
 		"go":    "golang/go",


### PR DESCRIPTION
Adds a new cmdx.Runner interface and makes subprocess invocation
go through that. This plays well with the env var injection
in envx.Env, as well as filesystem injection via fsx.FS.

The misc/ code is updated to make use of Runner instead of invoking
commands directly. In the future, this should allow doing "dry runs"
in limited places where the command outputs are not used for control
flow.

This allows us to tighten lint rules around os/exec usage.

syscaps usage is restricted to avoid library code using ambient authority.