### PR TITLE
chore(fs): Define dedicated type fsx.Name to clarify components

### DIFF
--- a/common/collections/map.go
+++ b/common/collections/map.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"cmp"
+	"slices"
 	"sort"
 )
 
@@ -12,6 +13,15 @@ func SortedMapKeys[K cmp.Ordered, V any](m map[K]V) []K {
 		keys = append(keys, k)
 	}
 	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	return keys
+}
+
+func SortedMapKeysFunc[K comparable, V any](m map[K]V, cmp func(k1, k2 K) int) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.SortFunc(keys, cmp)
 	return keys
 }
 

--- a/common/core/pathx/pathx.go
+++ b/common/core/pathx/pathx.go
@@ -173,7 +173,7 @@ func (p RelPath) Join(rel RelPath) RelPath {
 
 // JoinComponents joins individual path components onto p.
 //
-// Pre-condition: no element contains a path separator.
+// Pre-condition: all elements are non-empty and do not contain a path separator.
 func (p RelPath) JoinComponents(pathElems ...string) RelPath {
 	parts := make([]string, 0, len(pathElems)+1)
 	parts = append(parts, p.value)

--- a/common/fsx/fsx.go
+++ b/common/fsx/fsx.go
@@ -13,6 +13,7 @@ import (
 	"os"
 
 	"github.com/spf13/afero" //nolint:depguard // fsx is the designated wrapper
+	"github.com/typesanitizer/happygo/common/fsx/fsx_name"
 
 	"github.com/typesanitizer/happygo/common/assert"
 	. "github.com/typesanitizer/happygo/common/core"
@@ -28,8 +29,8 @@ type File = afero.File
 
 // DirEntry is a single entry returned by [FS.ReadDir].
 type DirEntry interface {
-	// BaseName returns just the basename component of the entry.
-	BaseName() string
+	// BaseName returns the basename of the entry as a validated [Name].
+	BaseName() Name
 	IsDir() bool
 	Info() (os.FileInfo, error)
 }
@@ -38,8 +39,10 @@ type dirEntry struct {
 	entry iofs.DirEntry
 }
 
-func (e dirEntry) BaseName() string {
-	return e.entry.Name()
+func (e dirEntry) BaseName() Name {
+	n, err := fsx_name.Parse(e.entry.Name())
+	assert.Invariantf(err == nil, "filesystem returned invalid Name(): %v", err)
+	return n
 }
 
 func (e dirEntry) IsDir() bool {

--- a/common/fsx/fsx_name/name.go
+++ b/common/fsx/fsx_name/name.go
@@ -1,0 +1,94 @@
+package fsx_name
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/typesanitizer/happygo/common/assert"
+	"github.com/typesanitizer/happygo/common/core/pathx"
+)
+
+// --- Aliases for external use ---
+
+// ParseError is one of two cases:
+//
+//  1. ParseErrorKind_EmptyName.
+//  2. ParseErrorKind_HasPathSeparators: The original name can
+//     be retrieved using the [ParseError.Name] method.
+type ParseError = NameParseError
+
+// ParseErrorKind tracks the case of a ParseError.
+type ParseErrorKind = NameParseErrorKind
+
+// --- Package implementation ---
+
+// Name is a validated single-component file or directory name.
+// It is guaranteed to be non-empty and contain no path separators.
+type Name struct {
+	value string
+}
+
+func (n Name) String() string {
+	return n.value
+}
+
+func (n Name) Compare(p Name) int {
+	return strings.Compare(n.value, p.value)
+}
+
+// New creates a Name from s.
+//
+// Pre-conditions:
+// 1. s is non-empty.
+// 2. s does not contain any path separators.
+func New(s string) Name {
+	n, err := Parse(s)
+	assert.Preconditionf(err == nil, "%v", err)
+	return n
+}
+
+// Parse attempts to parse the argument as a valid name
+// for the host operating system.
+func Parse(s string) (Name, error) {
+	if s == "" {
+		return Name{}, &NameParseError{ParseErrorKind_EmptyName, ""}
+	}
+	if pathx.HasPathSeparators(s) {
+		return Name{}, &NameParseError{ParseErrorKind_HasPathSeparators, s}
+	}
+	return Name{s}, nil
+}
+
+// See ParseError for doc comment.
+type NameParseError struct {
+	kind NameParseErrorKind
+	name string
+}
+
+func (e *NameParseError) Kind() NameParseErrorKind {
+	return e.kind
+}
+
+// Pre-condition: Kind() should be ParseErrorKind_HasPathSeparators
+func (e *NameParseError) Name() string {
+	assert.Preconditionf(e.kind == ParseErrorKind_HasPathSeparators, "e.kind should be ParseErrorKind_HasPathSeparators")
+	return e.name
+}
+
+func (e *NameParseError) Error() string {
+	switch e.kind {
+	case ParseErrorKind_EmptyName:
+		return "empty file/directory name"
+	case ParseErrorKind_HasPathSeparators:
+		return fmt.Sprintf("name %q contains path separator(s)", e.name)
+	default:
+		return assert.PanicUnknownCase[string](e.kind)
+	}
+}
+
+type NameParseErrorKind uint8
+
+const (
+	ParseErrorKind_EmptyName NameParseErrorKind = iota + 1
+	ParseErrorKind_HasPathSeparators
+)

--- a/common/fsx/name.go
+++ b/common/fsx/name.go
@@ -1,0 +1,14 @@
+package fsx
+
+import "github.com/typesanitizer/happygo/common/fsx/fsx_name"
+
+type Name = fsx_name.Name
+
+// NewName creates a Name from name.
+//
+// Pre-conditions:
+// 1. name is non-empty.
+// 2. name does not contain any path separators.
+func NewName(name string) Name {
+	return fsx_name.New(name)
+}

--- a/common/syscaps/syscaps_test.go
+++ b/common/syscaps/syscaps_test.go
@@ -37,7 +37,7 @@ func TestFSReadDirBatched(t *testing.T) {
 		got := collections.NewSet[string]()
 		for entryRes := range repoFS.ReadDir(parentDir) {
 			entry := Do(entryRes.Get())(h)
-			name := entry.BaseName()
+			name := entry.BaseName().String()
 			got.InsertNew(name)
 
 			info := Do(entry.Info())(h)

--- a/misc/cmd/happydo/list.go
+++ b/misc/cmd/happydo/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
+	"slices"
 
 	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/errorx"
@@ -66,16 +66,16 @@ func (w Workspace) listGoModules(logger *logx.Logger, out io.Writer, provenance 
 		return err
 	}
 	for _, f := range folders {
-		if _, err := fmt.Fprintln(out, f); err != nil {
+		if _, err := fmt.Fprintln(out, f.String()); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (w Workspace) goModules(logger *logx.Logger, provenance ListProvenance) ([]string, error) {
+func (w Workspace) goModules(logger *logx.Logger, provenance ListProvenance) ([]fsx.Name, error) {
 	rootRel := NewRelPath(".")
-	var folders []string
+	var folders []fsx.Name
 	for entryRes := range w.FS.ReadDir(rootRel) {
 		entry, err := entryRes.Get()
 		if err != nil {
@@ -85,7 +85,7 @@ func (w Workspace) goModules(logger *logx.Logger, provenance ListProvenance) ([]
 			continue
 		}
 		name := entry.BaseName()
-		goModRel := rootRel.JoinComponents(name, "go.mod")
+		goModRel := rootRel.JoinComponents(name.String(), "go.mod")
 		if _, err := w.FS.Stat(goModRel); err != nil {
 			if !os.IsNotExist(err) {
 				logger.Warn("stat go.mod", "dir", name, "err", err)
@@ -106,7 +106,7 @@ func (w Workspace) goModules(logger *logx.Logger, provenance ListProvenance) ([]
 			}
 		}
 	}
-	sort.Strings(folders) // for determinism
+	slices.SortFunc(folders, fsx.Name.Compare) // for determinism
 
 	if len(folders) == 0 {
 		return nil, errorx.Newf("nostack", "no Go modules found matching filter")

--- a/misc/cmd/happydo/list_test.go
+++ b/misc/cmd/happydo/list_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/typesanitizer/happygo/common/check/prelude"
 	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/envx"
+	"github.com/typesanitizer/happygo/common/fsx"
 	"github.com/typesanitizer/happygo/common/logx"
 	"github.com/typesanitizer/happygo/common/syscaps"
 	"github.com/typesanitizer/happygo/misc/internal/config"
@@ -33,8 +34,8 @@ func TestList(t *testing.T) {
 		FS:     repoFS,
 		Runner: syscaps.CmdRunner{Env: envx.Empty()},
 		Config: config.WorkspaceConfig{
-			ForkedFolders: map[string]config.ForkedFolder{
-				"beta": {Folder: "beta", GitHubRepo: "example/beta"},
+			ForkedFolders: map[fsx.Name]config.ForkedFolder{
+				fsx.NewName("beta"): {Folder: "beta", GitHubRepo: "example/beta"},
 			},
 			BranchMappings: config.BranchMappings{ByLocalBranch: nil},
 		},

--- a/misc/cmd/happydo/main.go
+++ b/misc/cmd/happydo/main.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/typesanitizer/happygo/common/fsx/fsx_name"
 	"github.com/urfave/cli/v3"
 
 	"github.com/typesanitizer/happygo/common/cmdx"
@@ -66,9 +67,14 @@ func main() {
 					&cli.BoolFlag{Name: "persist"},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
+					projectArg, err := fsx_name.Parse(cmd.String("project"))
+					if err != nil {
+						return errorx.Wrapf("nostack", err, "in argument for --project")
+					}
+
 					ctx, cancel := withTimeout(ctx, 5*time.Minute, cmd.Name)
 					defer cancel()
-					ws, projects, err := resolveProjects(getWorkspace, cmd.String("project"))
+					ws, projects, err := resolveProjects(getWorkspace, projectArg)
 					if err != nil {
 						return err
 					}
@@ -89,9 +95,14 @@ func main() {
 					&cli.StringFlag{Name: "base"},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
+					projectArg, err := fsx_name.Parse(cmd.String("project"))
+					if err != nil {
+						return errorx.Wrapf("nostack", err, "in argument for --project")
+					}
+
 					ctx, cancel := withTimeout(ctx, 5*time.Minute, cmd.Name)
 					defer cancel()
-					ws, projects, err := resolveProjects(getWorkspace, cmd.String("project"))
+					ws, projects, err := resolveProjects(getWorkspace, projectArg)
 					if err != nil {
 						return err
 					}
@@ -153,18 +164,18 @@ func main() {
 
 // resolveProjects maps "all" to the full forked folder list from workspace config,
 // or validates that a single project name exists in the config.
-func resolveProjects(getWorkspace func() (Workspace, error), project string) (Workspace, []string, error) {
+func resolveProjects(getWorkspace func() (Workspace, error), project fsx.Name) (Workspace, []fsx.Name, error) {
 	ws, err := getWorkspace()
 	if err != nil {
 		return Workspace{}, nil, err
 	}
-	if project == "all" {
-		return ws, collections.SortedMapKeys(ws.Config.ForkedFolders), nil
+	if project.String() == "all" {
+		return ws, collections.SortedMapKeysFunc(ws.Config.ForkedFolders, fsx.Name.Compare), nil
 	}
 	if _, ok := ws.Config.ForkedFolders[project]; !ok {
 		return Workspace{}, nil, errorx.Newf("nostack", "invalid --project %q, not a forked folder", project)
 	}
-	return ws, []string{project}, nil
+	return ws, []fsx.Name{project}, nil
 }
 
 func withTimeout(ctx context.Context, duration time.Duration, cmdName string) (context.Context, context.CancelFunc) {

--- a/misc/cmd/happydo/sync_branch.go
+++ b/misc/cmd/happydo/sync_branch.go
@@ -23,7 +23,7 @@ type remoteRef struct {
 }
 
 func (ws Workspace) runSyncBranch(
-	ctx logx.LogCtx, projects []string, options RunSyncBranchOptions,
+	ctx logx.LogCtx, projects []fsx.Name, options RunSyncBranchOptions,
 ) (err error) {
 	assert.Precondition(len(projects) > 0, "must sync 1+ projects")
 	baseBranch := options.Base.ValueOr("main")
@@ -56,10 +56,10 @@ func (ws Workspace) runSyncBranch(
 
 func runSyncBranchProject(
 	ctx logx.LogCtx, ws Workspace,
-	project string, worktreeDir RelPath, baseBranch string, push bool,
+	project fsx.Name, worktreeDir RelPath, baseBranch string, push bool,
 ) error {
 	worktreeAbs := ws.FS.Root().Join(worktreeDir)
-	syncBranch := syncBranchPrefix + project
+	syncBranch := syncBranchPrefix + project.String()
 	ctx.Info(
 		"syncing",
 		"project", project, "branch", syncBranch,
@@ -75,7 +75,7 @@ func runSyncBranchProject(
 	if _, err := ws.Runner.Run(ctx, checkoutCmd, cmdx.RunOptionsDefault()); err != nil {
 		return err
 	}
-	if err := ws.runUpdate(ctx, worktreeAbs, baseBranch, []string{project}); err != nil {
+	if err := ws.runUpdate(ctx, worktreeAbs, baseBranch, []fsx.Name{project}); err != nil {
 		return err
 	}
 	if !push {

--- a/misc/cmd/happydo/sync_pr.go
+++ b/misc/cmd/happydo/sync_pr.go
@@ -11,6 +11,7 @@ import (
 	"github.com/typesanitizer/happygo/common/cmdx"
 	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
 	"github.com/typesanitizer/happygo/common/logx"
 )
 
@@ -34,14 +35,14 @@ const (
 // Parent 1 is the local pre-sync commit, and parent 2 is the upstream subtree
 // commit that was pulled. We persist these values in mergebot-* trailers.
 type parsedSubtreeMetadata struct {
-	Dir            Option[string]
+	Dir            Option[fsx.Name]
 	LocalCommit    Option[string]
 	UpstreamCommit Option[string]
 }
 
 // subtreeMetadata is a validated parsedSubtreeMetadata with all fields guaranteed non-empty.
 type subtreeMetadata struct {
-	Dir            string
+	Dir            fsx.Name
 	LocalCommit    string
 	UpstreamCommit string
 }
@@ -58,7 +59,7 @@ func (p parsedSubtreeMetadata) validate() (subtreeMetadata, error) {
 	return subtreeMetadata{Dir: dir, LocalCommit: local, UpstreamCommit: upstream}, nil
 }
 
-func (ws Workspace) runSyncPR(ctx logx.LogCtx, projects []string, options RunSyncPROptions) error {
+func (ws Workspace) runSyncPR(ctx logx.LogCtx, projects []fsx.Name, options RunSyncPROptions) error {
 	assert.Precondition(len(projects) > 0, "must sync 1+ projects")
 	base := options.Base.ValueOr("main")
 	for _, project := range projects {
@@ -72,9 +73,9 @@ func (ws Workspace) runSyncPR(ctx logx.LogCtx, projects []string, options RunSyn
 func runSyncPRProject(
 	ctx logx.LogCtx,
 	runner cmdx.BaseRunner,
-	repoRoot AbsPath, project string, base string,
+	repoRoot AbsPath, project fsx.Name, base string,
 ) error {
-	syncBranch := syncBranchPrefix + project
+	syncBranch := syncBranchPrefix + project.String()
 	fetchCmd := cmdx.New("git", "fetch", "origin", syncBranch).In(repoRoot)
 	if _, err := runner.Run(ctx, fetchCmd, cmdx.RunOptionsDefault()); err != nil {
 		return err
@@ -102,7 +103,7 @@ func runSyncPRProject(
 	if err != nil {
 		return err
 	}
-	projectLabel := "project/" + project
+	projectLabel := "project/" + project.String()
 	ensureSyncLabels := func() error {
 		if err := ensureLabelExists(ctx, runner, repoRoot, projectLabel,
 			"1d76db", "Project-specific sync updates"); err != nil {
@@ -189,9 +190,8 @@ func findOpenPR(
 
 func subtreeMetadataForSyncHead(
 	ctx logx.LogCtx, runner cmdx.BaseRunner,
-	repoRoot AbsPath, project string, headSHA string,
+	repoRoot AbsPath, project fsx.Name, headSHA string,
 ) (subtreeMetadata, error) {
-	assert.Precondition(project != "", "project must be non-empty")
 	assert.Precondition(headSHA != "", "headSHA must be non-empty")
 
 	var emptyMetadata subtreeMetadata
@@ -279,7 +279,7 @@ func formatMergeBody(metadata subtreeMetadata) string {
 	lines := []string{
 		fmt.Sprintf("Pull in changes from upstream commit %s", metadata.UpstreamCommit),
 		"",
-		mergebotSubtreeDirTrailer + ": " + metadata.Dir,
+		mergebotSubtreeDirTrailer + ": " + metadata.Dir.String(),
 		mergebotLocalCommitTrailer + ": " + metadata.LocalCommit,
 		mergebotUpstreamCommitTrailer + ": " + metadata.UpstreamCommit,
 	}

--- a/misc/cmd/happydo/sync_pr_test.go
+++ b/misc/cmd/happydo/sync_pr_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/typesanitizer/happygo/common/check"
+	"github.com/typesanitizer/happygo/common/fsx"
 )
 
 func TestSyncMergeBodyAllTrailers(t *testing.T) {
@@ -12,7 +13,7 @@ func TestSyncMergeBodyAllTrailers(t *testing.T) {
 	h.Parallel()
 
 	metadata := subtreeMetadata{
-		Dir:            "go",
+		Dir:            fsx.NewName("go"),
 		LocalCommit:    "abc123",
 		UpstreamCommit: "def456",
 	}

--- a/misc/cmd/happydo/update.go
+++ b/misc/cmd/happydo/update.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/typesanitizer/happygo/common/cmdx"
 	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/fsx"
 	"github.com/typesanitizer/happygo/common/logx"
 )
 
-func (ws Workspace) runUpdate(ctx logx.LogCtx, dir AbsPath, localBranch string, projects []string) error {
+func (ws Workspace) runUpdate(ctx logx.LogCtx, dir AbsPath, localBranch string, projects []fsx.Name) error {
 	for _, project := range projects {
 		upstream, err := ws.Config.UpstreamForProject(localBranch, project)
 		if err != nil {
@@ -17,7 +18,7 @@ func (ws Workspace) runUpdate(ctx logx.LogCtx, dir AbsPath, localBranch string, 
 		upstreamURL := fmt.Sprintf("https://github.com/%s.git", upstream.GitHubRepo)
 		ctx.Info("running subtree pull", "project", project, "upstream", upstreamURL, "upstream_branch", upstream.Branch)
 		subtreePullCmd := cmdx.New(
-			"git", "subtree", "pull", "--prefix", project, upstreamURL, upstream.Branch,
+			"git", "subtree", "pull", "--prefix", project.String(), upstreamURL, upstream.Branch,
 		).In(dir)
 		stdout, err := ws.Runner.Run(ctx, subtreePullCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 		if err != nil {

--- a/misc/internal/config/validate.go
+++ b/misc/internal/config/validate.go
@@ -3,6 +3,8 @@ package config
 import (
 	"github.com/typesanitizer/happygo/common/collections"
 	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/fsx/fsx_name"
 )
 
 // Validate checks structural invariants for JSON workspace configuration and builds validated config.
@@ -18,8 +20,8 @@ func (wcJSON WorkspaceConfigJSON) Validate() (WorkspaceConfig, error) {
 	return WorkspaceConfig{ForkedFolders: forkedFolders, BranchMappings: branchMappings}, nil
 }
 
-func validateForkedFolders(forkedFoldersJSON []ForkedFolderJSON) (map[string]ForkedFolder, collections.Set[GitHubRepo], error) {
-	forkedFolders := map[string]ForkedFolder{}
+func validateForkedFolders(forkedFoldersJSON []ForkedFolderJSON) (map[fsx.Name]ForkedFolder, collections.Set[GitHubRepo], error) {
+	forkedFolders := map[fsx.Name]ForkedFolder{}
 	forkedRepos := collections.NewSet[GitHubRepo]()
 	var err error
 
@@ -28,11 +30,11 @@ func validateForkedFolders(forkedFoldersJSON []ForkedFolderJSON) (map[string]For
 	}
 
 	for _, forkedFolderJSON := range forkedFoldersJSON {
-		if forkedFolderJSON.Folder == "" {
-			err = errorx.Join(err, errorx.New("nostack", "forked_folders has empty folder"))
-			continue
+		folder, parseErr := fsx_name.Parse(forkedFolderJSON.Folder)
+		if parseErr != nil {
+			err = errorx.Join(err, errorx.Newf("nostack", "invalid folder value in forked_folders: %v", parseErr))
 		}
-		if _, ok := forkedFolders[forkedFolderJSON.Folder]; ok {
+		if _, ok := forkedFolders[folder]; ok {
 			err = errorx.Join(err, errorx.Newf("nostack", "forked_folders has duplicate folder %q", forkedFolderJSON.Folder))
 			continue
 		}
@@ -47,7 +49,7 @@ func validateForkedFolders(forkedFoldersJSON []ForkedFolderJSON) (map[string]For
 			continue
 		}
 
-		forkedFolders[forkedFolderJSON.Folder] = ForkedFolder{
+		forkedFolders[folder] = ForkedFolder{
 			Folder:     forkedFolderJSON.Folder,
 			GitHubRepo: githubRepo,
 		}

--- a/misc/internal/config/validate_test.go
+++ b/misc/internal/config/validate_test.go
@@ -45,7 +45,7 @@ func TestValidateErrors(t *testing.T) {
 			modify: func(c *WorkspaceConfigJSON) {
 				c.ForkedFolders[0].Folder = ""
 			},
-			wantErr: "empty folder",
+			wantErr: "invalid folder value in forked_folders",
 		},
 		{
 			name: "duplicate folder",

--- a/misc/internal/config/workspace_config.go
+++ b/misc/internal/config/workspace_config.go
@@ -5,12 +5,13 @@ import (
 	"io"
 
 	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
 )
 
 // WorkspaceConfig is the validated in-memory repository configuration.
 type WorkspaceConfig struct {
 	// ForkedFolders maps folder name to forked folder metadata. Always non-empty.
-	ForkedFolders map[string]ForkedFolder
+	ForkedFolders map[fsx.Name]ForkedFolder
 	// BranchMappings is the validated in-memory branch mapping representation.
 	BranchMappings BranchMappings
 }
@@ -29,7 +30,7 @@ func Load(r io.Reader) (WorkspaceConfig, error) {
 }
 
 // UpstreamForProject resolves the upstream repo and branch config for one project on a local branch.
-func (wc WorkspaceConfig) UpstreamForProject(localBranch string, project string) (UpstreamRepo, error) {
+func (wc WorkspaceConfig) UpstreamForProject(localBranch string, project fsx.Name) (UpstreamRepo, error) {
 	mapping, ok := wc.BranchMappings.ByLocalBranch[localBranch]
 	if !ok {
 		return UpstreamRepo{}, errorx.Newf("nostack", "no branch mapping configured for branch %q", localBranch)

--- a/misc/mappings_test.go
+++ b/misc/mappings_test.go
@@ -4,10 +4,12 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
 
+	"github.com/typesanitizer/happygo/common/fsx"
 	"gopkg.in/yaml.v3"
 
 	"github.com/typesanitizer/happygo/common/check"
@@ -27,7 +29,8 @@ func TestWorkspaceConfig(t *testing.T) {
 
 	wsConfig := Do(config.Load(f))(h)
 
-	configFolders := collections.SortedMapKeys(wsConfig.ForkedFolders)
+	configFolders := slices.Collect(iterx.Map(maps.Keys(wsConfig.ForkedFolders), fsx.Name.String))
+	slices.Sort(configFolders)
 
 	repoRoot := DoMsg(pathx.ResolveAbsPath(".."))(h, "resolving repo root").String()
 
@@ -41,7 +44,7 @@ func TestWorkspaceConfig(t *testing.T) {
 		h.Parallel()
 
 		for folder, repo := range forkedProjects {
-			forked, ok := wsConfig.ForkedFolders[folder]
+			forked, ok := wsConfig.ForkedFolders[fsx.NewName(folder)]
 			h.Assertf(ok, "forked folder %q must be present in repo-configuration.json", folder)
 			h.Assertf(forked.GitHubRepo == repo,
 				"forked folder %q has repo %q, want %q", folder, forked.GitHubRepo, repo)


### PR DESCRIPTION
This reduces the number of strings needed,
and makes it clearer which code interacts
with file names vs full paths.