### PR TITLE
feat(envx_path): Add capability-based executable lookup

### DIFF
--- a/common/check/check.go
+++ b/common/check/check.go
@@ -124,7 +124,11 @@ func (h Harness) T() *testing.T {
 // AssertSame compares want and got using cmp.Diff and fails with a diff if they differ.
 // Additional cmp options may be provided to customize comparison.
 func AssertSame[T any](h BasicHarness, want, got T, what string, opts ...cmp.Option) {
-	if diff := cmp.Diff(want, got, opts...); diff != "" {
+	defaultOpts := cmp.Options{
+		cmp.AllowUnexported(pathx.AbsPath{}, pathx.RelPath{}, pathx.RootRelPath{}),
+	}
+	allOpts := append(defaultOpts, opts...)
+	if diff := cmp.Diff(want, got, allOpts...); diff != "" {
 		h.Assertf(false, "%s mismatch (-want +got):\n%s", what, diff)
 	}
 }

--- a/common/core/pathx/pathx.go
+++ b/common/core/pathx/pathx.go
@@ -97,6 +97,22 @@ func (p AbsPath) Join(rel RelPath) AbsPath {
 	return NewAbsPath(filepath.Join(p.value, rel.value))
 }
 
+// AppendExtension returns p with ext appended.
+//
+// Pre-conditions:
+// 1. p must be non-empty.
+// 2. p does not end with a path separator (i.e. p must be a valid file path).
+func (p AbsPath) AppendExtension(ext string) AbsPath {
+	if len(p.value) == 0 {
+		assert.Precondition(false, "empty path")
+	} else {
+		lastCharStr := p.value[len(p.value)-1:]
+		assert.Preconditionf(!HasPathSeparators(lastCharStr),
+			"path %q ends with a path separator; so it's not a valid file path", p.value)
+	}
+	return NewAbsPath(p.value + ext)
+}
+
 // JoinComponents joins individual path components onto p.
 //
 // Pre-condition: no element contains a path separator.

--- a/common/core/pathx/pathx_test.go
+++ b/common/core/pathx/pathx_test.go
@@ -171,6 +171,41 @@ func TestJoinMatchesJoinComponents(t *testing.T) {
 	check.AssertSame(h, want.String(), got.String(), "Join vs JoinComponents")
 }
 
+func TestAppendExtension(t *testing.T) {
+	h := check.New(t)
+
+	h.Run("AppendsExtension", func(h check.Harness) {
+		h.Parallel()
+
+		root := pathx.NewAbsPath(h.T().TempDir())
+		path := root.JoinComponents("tool")
+		got := path.AppendExtension(".exe")
+		check.AssertSame(h, root.JoinComponents("tool.exe").String(), got.String(), "AppendExtension")
+	})
+
+	h.Run("PanicsOnEmptyPath", func(h check.Harness) {
+		h.Parallel()
+
+		want := assert.AssertionError{Fmt: "precondition violation: %s", Args: []any{"empty path"}}
+		h.AssertPanicsWith(want, func() {
+			_ = (pathx.AbsPath{}).AppendExtension(".exe")
+		})
+	})
+
+	h.Run("PanicsOnTrailingSeparator", func(h check.Harness) {
+		h.Parallel()
+
+		path := pathx.NewAbsPath(h.T().TempDir() + string(filepath.Separator))
+		want := assert.AssertionError{
+			Fmt:  "precondition violation: path %q ends with a path separator; so it's not a valid file path",
+			Args: []any{path.String()},
+		}
+		h.AssertPanicsWith(want, func() {
+			_ = path.AppendExtension(".exe")
+		})
+	})
+}
+
 func TestRootRelPathBasics(t *testing.T) {
 	h := check.New(t)
 	root := pathx.NewAbsPath(t.TempDir())

--- a/common/envx/envx_path/errdot.go
+++ b/common/envx/envx_path/errdot.go
@@ -1,0 +1,7 @@
+package envx_path
+
+import "os/exec"
+
+// ErrDot is re-exported from os/exec for callers comparing errors returned by
+// FindExecutable when a relative PATH entry resolves to a matching executable.
+var ErrDot = exec.ErrDot

--- a/common/envx/envx_path/find_executable.go
+++ b/common/envx/envx_path/find_executable.go
@@ -1,0 +1,212 @@
+// Package envx_path provides environment-sensitive PATH lookup helpers.
+package envx_path
+
+import (
+	"fmt"
+	"iter"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/typesanitizer/happygo/common/assert"
+	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/pathx"
+	"github.com/typesanitizer/happygo/common/envx"
+	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
+)
+
+// NotExecutableErr indicates a candidate file exists but is not executable.
+var NotExecutableErr = errorx.New("nostack", "not an executable file")
+
+// FindExecutable is analogous to exec.LookPath for bare executable names, but
+// searches within fs instead of the host filesystem.
+//
+// Differences from exec.LookPath:
+//   - PATH entries that resolve outside fs.Root() return an errorx.Problem
+//     with code errorx.Code_AccessDenied instead of consulting the host
+//     filesystem
+//   - environment lookup comes from env instead of process-global state;
+//
+// Error cases:
+//   - If PATH is missing or empty, the root cause is a [errorx.Problem] with
+//     code [errorx.Code_InvalidArgument].
+//   - If a relative PATH entry inside fs resolves to a matching executable,
+//     the root cause is [ErrDot], like exec.LookPath.
+//   - If a PATH entry resolves to a directory which does not fall under fs,
+//     the root cause is a [errorx.Problem] with code [errorx.Code_AccessDenied].
+//   - If no executable is found under a valid PATH, the root cause is
+//     [os.ErrNotExist].
+//
+// When an error is returned, other metadata about the search/potential candidates
+// is included via an [ExeSearchError] (discoverable via [errorx.FindInChainAs]),
+// for additional context. It contains a list of IgnoredPaths.
+//
+//   - If some filesystem error was hit (e.g. permission denied), that error is
+//     recorded as IgnoredPath.Err.
+//   - This excludes "file not found" errors, because those are expected in routine
+//     operation.
+//   - If a file match was found, but it was not executable, IgnoredPath.Err is set
+//     to [NotExecutableErr].
+//
+// Pre-condition: name is non-empty and does not contain path separators.
+func FindExecutable(fs fsx.FS, env envx.Env, name string) (AbsPath, error) {
+	assert.Preconditionf(name != "", "name is empty")
+	assert.Preconditionf(!pathx.HasPathSeparators(name), "name contains path separators: %q", name)
+
+	pathEnvVar, ok := env.Lookup("PATH").Get()
+	if !ok || pathEnvVar == "" {
+		return AbsPath{}, errorx.NewProblem(errorx.Code_InvalidArgument, "PATH must be set and non-empty")
+	}
+	var ignoredPaths []IgnoredPath
+	for searchDir := range searchDirs(pathEnvVar) {
+		var dir AbsPath
+		if searchDir.isRelative {
+			dir = fs.Root().Join(NewRelPath(searchDir.pathEntry))
+		} else {
+			dir = NewAbsPath(searchDir.pathEntry)
+		}
+		if !dir.MakeRelativeTo(fs.Root()).IsSome() {
+			err := errorx.NewProblem(errorx.Code_AccessDenied,
+				fmt.Sprintf("PATH entry %q resolves outside filesystem root %q", searchDir.pathEntry, fs.Root()))
+			return AbsPath{}, wrapIgnored(err, ignoredPaths)
+		}
+		for candidatePath := range candidatePaths(env, dir.JoinComponents(name)) {
+			rootRel, ok := candidatePath.MakeRelativeTo(fs.Root()).Get()
+			// Proof of invariant:
+			// 1. name doesn't have path separators (by pre-condition on FindExecutable).
+			// 2. The check above returned early if dir escaped fs.Root().
+			// 3. If dir is inside fs.Root() and name doesn't have path separators,
+			//    then dir.JoinComponents(name) is inside fs.Root() as well.
+			// 4. candidatePaths only potentially appends a file extension.
+			assert.Invariantf(ok, "candidate path %q escaped filesystem root %q", candidatePath, fs.Root())
+			info, err := fs.Stat(rootRel.Rel())
+			if err != nil {
+				if !os.IsNotExist(err) {
+					ignoredPaths = append(ignoredPaths, IgnoredPath{Path: candidatePath, Err: err})
+				}
+				continue
+			}
+			if info.IsDir() {
+				continue
+			}
+			if !isExecutableCandidate(info.Mode()) {
+				ignoredPaths = append(ignoredPaths, IgnoredPath{Path: candidatePath, Err: NotExecutableErr})
+				continue
+			}
+			if searchDir.isRelative {
+				err := errorx.Wrapf("nostack", ErrDot,
+					"PATH entry %q resolved executable %s relative to filesystem root",
+					searchDir.pathEntry, candidatePath)
+				return candidatePath, wrapIgnored(err, ignoredPaths)
+			}
+			return candidatePath, nil
+		}
+	}
+	err := errorx.Wrapf("nostack", os.ErrNotExist,
+		"failed to find executable %q in PATH %q", name, pathEnvVar)
+	return AbsPath{}, wrapIgnored(err, ignoredPaths)
+}
+
+// IgnoredPath records a candidate path that was found but skipped during
+// executable search.
+type IgnoredPath struct {
+	Path AbsPath
+	// Err is guaranteed to be non-nil.
+	Err error
+}
+
+// ExeSearchError wraps an executable search error with information about
+// candidates that were found but ignored (e.g. permission errors, non-executable files).
+type ExeSearchError struct {
+	inner        error         // guaranteed non-nil
+	ignoredPaths []IgnoredPath // guaranteed non-empty
+}
+
+// Post-condition: The returned slice is guaranteed to be non-empty.
+func (e *ExeSearchError) IgnoredPaths() []IgnoredPath {
+	return e.ignoredPaths
+}
+
+func (e *ExeSearchError) Error() string {
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, "%s (%d candidates ignored)", e.inner, len(e.ignoredPaths))
+	for _, ignoredPath := range e.ignoredPaths {
+		b.WriteString("\n")
+		switch {
+		case errorx.GetRootCauseAsValue(ignoredPath.Err, NotExecutableErr):
+			_, _ = fmt.Fprintf(&b, "ignored %q as it was not executable", ignoredPath.Path)
+		default:
+			_, _ = fmt.Fprintf(&b, "ignored %q due to Stat error %v", ignoredPath.Path, ignoredPath.Err)
+		}
+	}
+	return b.String()
+}
+
+func (e *ExeSearchError) Unwrap() error {
+	return e.inner
+}
+
+type searchDir struct {
+	pathEntry  string
+	isRelative bool
+}
+
+func searchDirs(pathEnvVar string) iter.Seq[searchDir] {
+	return func(yield func(searchDir) bool) {
+		for pathEntry := range strings.SplitSeq(pathEnvVar, string(os.PathListSeparator)) {
+			if pathEntry == "" {
+				continue
+			}
+			if !yield(searchDir{pathEntry: pathEntry, isRelative: !filepath.IsAbs(pathEntry)}) {
+				return
+			}
+		}
+	}
+}
+
+// candidatePaths returns a sequence of all the paths to examine
+// for executables, given a particular potential executable path.
+//
+// This largely matters for Windows because on Windows, the
+// search needs to look at extensions inferred via the PATHEXT
+// environment variable, in case base itself doesn't have an extension.
+func candidatePaths(env envx.Env, base AbsPath) iter.Seq[AbsPath] {
+	return func(yield func(AbsPath) bool) {
+		if runtime.GOOS != "windows" || filepath.Ext(base.String()) != "" {
+			yield(base)
+			return
+		}
+		pathExt, ok := env.Lookup("PATHEXT").Get()
+		if !ok || pathExt == "" {
+			// Match exec.LookPath's Windows fallback when PATHEXT is unset or empty.
+			pathExt = ".COM;.EXE;.BAT;.CMD"
+		}
+		for ext := range strings.SplitSeq(pathExt, ";") {
+			if ext == "" {
+				continue
+			}
+			if !yield(base.AppendExtension(ext)) {
+				return
+			}
+		}
+	}
+}
+
+func wrapIgnored(err error, ignoredPaths []IgnoredPath) error {
+	if len(ignoredPaths) == 0 {
+		return err
+	}
+	return &ExeSearchError{inner: err, ignoredPaths: ignoredPaths}
+}
+
+// On Unix, executable bits gate path lookup results. On Windows, this matches
+// exec.LookPath: after PATHEXT filtering, any non-directory file is accepted
+// here because Windows path lookup does not use Unix-style execute mode bits.
+func isExecutableCandidate(mode os.FileMode) bool {
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return mode&0o111 != 0
+}

--- a/common/envx/envx_path/find_executable_test.go
+++ b/common/envx/envx_path/find_executable_test.go
@@ -1,0 +1,319 @@
+package envx_path_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/typesanitizer/happygo/common/assert"
+	"github.com/typesanitizer/happygo/common/check"
+	. "github.com/typesanitizer/happygo/common/check/prelude"
+	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/envx"
+	"github.com/typesanitizer/happygo/common/envx/envx_path"
+	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/iterx"
+	"github.com/typesanitizer/happygo/common/syscaps"
+)
+
+func TestFindExecutable(t *testing.T) {
+	h := check.New(t)
+	// No h.Parallel() here because some nested tests use Setenv and Chdir.
+
+	h.Run("Happy path works", testFindExecutableHappyPath)
+	h.Run("Error cases are reported", testFindExecutableErrorCases)
+	h.Run("Preconditions are enforced", testFindExecutablePreconditions)
+}
+
+func testFindExecutableHappyPath(h check.Harness) {
+	exe := hostOSExecutable()
+	fakeRoot := baseFakeRoot().JoinComponents("find-executable", "happy-path")
+
+	h.Run("PATH behavior", func(h check.Harness) {
+		fs := newMemFS(h, fakeRoot.JoinComponents("path-behavior"))
+		binRel := NewRelPath("bin")
+		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
+		exeRel := binRel.JoinComponents(exe.Name)
+		writeExecutable(h, fs, exeRel)
+
+		h.Run("Absolute PATH finds executable", func(h check.Harness) {
+			h.Parallel()
+
+			envVars := map[string]string{"PATH": fs.Root().Join(binRel).String()}
+			if runtime.GOOS == "windows" {
+				envVars["PATHEXT"] = ".COM;.EXE;.BAT;.CMD"
+			}
+			env := testEnv(envVars)
+
+			got := Do(envx_path.FindExecutable(fs, env, exe.LookupName))(h)
+			check.AssertSame(h, fs.Root().Join(exeRel), got, "FindExecutable")
+		})
+
+		h.Run("Missing candidates are skipped", func(h check.Harness) {
+			h.Parallel()
+
+			envVars := map[string]string{
+				"PATH": strings.Join([]string{
+					fs.Root().JoinComponents("missing").String(),
+					fs.Root().Join(binRel).String(),
+				}, string(os.PathListSeparator)),
+			}
+			if runtime.GOOS == "windows" {
+				envVars["PATHEXT"] = ".COM;.EXE;.BAT;.CMD"
+			}
+			env := testEnv(envVars)
+
+			got := Do(envx_path.FindExecutable(fs, env, exe.LookupName))(h)
+			check.AssertSame(h, fs.Root().Join(exeRel), got, "FindExecutable after missing candidate")
+		})
+	})
+
+	h.Run("Windows compatibility matches exec.LookPath", func(h check.Harness) {
+		if runtime.GOOS != "windows" {
+			h.T().Skip("Windows-specific exec.LookPath compatibility tests")
+		}
+
+		root := NewAbsPath(h.T().TempDir())
+		fs := Do(syscaps.FS(root))(h)
+		binRel := NewRelPath("bin")
+		binDir := root.Join(binRel)
+		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
+
+		h.Run("Empty PATHEXT falls back like exec.LookPath", func(h check.Harness) {
+			exeRel := binRel.JoinComponents("tool.EXE")
+			writeExecutable(h, fs, exeRel)
+			exePath := root.Join(exeRel)
+
+			h.T().Setenv("PATH", binDir.String())
+			h.T().Setenv("PATHEXT", "")
+
+			wantPath := Do(exec.LookPath("tool"))(h)
+			check.AssertSame(h, exePath.String(), wantPath, "exec.LookPath path")
+
+			env := testEnv(map[string]string{"PATH": binDir.String()})
+			gotPath := Do(envx_path.FindExecutable(fs, env, "tool"))(h)
+			check.AssertSame(h, exePath, gotPath, "FindExecutable path")
+		})
+
+		h.Run("Explicit extension matches exec.LookPath", func(h check.Harness) {
+			txtRel := binRel.JoinComponents("tool.txt")
+			writeExecutable(h, fs, txtRel)
+			txtPath := root.Join(txtRel)
+
+			h.T().Setenv("PATH", binDir.String())
+
+			wantPath := Do(exec.LookPath("tool.txt"))(h)
+			check.AssertSame(h, txtPath.String(), wantPath, "exec.LookPath path")
+
+			env := testEnv(map[string]string{"PATH": binDir.String()})
+			gotPath := Do(envx_path.FindExecutable(fs, env, "tool.txt"))(h)
+			check.AssertSame(h, txtPath, gotPath, "FindExecutable path")
+		})
+	})
+}
+
+func testFindExecutableErrorCases(h check.Harness) {
+	exe := hostOSExecutable()
+	fakeRoot := baseFakeRoot().JoinComponents("find-executable", "error-cases")
+
+	h.Run("Missing PATH is invalid", func(h check.Harness) {
+		h.Parallel()
+
+		fs := newMemFS(h, fakeRoot.JoinComponents("missing-path"))
+		_, err := envx_path.FindExecutable(fs, envx.Empty(), "tool")
+		assertProblemCode(h, err, errorx.Code_InvalidArgument)
+	})
+
+	h.Run("Absolute PATH outside root is denied", func(h check.Harness) {
+		h.Parallel()
+
+		fs := newMemFS(h, fakeRoot.JoinComponents("absolute-outside-root"))
+		outsideDir := baseFakeRoot().JoinComponents("outside", "absolute")
+		env := testEnv(map[string]string{"PATH": outsideDir.String()})
+
+		_, err := envx_path.FindExecutable(fs, env, "tool")
+		assertProblemCode(h, err, errorx.Code_AccessDenied)
+	})
+
+	h.Run("Non-executable candidates are reported", func(h check.Harness) {
+		h.Parallel()
+
+		if runtime.GOOS == "windows" {
+			h.T().Skip("Windows treats any non-directory file as executable after PATHEXT filtering")
+		}
+
+		fs := newMemFS(h, fakeRoot.JoinComponents("non-executable-candidates"))
+		binRel := NewRelPath("bin")
+		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
+		exeRel := binRel.JoinComponents(exe.Name)
+		h.NoErrorf(fs.WriteFile(exeRel, []byte("#!/bin/sh\n"), 0o644), "WriteFile(%q)", exeRel)
+
+		env := testEnv(map[string]string{"PATH": fs.Root().Join(binRel).String()})
+		_, err := envx_path.FindExecutable(fs, env, exe.LookupName)
+		h.Assertf(errorx.GetRootCauseAsValue(err, os.ErrNotExist),
+			"expected not-exist error, got %v", err)
+
+		searchErr, ok := errorx.FindInChainAs[*envx_path.ExeSearchError](err).Get()
+		h.Assertf(ok, "expected *ExeSearchError, got %T", err)
+		check.AssertSame(h, 1, len(searchErr.IgnoredPaths()), "IgnoredPaths count")
+		ignored := searchErr.IgnoredPaths()[0]
+		check.AssertSame(h, fs.Root().Join(exeRel), ignored.Path, "IgnoredPath.Path")
+		h.Assertf(errorx.GetRootCauseAsValue(ignored.Err, envx_path.NotExecutableErr),
+			"expected not-executable error, got %v", ignored.Err)
+
+		wantErr := fmt.Sprintf("%s (%d candidates ignored)\nignored %q as it was not executable",
+			searchErr.Unwrap().Error(), len(searchErr.IgnoredPaths()), ignored.Path)
+		check.AssertSame(h, wantErr, searchErr.Error(), "ExeSearchError.Error()")
+	})
+
+	h.Run("Relative PATH outside root is denied", func(h check.Harness) {
+		h.Parallel()
+
+		fs := newMemFS(h, fakeRoot.JoinComponents("relative-outside-root"))
+		outsideRel := filepath.Join("..", "outside")
+		env := testEnv(map[string]string{"PATH": outsideRel})
+
+		_, err := envx_path.FindExecutable(fs, env, "tool")
+		assertProblemCode(h, err, errorx.Code_AccessDenied)
+	})
+
+	h.Run("exec.LookPath compatibility", func(h check.Harness) {
+		root := NewAbsPath(h.T().TempDir())
+		fs := Do(syscaps.FS(root))(h)
+		binRel := NewRelPath("bin")
+		binDir := root.Join(binRel)
+		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
+		exeRel := binRel.JoinComponents(exe.Name)
+		writeExecutable(h, fs, exeRel)
+
+		h.Run("Relative PATH returns ErrDot", func(h check.Harness) {
+			h.T().Chdir(root.String())
+			h.T().Setenv("PATH", "bin")
+			if runtime.GOOS == "windows" {
+				h.T().Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+			}
+
+			wantPath, wantErr := exec.LookPath(exe.LookupName)
+			h.Assertf(errorx.GetRootCauseAsValue(wantErr, exec.ErrDot),
+				"expected exec.LookPath error %v to wrap exec.ErrDot", wantErr)
+			check.AssertSame(h, filepath.Join("bin", exe.Name), wantPath, "exec.LookPath path")
+
+			envVars := map[string]string{"PATH": "bin"}
+			if runtime.GOOS == "windows" {
+				envVars["PATHEXT"] = ".COM;.EXE;.BAT;.CMD"
+			}
+			env := testEnv(envVars)
+
+			gotPath, gotErr := envx_path.FindExecutable(fs, env, exe.LookupName)
+			h.Assertf(errorx.GetRootCauseAsValue(gotErr, envx_path.ErrDot),
+				"expected FindExecutable error %v to wrap ErrDot", gotErr)
+			check.AssertSame(h, root.Join(exeRel), gotPath, "FindExecutable path")
+		})
+
+		h.Run("Stat errors are skipped", func(h check.Harness) {
+			if runtime.GOOS == "windows" {
+				h.T().Skip("permission-denied stat behavior differs on Windows")
+			}
+
+			h.NoErrorf(os.Chmod(binDir.String(), 0o000), "Chmod(%q)", binDir)
+			h.T().Cleanup(func() {
+				_ = os.Chmod(binDir.String(), 0o755)
+			})
+
+			h.T().Setenv("PATH", binDir.String())
+
+			_, stdlibErr := exec.LookPath(exe.LookupName)
+			h.Assertf(errorx.GetRootCauseAsValue(stdlibErr, exec.ErrNotFound),
+				"expected exec.LookPath ErrNotFound, got %v", stdlibErr)
+
+			env := testEnv(map[string]string{"PATH": binDir.String()})
+			_, err := envx_path.FindExecutable(fs, env, exe.LookupName)
+			h.Assertf(errorx.GetRootCauseAsValue(err, os.ErrNotExist),
+				"expected not-exist error, got %v", err)
+
+			searchErr, ok := errorx.FindInChainAs[*envx_path.ExeSearchError](err).Get()
+			h.Assertf(ok, "expected *ExeSearchError, got %T", err)
+			check.AssertSame(h, 1, len(searchErr.IgnoredPaths()), "IgnoredPaths count")
+			ignored := searchErr.IgnoredPaths()[0]
+			check.AssertSame(h, binDir.JoinComponents(exe.Name), ignored.Path, "IgnoredPath.Path")
+			h.Assertf(errorx.GetRootCauseAsValue(ignored.Err, os.ErrPermission),
+				"expected permission error, got %v", ignored.Err)
+
+			wantErr := fmt.Sprintf("%s (%d candidates ignored)\nignored %q due to Stat error %v",
+				searchErr.Unwrap().Error(), 1, ignored.Path, ignored.Err)
+			check.AssertSame(h, wantErr, searchErr.Error(), "ExeSearchError.Error()")
+		})
+	})
+}
+
+func testFindExecutablePreconditions(h check.Harness) {
+	fakeRoot := baseFakeRoot().JoinComponents("find-executable", "preconditions")
+
+	h.Run("Empty name panics", func(h check.Harness) {
+		h.Parallel()
+
+		fs := newMemFS(h, fakeRoot.JoinComponents("empty-name"))
+		want := assert.AssertionError{Fmt: "precondition violation: name is empty", Args: nil}
+		h.AssertPanicsWith(want, func() {
+			_, _ = envx_path.FindExecutable(fs, envx.Empty(), "")
+		})
+	})
+
+	h.Run("Path separators panic", func(h check.Harness) {
+		h.Parallel()
+
+		fs := newMemFS(h, fakeRoot.JoinComponents("path-separators"))
+		want := assert.AssertionError{
+			Fmt:  "precondition violation: name contains path separators: %q",
+			Args: []any{"dir/tool"},
+		}
+		h.AssertPanicsWith(want, func() {
+			_, _ = envx_path.FindExecutable(fs, envx.Empty(), "dir/tool")
+		})
+	})
+}
+
+func newMemFS(h check.Harness, root AbsPath) fsx.FS {
+	h.T().Helper()
+	return Do(fsx.MemMap(root))(h)
+}
+
+func baseFakeRoot() AbsPath {
+	if runtime.GOOS == "windows" {
+		return NewAbsPath(`C:\virtual-root`)
+	}
+	return NewAbsPath("/virtual-root")
+}
+
+func assertProblemCode(h check.Harness, err error, want errorx.Code) {
+	h.T().Helper()
+	problem, ok := errorx.GetRootCauseAs[*errorx.Problem](err).Get()
+	h.Assertf(ok, "expected *errorx.Problem, got %T", err)
+	check.AssertSame(h, want, problem.Code(), "Problem.Code()")
+}
+
+func testEnv(pairs map[string]string) envx.Env {
+	return envx.New(iterx.FromMap(pairs))
+}
+
+type hostExecutable struct {
+	Name       string
+	LookupName string
+}
+
+func hostOSExecutable() hostExecutable {
+	if runtime.GOOS == "windows" {
+		return hostExecutable{Name: "tool.EXE", LookupName: "tool"}
+	}
+	return hostExecutable{Name: "tool", LookupName: "tool"}
+}
+
+func writeExecutable(h check.Harness, fs fsx.FS, path RelPath) {
+	h.T().Helper()
+	h.NoErrorf(fs.WriteFile(path, []byte("#!/bin/sh\n"), 0o755), "WriteFile(%q)", path)
+}

--- a/common/errorx/errorx.go
+++ b/common/errorx/errorx.go
@@ -5,10 +5,12 @@ package errorx
 import (
 	"errors" //nolint:depguard // In designated wrapper package
 	"fmt"
+	"iter"
 
 	cockroach "github.com/cockroachdb/errors" //nolint:depguard // In designated wrapper package
 	"github.com/typesanitizer/happygo/common/assert"
 	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/iterx"
 )
 
 // IncludeStackTrace controls whether a stack trace is captured when creating an error.
@@ -61,7 +63,100 @@ func Wrapf(ist IncludeStackTrace, err error, format string, args ...any) error {
 
 const NESTING_LIMIT = 1000
 
-// RootCauseResult represents one of two cases:
+type linkKind uint8
+
+const (
+	linkNormal       linkKind = iota // intermediate node or leaf
+	linkMultiError                   // stopped at multi-error fork (2+ children)
+	linkNestingLimit                 // exceeded NESTING_LIMIT
+)
+
+func (k linkKind) String() string {
+	switch k {
+	case linkNormal:
+		return "normal"
+	case linkMultiError:
+		return "multi-error"
+	case linkNestingLimit:
+		return "nesting-limit"
+	default:
+		return assert.PanicUnknownCase[string](k)
+	}
+}
+
+// ChainLink represents a single node encountered while traversing an error chain.
+//
+// At intermediate nodes, Current is the error at that level and the kind is
+// [linkNormal]. The final yielded ChainLink carries the terminal condition:
+//   - A leaf error (no Unwrap/Cause, or Unwrap returns nil): linkNormal
+//   - A multi-error fork (Unwrap() []error with 2+ elements): linkMultiError
+//   - Nesting limit exceeded: linkNestingLimit
+type ChainLink struct {
+	current error
+	kind    linkKind
+}
+
+// Current returns the error at this point in the chain.
+func (c ChainLink) Current() error {
+	return c.current
+}
+
+// HitMultiError returns whether traversal stopped at a multi-error fork.
+func (c ChainLink) HitMultiError() bool {
+	return c.kind == linkMultiError
+}
+
+// HitNestingLimit returns whether traversal exceeded [NESTING_LIMIT].
+func (c ChainLink) HitNestingLimit() bool {
+	return c.kind == linkNestingLimit
+}
+
+// Chain yields each error in the unwrap chain from outermost to innermost.
+//
+// The chain is traversed via Unwrap() error, Unwrap() []error (single-element
+// only), and Cause() error. Traversal stops at leaves, multi-error forks
+// (2+ children), or after [NESTING_LIMIT] iterations.
+//
+// The final yielded [ChainLink] carries the terminal condition.
+//
+// Pre-condition: err != nil
+// Post-condition: The iterator is non-empty, and the first element has Current() == err.
+func Chain(err error) iter.Seq[ChainLink] {
+	assert.Precondition(err != nil, "trying to traverse chain for nil error")
+	return func(yield func(ChainLink) bool) {
+		cur := err
+		for range NESTING_LIMIT {
+			kind := linkNormal
+			var next error
+			switch e := cur.(type) {
+			case interface{ Unwrap() []error }:
+				errList := e.Unwrap()
+				switch len(errList) {
+				case 0:
+					break
+				case 1:
+					next = errList[0]
+				default:
+					kind = linkMultiError
+				}
+			case interface{ Unwrap() error }:
+				next = e.Unwrap()
+			case interface{ Cause() error }:
+				next = e.Cause()
+			}
+			if !yield(ChainLink{current: cur, kind: kind}) {
+				return
+			}
+			if kind != linkNormal || next == nil {
+				return
+			}
+			cur = next
+		}
+		yield(ChainLink{current: cur, kind: linkNestingLimit})
+	}
+}
+
+// RootCauseResult represents the outcome of traversing an error chain:
 //
 //  1. Root cause: A root cause was found by following a linear chain
 //     from the original error (this may be the original error itself).
@@ -73,43 +168,36 @@ const NESTING_LIMIT = 1000
 //
 // The case can be checked using HitNestingLimit() and HitMultiError().
 type RootCauseResult struct {
-	// Logically, there are two cases.
-	// 1. We hit a multi-error with 2+ causes when traversing the error tree.
-	//    If this is the case, hitMultiError will be set to non-nil with that
-	//    multi-error.
-	// 2. We didn't hit a multi-error. In this case rootCause will be set to
-	//    a non-nil error.
-	rootCause       error
-	hitMultiError   error
-	hitNestingLimit bool
+	// err holds either the root cause or the multi-error, depending on kind.
+	// It is nil only when kind == linkNestingLimit.
+	err  error
+	kind linkKind
 }
 
 func (r RootCauseResult) HitNestingLimit() bool {
-	return r.hitNestingLimit
+	return r.kind == linkNestingLimit
 }
 
 // HitMultiError returns whether an error tree traversal hit a multi-error with
 // 2 or more sub-errors.
 func (r RootCauseResult) HitMultiError() bool {
-	return !r.hitNestingLimit && r.hitMultiError != nil
+	return r.kind == linkMultiError
 }
 
 // GetMultiError returns the first multi-error found during error tree traversal.
 //
 // Pre-condition: This result must be a multi-error.
 func (r RootCauseResult) GetMultiError() error {
-	assert.Preconditionf(!r.hitNestingLimit, "requesting multi-error but hit nesting limit %v during traversal", NESTING_LIMIT)
-	assert.Preconditionf(r.hitMultiError != nil, "requesting multi-error but found root cause: %v", r.rootCause)
-	return r.hitMultiError
+	assert.Preconditionf(r.kind == linkMultiError, "requesting multi-error but kind is %s", r.kind)
+	return r.err
 }
 
 // GetRootCause returns a non-nil root cause.
 //
-// Pre-condition: This result must not be a multi-error.
+// Pre-condition: This result must be a root cause (not multi-error or nesting limit).
 func (r RootCauseResult) GetRootCause() error {
-	assert.Preconditionf(!r.hitNestingLimit, "requesting root cause but hit nesting limit %v during traversal", NESTING_LIMIT)
-	assert.Preconditionf(!r.HitMultiError(), "requesting root cause despite hitting multi-error: %v", r.hitMultiError)
-	return r.rootCause
+	assert.Preconditionf(r.kind == linkNormal, "requesting root cause but kind is %s", r.kind)
+	return r.err
 }
 
 // GetRootCause traverses the provided error tree, and gets the underlying
@@ -125,40 +213,8 @@ func (r RootCauseResult) GetRootCause() error {
 //
 // Pre-condition: err != nil
 func GetRootCause(err error) RootCauseResult {
-	assert.Precondition(err != nil, "trying to get root cause for nil error")
-	cur := err
-	for range NESTING_LIMIT {
-		switch e := cur.(type) {
-		case interface{ Unwrap() []error }:
-			errList := e.Unwrap()
-			switch len(errList) {
-			case 0:
-				return RootCauseResult{rootCause: cur, hitMultiError: nil, hitNestingLimit: false}
-			case 1:
-				cur = errList[0]
-				continue
-			default:
-				return RootCauseResult{rootCause: nil, hitMultiError: cur, hitNestingLimit: false}
-			}
-		case interface{ Unwrap() error }:
-			inner := e.Unwrap()
-			if inner != nil {
-				cur = inner
-				continue
-			}
-			return RootCauseResult{rootCause: cur, hitMultiError: nil, hitNestingLimit: false}
-		case interface{ Cause() error }:
-			inner := e.Cause()
-			if inner != nil {
-				cur = inner
-				continue
-			}
-			return RootCauseResult{rootCause: cur, hitMultiError: nil, hitNestingLimit: false}
-		default:
-			return RootCauseResult{rootCause: cur, hitMultiError: nil, hitNestingLimit: false}
-		}
-	}
-	return RootCauseResult{rootCause: nil, hitMultiError: nil, hitNestingLimit: true}
+	last := iterx.Last(Chain(err))
+	return RootCauseResult{err: last.Current(), kind: last.kind}
 }
 
 // GetRootCauseAs is similar to GetRootCause except that it tries to cast
@@ -173,6 +229,25 @@ func GetRootCauseAs[T error](err error) Option[T] {
 	}
 	v, ok := r.GetRootCause().(T)
 	return NewOption(v, ok)
+}
+
+// FindInChainAs traverses the error chain and returns the first error
+// that matches the type parameter T.
+//
+// Returns None if no match is found or if a multi-error is hit before
+// finding a match.
+//
+// You generally want to use [GetRootCauseAs] instead of this function,
+// but this can be useful if the error you want to check potentially
+// wraps some other errors.
+//
+// Pre-condition: err != nil, and err's nesting does not exceed [NESTING_LIMIT].
+func FindInChainAs[T error](err error) Option[T] {
+	return iterx.Find(Chain(err), func(link ChainLink) Option[T] {
+		assert.Precondition(!link.HitNestingLimit(), "hit nesting limit during traversal")
+		v, ok := link.Current().(T)
+		return NewOption(v, ok)
+	})
 }
 
 // GetRootCauseAsValue is similar to GetRootCause except that it tries to compare

--- a/common/errorx/errorx_test.go
+++ b/common/errorx/errorx_test.go
@@ -48,47 +48,47 @@ func TestGetRootCause(t *testing.T) {
 			{
 				name:     "sentinel",
 				input:    sentinel,
-				expected: RootCauseResult{rootCause: sentinel},
+				expected: RootCauseResult{err: sentinel, kind: linkNormal},
 			},
 			{
 				name:     "simple leaf",
 				input:    leaf1,
-				expected: RootCauseResult{rootCause: leaf1},
+				expected: RootCauseResult{err: leaf1, kind: linkNormal},
 			},
 			{
 				name:     "hitting multi error",
 				input:    fork12,
-				expected: RootCauseResult{hitMultiError: fork12},
+				expected: RootCauseResult{err: fork12, kind: linkMultiError},
 			},
 			{
 				name:     "no notion of equality checking/coalescing on hitting multi-errors",
 				input:    twoSentinels,
-				expected: RootCauseResult{hitMultiError: twoSentinels},
+				expected: RootCauseResult{err: twoSentinels, kind: linkMultiError},
 			},
 			{
 				name:     "root cause found in chain",
 				input:    chain12,
-				expected: RootCauseResult{rootCause: leaf2},
+				expected: RootCauseResult{err: leaf2, kind: linkNormal},
 			},
 			{
 				name:     "root cause found after wrapping (via Unwrap())",
 				input:    wrappedLeaf1,
-				expected: RootCauseResult{rootCause: leaf1},
+				expected: RootCauseResult{err: leaf1, kind: linkNormal},
 			},
 			{
 				name:     "root cause found after wrapping (via Cause())",
 				input:    causedLeaf1,
-				expected: RootCauseResult{rootCause: leaf1},
+				expected: RootCauseResult{err: leaf1, kind: linkNormal},
 			},
 			{
 				name:     "root cause is prior if Unwrap() == nil",
 				input:    wrappedEmpty,
-				expected: RootCauseResult{rootCause: wrappedEmpty},
+				expected: RootCauseResult{err: wrappedEmpty, kind: linkNormal},
 			},
 			{
 				name:     "root cause is prior if Cause() == nil",
 				input:    causedEmpty,
-				expected: RootCauseResult{rootCause: causedEmpty},
+				expected: RootCauseResult{err: causedEmpty, kind: linkNormal},
 			},
 		}
 

--- a/common/errorx/problem.go
+++ b/common/errorx/problem.go
@@ -1,0 +1,49 @@
+package errorx
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/typesanitizer/happygo/common/assert"
+)
+
+// Code classifies a structured non-stack error.
+type Code string
+
+const (
+	Code_InvalidArgument Code = "invalid argument"
+	Code_AccessDenied    Code = "access denied"
+)
+
+var allCodes = sync.OnceValue(func() []Code {
+	return []Code{Code_InvalidArgument, Code_AccessDenied}
+})
+
+func isValidCode(code Code) bool {
+	return slices.Contains(allCodes(), code)
+}
+
+// Problem is a structured error with a stable code and message.
+type Problem struct {
+	code Code
+	msg  string
+}
+
+// NewProblem returns a Problem with the given code and message.
+func NewProblem(code Code, msg string) *Problem {
+	assert.Preconditionf(isValidCode(code), "invalid errorx.Code %q", code)
+	return &Problem{code: code, msg: msg}
+}
+
+func (p *Problem) Error() string {
+	return fmt.Sprintf("%s (%s)", p.msg, p.code)
+}
+
+func (p *Problem) Code() Code {
+	return p.code
+}
+
+func (p *Problem) Msg() string {
+	return p.msg
+}

--- a/common/iterx/iterx.go
+++ b/common/iterx/iterx.go
@@ -3,6 +3,9 @@ package iterx
 import (
 	"iter"
 
+	"github.com/typesanitizer/happygo/common/assert"
+	"github.com/typesanitizer/happygo/common/core/option"
+	"github.com/typesanitizer/happygo/common/core/pair"
 	"github.com/typesanitizer/happygo/common/core/result"
 )
 
@@ -13,6 +16,31 @@ func Collect[T any](seq iter.Seq[T]) []T {
 		result = append(result, v)
 	}
 	return result
+}
+
+// Last returns the last yielded value from seq.
+//
+// Pre-condition: seq yields at least once.
+func Last[T any](seq iter.Seq[T]) T {
+	var last T
+	sawValue := false
+	for v := range seq {
+		last = v
+		sawValue = true
+	}
+	assert.Precondition(sawValue, "iterator yielded no values")
+	return last
+}
+
+// Find returns the first Some value produced by f over seq.
+func Find[A any, B any](seq iter.Seq[A], f func(A) option.Option[B]) option.Option[B] {
+	for v := range seq {
+		result := f(v)
+		if result.IsSome() {
+			return result
+		}
+	}
+	return option.None[B]()
 }
 
 // Map transforms each value in seq with f.
@@ -40,6 +68,16 @@ func Unbatch[T any](seq iter.Seq[result.Result[[]T]]) iter.Seq[result.Result[T]]
 				if !yield(result.Success(item)) {
 					return
 				}
+			}
+		}
+	}
+}
+
+func FromMap[K comparable, V any](kvs map[K]V) iter.Seq[pair.KeyValue[K, V]] {
+	return func(yield func(pair.KeyValue[K, V]) bool) {
+		for k, v := range kvs {
+			if !yield(pair.NewKeyValue(k, v)) {
+				return
 			}
 		}
 	}


### PR DESCRIPTION
Adds an API to look up executables using fsx.FS and envx.Env,
instead of using APIs which make use of global state.

The new API envx_path.FindExecutable has a more readable
name than the "LookPath" API it replaces, as well as better
documentation of various error cases.

Testing the error cases involves having some API for pattern-matching
on specific kinds of errors, so this patch introduces more fine-grained
APIs compared to the more freestyle errors.As/Is, which can find
matches anywhere in an error tree, which is often NOT the desired
behavior.