### PR TITLE
chore(ci): Run common/ and misc/ tests on macOS and Windows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -98,10 +98,6 @@ jobs:
 
   test-first-party:
     name: go test (first-party)
-    # Only test on Ubuntu since currently these are mostly meant
-    # to be run in CI, and macOS runners are more limited; don't
-    # want actual macOS testing runners to be occupied by these tests.
-    if: inputs.os == 'ubuntu-latest'
     runs-on: ${{ inputs.os }}
     needs: build-head
     steps:
@@ -121,9 +117,8 @@ jobs:
 
   lint-first-party:
     name: golangci-lint (first-party)
-    # Only test on Ubuntu since currently these are mostly meant
-    # to be run in CI, and macOS runners are more limited; don't
-    # want actual macOS testing runners to be occupied by these tests.
+    # Only lint on Ubuntu; macOS runners are more limited and we
+    # don't want them occupied by lint-only jobs.
     if: inputs.os == 'ubuntu-latest'
     runs-on: ${{ inputs.os }}
     needs: build-head

--- a/common/core/pathx/pathx_test.go
+++ b/common/core/pathx/pathx_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -248,7 +249,11 @@ func TestPathFormatting(t *testing.T) {
 	h := check.New(t)
 
 	sep := string(filepath.Separator)
-	absStr := sep + filepath.Join("tmp", "x")
+	absPrefix := sep
+	if runtime.GOOS == "windows" {
+		absPrefix = `C:` + sep
+	}
+	absStr := absPrefix + filepath.Join("tmp", "x")
 	relStr := filepath.Join("a", "b")
 	rootRelStr := relStr // RootRelPath.String() returns just the relative portion.
 
@@ -262,9 +267,9 @@ func TestPathFormatting(t *testing.T) {
 		want      string
 		wantQuote string
 	}{
-		{name: "AbsPath", value: abs, want: absStr, wantQuote: `"` + absStr + `"`},
-		{name: "RelPath", value: rel, want: relStr, wantQuote: `"` + relStr + `"`},
-		{name: "RootRelPath", value: rootRel, want: rootRelStr, wantQuote: `"` + rootRelStr + `"`},
+		{name: "AbsPath", value: abs, want: absStr, wantQuote: strconv.Quote(absStr)},
+		{name: "RelPath", value: rel, want: relStr, wantQuote: strconv.Quote(relStr)},
+		{name: "RootRelPath", value: rootRel, want: rootRelStr, wantQuote: strconv.Quote(rootRelStr)},
 	}
 
 	baseErr := errorx.Newf("nostack", "base")

--- a/common/envx/envx_path/find_executable.go
+++ b/common/envx/envx_path/find_executable.go
@@ -181,9 +181,10 @@ func candidatePaths(env envx.Env, base AbsPath) iter.Seq[AbsPath] {
 		pathExt, ok := env.Lookup("PATHEXT").Get()
 		if !ok || pathExt == "" {
 			// Match exec.LookPath's Windows fallback when PATHEXT is unset or empty.
-			pathExt = ".COM;.EXE;.BAT;.CMD"
+			pathExt = ".com;.exe;.bat;.cmd"
 		}
-		for ext := range strings.SplitSeq(pathExt, ";") {
+		// Lowercase to match exec.LookPath behavior (see pathExt() in os/exec).
+		for ext := range strings.SplitSeq(strings.ToLower(pathExt), ";") {
 			if ext == "" {
 				continue
 			}

--- a/common/envx/envx_path/find_executable_test.go
+++ b/common/envx/envx_path/find_executable_test.go
@@ -46,7 +46,7 @@ func testFindExecutableHappyPath(h check.Harness) {
 
 			envVars := map[string]string{"PATH": fs.Root().Join(binRel).String()}
 			if runtime.GOOS == "windows" {
-				envVars["PATHEXT"] = ".COM;.EXE;.BAT;.CMD"
+				envVars["PATHEXT"] = ".com;.exe;.bat;.cmd"
 			}
 			env := testEnv(envVars)
 
@@ -64,7 +64,7 @@ func testFindExecutableHappyPath(h check.Harness) {
 				}, string(os.PathListSeparator)),
 			}
 			if runtime.GOOS == "windows" {
-				envVars["PATHEXT"] = ".COM;.EXE;.BAT;.CMD"
+				envVars["PATHEXT"] = ".com;.exe;.bat;.cmd"
 			}
 			env := testEnv(envVars)
 
@@ -85,7 +85,7 @@ func testFindExecutableHappyPath(h check.Harness) {
 		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
 
 		h.Run("Empty PATHEXT falls back like exec.LookPath", func(h check.Harness) {
-			exeRel := binRel.JoinComponents("tool.EXE")
+			exeRel := binRel.JoinComponents("tool.exe")
 			writeExecutable(h, fs, exeRel)
 			exePath := root.Join(exeRel)
 
@@ -195,7 +195,7 @@ func testFindExecutableErrorCases(h check.Harness) {
 			h.T().Chdir(root.String())
 			h.T().Setenv("PATH", "bin")
 			if runtime.GOOS == "windows" {
-				h.T().Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+				h.T().Setenv("PATHEXT", ".com;.exe;.bat;.cmd")
 			}
 
 			wantPath, wantErr := exec.LookPath(exe.LookupName)
@@ -205,7 +205,7 @@ func testFindExecutableErrorCases(h check.Harness) {
 
 			envVars := map[string]string{"PATH": "bin"}
 			if runtime.GOOS == "windows" {
-				envVars["PATHEXT"] = ".COM;.EXE;.BAT;.CMD"
+				envVars["PATHEXT"] = ".com;.exe;.bat;.cmd"
 			}
 			env := testEnv(envVars)
 
@@ -308,7 +308,7 @@ type hostExecutable struct {
 
 func hostOSExecutable() hostExecutable {
 	if runtime.GOOS == "windows" {
-		return hostExecutable{Name: "tool.EXE", LookupName: "tool"}
+		return hostExecutable{Name: "tool.exe", LookupName: "tool"}
 	}
 	return hostExecutable{Name: "tool", LookupName: "tool"}
 }


### PR DESCRIPTION
This also fixes some issues related to Windows
where the tests didn't quite pass due to incorrect
casing of file extensions.

Fixes #115.
