### PR TITLE
fix(ci): Use more secure defaults for GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,9 @@ jobs:
   build-head:
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/build-toolchain
         with:
           os: ${{ inputs.os }}
@@ -28,8 +30,9 @@ jobs:
     steps:
       # Sparse checkout: only fetch .github/ to access the action.
       # The action will checkout golang/go into go/.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: .github
       - uses: ./.github/actions/build-toolchain
         with:
@@ -40,7 +43,9 @@ jobs:
     runs-on: ${{ inputs.os }}
     needs: build-head
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-head-toolchain
         with:
           os: ${{ inputs.os }}
@@ -61,7 +66,9 @@ jobs:
     runs-on: ${{ inputs.os }}
     needs: build-head
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-head-toolchain
         with:
           os: ${{ inputs.os }}
@@ -76,7 +83,9 @@ jobs:
     runs-on: ${{ inputs.os }}
     needs: build-head
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-head-toolchain
         with:
           os: ${{ inputs.os }}
@@ -96,7 +105,9 @@ jobs:
     runs-on: ${{ inputs.os }}
     needs: build-head
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-head-toolchain
         with:
           os: ${{ inputs.os }}
@@ -117,7 +128,9 @@ jobs:
     runs-on: ${{ inputs.os }}
     needs: build-head
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-head-toolchain
         with:
           os: ${{ inputs.os }}
@@ -141,9 +154,11 @@ jobs:
       matrix:
         go-toolchain: [head, stable, gotip]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       # Stable Go is used only for fixture builds; capture its GOROOT before PATH changes.
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         if: matrix.go-toolchain == 'stable'
         with:
           go-version: 1.25.x
@@ -158,17 +173,20 @@ jobs:
       - uses: ./.github/actions/setup-head-toolchain
         with:
           os: ${{ inputs.os }}
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         if: matrix.go-toolchain == 'gotip'
         with:
           name: go-gotip-${{ inputs.os }}
-          path: .
+          path: gotip-artifact
       - name: Unpack toolchain (tar)
         if: matrix.go-toolchain == 'gotip'
         shell: bash
         run: |
           mkdir -p gotip
-          tar -xzf go-gotip-${{ inputs.os }}.tgz -p -C gotip
+          shopt -s nullglob
+          archives=(gotip-artifact/*.tgz)
+          test "${#archives[@]}" -eq 1
+          tar -xzf "${archives[0]}" -p -C gotip
       # NOTE(id: delve-windows-test-dep-setup): Mirrors logic in delve/_scripts/test_windows.ps1.
       - name: Install procdump (windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   pipeline:
     name: ${{ matrix.os }}


### PR DESCRIPTION
Zizmor flagged a few issues:

- Excessive permissions on tokens
- Interpolating {{ inputs.os }} inside script (actually a
  non-issue but ¯\\_(ツ)_/¯)
- Unpinned dependencies.

We should probably have zizmor and actionlint running
for the CI workflow itself.