### PR TITLE
fix(ci): Skip CI on draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,18 @@ name: ci
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches:
       - main
 
 jobs:
   pipeline:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
It doesn't make sense to run CI on draft PRs, as this starves
the limited GitHub Actions runner capacity when stacking PRs.
