### PR TITLE
feat(fsx): Add StatOptions to customize Stat behavior

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -104,6 +104,8 @@ linters:
           msg: use Harness.Run instead of t.Run
         - pattern: ^testing\.T\.Parallel$
           msg: use Harness.Parallel instead of t.Parallel
+        - pattern: ^os\.IsNotExist$
+          msg: use errorx.GetRootCauseAsValue instead of os.IsNotExist
         - pattern: ^os\.MkdirAll$
           msg: use AbsPath.MkdirAll instead of os.MkdirAll
         - pattern: ^os\.MkdirTemp$

--- a/common/core/pathx/lexical.go
+++ b/common/core/pathx/lexical.go
@@ -20,12 +20,12 @@ func LexicallyNormalize(path string) string {
 	volumeLen := len(filepath.VolumeName(path))
 	path = path[volumeLen:]
 	if path == "" {
-		if volumeLen > 1 && isPathSeparator(originalPath[0]) && isPathSeparator(originalPath[1]) {
+		if volumeLen > 1 && IsPathSeparator(originalPath[0]) && IsPathSeparator(originalPath[1]) {
 			return filepath.FromSlash(originalPath)
 		}
 		return originalPath + "."
 	}
-	rooted := isPathSeparator(path[0])
+	rooted := IsPathSeparator(path[0])
 
 	// Invariants:
 	//   - We read from path using readPos.
@@ -49,13 +49,13 @@ func LexicallyNormalize(path string) string {
 
 	for readPos < inputLen {
 		switch {
-		case isPathSeparator(path[readPos]):
+		case IsPathSeparator(path[readPos]):
 			// Empty path element.
 			readPos++
-		case path[readPos] == '.' && (readPos+1 == inputLen || isPathSeparator(path[readPos+1])):
+		case path[readPos] == '.' && (readPos+1 == inputLen || IsPathSeparator(path[readPos+1])):
 			// . path element.
 			readPos++
-		case path[readPos] == '.' && path[readPos+1] == '.' && (readPos+2 == inputLen || isPathSeparator(path[readPos+2])):
+		case path[readPos] == '.' && path[readPos+1] == '.' && (readPos+2 == inputLen || IsPathSeparator(path[readPos+2])):
 			// .. path element: remove the previous real element when possible.
 			readPos += 2
 			switch {
@@ -74,7 +74,7 @@ func LexicallyNormalize(path string) string {
 			if (rooted && output.writePos != 1) || (!rooted && output.writePos != 0) {
 				output.appendByte(filepath.Separator)
 			}
-			for ; readPos < inputLen && !isPathSeparator(path[readPos]); readPos++ {
+			for ; readPos < inputLen && !IsPathSeparator(path[readPos]); readPos++ {
 				output.appendByte(path[readPos])
 			}
 		}
@@ -129,7 +129,7 @@ func (b *lexicalBuffer) prependBytes(prefix ...byte) {
 
 func (b *lexicalBuffer) removeLastPathElement(stopPos int) {
 	b.writePos--
-	for b.writePos > stopPos && !isPathSeparator(b.byteAt(b.writePos)) {
+	for b.writePos > stopPos && !IsPathSeparator(b.byteAt(b.writePos)) {
 		b.writePos--
 	}
 }
@@ -154,7 +154,7 @@ func shouldPreserveTrailingSeparator(output *lexicalBuffer, rooted bool) bool {
 	if output.writePos == 2 && output.byteAt(0) == '.' && output.byteAt(1) == '.' {
 		return false
 	}
-	return !isPathSeparator(output.byteAt(output.writePos - 1))
+	return !IsPathSeparator(output.byteAt(output.writePos - 1))
 }
 
 func postLexicallyNormalize(output *lexicalBuffer) {
@@ -162,7 +162,7 @@ func postLexicallyNormalize(output *lexicalBuffer) {
 		return
 	}
 	for _, c := range output.buffer[:output.writePos] {
-		if isPathSeparator(c) {
+		if IsPathSeparator(c) {
 			break
 		}
 		if c == ':' {
@@ -170,7 +170,7 @@ func postLexicallyNormalize(output *lexicalBuffer) {
 			return
 		}
 	}
-	if output.writePos >= 3 && isPathSeparator(output.buffer[0]) && output.buffer[1] == '?' && output.buffer[2] == '?' {
+	if output.writePos >= 3 && IsPathSeparator(output.buffer[0]) && output.buffer[1] == '?' && output.buffer[2] == '?' {
 		output.prependBytes(filepath.Separator, '.')
 	}
 }
@@ -179,10 +179,10 @@ func hasTrailingPathSeparator(path string) bool {
 	if path == "" {
 		return false
 	}
-	return isPathSeparator(path[len(path)-1])
+	return IsPathSeparator(path[len(path)-1])
 }
 
-func isPathSeparator(c byte) bool {
+func IsPathSeparator(c byte) bool {
 	if runtime.GOOS == "windows" {
 		return c == '\\' || c == '/'
 	}

--- a/common/core/pathx/pathx.go
+++ b/common/core/pathx/pathx.go
@@ -253,7 +253,7 @@ func (p RelPath) lexicallyContainsUnix() bool {
 // HasPathSeparators reports whether s contains any path separators.
 func HasPathSeparators(s string) bool {
 	for i := range len(s) {
-		if isPathSeparator(s[i]) {
+		if IsPathSeparator(s[i]) {
 			return true
 		}
 	}

--- a/common/envx/envx_path/find_executable.go
+++ b/common/envx/envx_path/find_executable.go
@@ -81,10 +81,10 @@ func FindExecutable(fs fsx.FS, env envx.Env, name string) (AbsPath, error) {
 			//    then dir.JoinComponents(name) is inside fs.Root() as well.
 			// 4. candidatePaths only potentially appends a file extension.
 			assert.Invariantf(ok, "candidate path %q escaped filesystem root %q", candidatePath, fs.Root())
-			info, err := fs.Stat(rootRel.Rel())
-			if err != nil {
-				if !os.IsNotExist(err) {
-					ignoredPaths = append(ignoredPaths, IgnoredPath{Path: candidatePath, Err: err})
+			info, statErr := fs.Stat(rootRel.Rel(), fsx.StatOptions{FollowFinalSymlink: true, OnErrorTraverseParents: false})
+			if statErr != nil {
+				if !errorx.GetRootCauseAsValue(statErr, fsx.ErrNotExist) {
+					ignoredPaths = append(ignoredPaths, IgnoredPath{Path: candidatePath, Err: statErr})
 				}
 				continue
 			}

--- a/common/fsx/fsx.go
+++ b/common/fsx/fsx.go
@@ -23,6 +23,9 @@ import (
 	"github.com/typesanitizer/happygo/common/iterx"
 )
 
+// ErrNotExist is [fs.ErrNotExist], re-exported so callers need not import io/fs.
+var ErrNotExist = iofs.ErrNotExist
+
 // File is an open file handle returned by [FS.Open] and similar methods.
 // It is an alias for [afero.File] so callers need not import afero directly.
 type File = afero.File
@@ -53,13 +56,18 @@ func (e dirEntry) Info() (os.FileInfo, error) {
 	return e.entry.Info()
 }
 
+type BaseFS interface {
+	afero.Fs
+	afero.Lstater
+}
+
 // FS is a rooted filesystem wrapper. All methods operate on paths relative
 // to Root().
 type FS struct {
 	// Stored separately because afero.BasePathFs does not expose its configured
 	// root path back to callers, but fsx needs to provide Root().
 	root AbsPath
-	base afero.Fs
+	base BaseFS
 }
 
 // MemMap returns an in-memory FS rooted at root.
@@ -68,13 +76,15 @@ func MemMap(root AbsPath) (FS, error) {
 	if err := backing.MkdirAll(root.String(), 0o755); err != nil {
 		return FS{}, errorx.Wrapf("+stacks", err, "create fs root %s", root)
 	}
-	return NewRootedFS(root, backing)
+	base, ok := backing.(BaseFS)
+	assert.Invariantf(ok, "NewMemMapFs return value should implement BaseFS, but got type %T", backing)
+	return NewRootedFS(root, base)
 }
 
 // NewRootedFS returns an FS rooted at root and backed by backing.
 //
 // Pre-condition: root must already exist in backing and be a directory.
-func NewRootedFS(root AbsPath, backing afero.Fs) (FS, error) {
+func NewRootedFS(root AbsPath, backing BaseFS) (FS, error) {
 	info, err := backing.Stat(root.String())
 	if err != nil {
 		return FS{}, errorx.Wrapf("+stacks", err, "stat fs root %s", root)
@@ -82,17 +92,15 @@ func NewRootedFS(root AbsPath, backing afero.Fs) (FS, error) {
 	if !info.IsDir() {
 		return FS{}, errorx.Newf("nostack", "fs root %s is not a directory", root)
 	}
-	return FS{root: root, base: afero.NewBasePathFs(backing, root.String())}, nil
+
+	rootedBase, ok := afero.NewBasePathFs(backing, root.String()).(BaseFS)
+	assert.Invariantf(ok, "NewBasePathFs return value should implement BaseFS, but got type %T", backing)
+	return FS{root: root, base: rootedBase}, nil
 }
 
 // Root returns the absolute path this FS is rooted at.
 func (fs FS) Root() AbsPath {
 	return fs.root
-}
-
-// Stat returns file info for the given root-relative path.
-func (fs FS) Stat(rel RelPath) (os.FileInfo, error) {
-	return fs.base.Stat(rel.String())
 }
 
 // ReadDir iterates over directory entries at the given root-relative path.

--- a/common/fsx/stat.go
+++ b/common/fsx/stat.go
@@ -1,0 +1,98 @@
+package fsx
+
+import (
+	"os"
+
+	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/pathx"
+)
+
+// Stat returns file info for the given root-relative path.
+//
+// If rel corresponds to a symlink:
+//   - If opts.FollowFinalSymlink is true, the symlink is dereferenced,
+//     and the os.FileInfo for the path it points to is returned.
+//   - If opts.FollowFinalSymlink is false, the os.FileInfo for the
+//     symlink itself is returned.
+//
+// On error, the returned error is always a *StatError. If
+// opts.OnErrorTraverseParents is true, StatError.ShortestMissing() returns the
+// shallowest ancestor that does not exist. Otherwise, ShortestMissing()
+// returns rel.
+func (fs FS) Stat(rel RelPath, opts StatOptions) (os.FileInfo, error) {
+	var info os.FileInfo
+	var err error
+	if opts.FollowFinalSymlink {
+		info, err = fs.base.Stat(rel.String())
+	} else {
+		info, _, err = fs.base.LstatIfPossible(rel.String())
+	}
+	if err == nil {
+		return info, nil
+	}
+	if !opts.OnErrorTraverseParents {
+		return nil, &StatError{fsError: err, shortestMissing: rel}
+	}
+	// Binary search over path components to find the shallowest missing
+	// ancestor with O(log n) stat calls. Since RelPath is normalized, we can
+	// slice the raw string at separator boundaries without re-joining.
+	raw := rel.String()
+	// Collect separator indices; each marks the end of a prefix that is a
+	// valid ancestor path.
+	var seps []int
+	for i := 0; i < len(raw); i++ {
+		if pathx.IsPathSeparator(raw[i]) {
+			seps = append(seps, i)
+		}
+	}
+	// seps[i] gives prefix raw[:seps[i]] which is an ancestor.
+	// We want the smallest index where stat fails.
+	// Invariant: raw[:lo] exists (lo=0 means root itself), raw[:hi] does not.
+	lo, hi := 0, len(seps)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if _, statErr := fs.base.Stat(raw[:seps[mid]]); statErr != nil {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	if lo < len(seps) {
+		return nil, &StatError{fsError: err, shortestMissing: NewRelPath(raw[:seps[lo]])}
+	}
+	// All ancestors exist; the leaf itself is the shallowest missing.
+	return nil, &StatError{fsError: err, shortestMissing: rel}
+}
+
+type StatOptions struct {
+	// FollowFinalSymlink controls behavior when the final path component is a
+	// symlink. If true, the symlink is dereferenced (stat). If false, info about
+	// the symlink itself is returned (lstat). Intervening symlinks in parent
+	// directories are always resolved by the OS regardless of this setting.
+	FollowFinalSymlink bool
+	// OnErrorTraverseParents walks up the path to find the shallowest missing
+	// ancestor when the initial stat fails. StatError.ShortestMissing() will
+	// return the shallowest component that does not exist.
+	OnErrorTraverseParents bool
+}
+
+// StatError holds information about a failed stat, including the shallowest
+// missing ancestor when OnErrorTraverseParents was set.
+type StatError struct {
+	fsError         error
+	shortestMissing RelPath
+}
+
+func (e *StatError) Error() string {
+	return e.fsError.Error()
+}
+
+func (e *StatError) Unwrap() error {
+	return e.fsError
+}
+
+// ShortestMissing returns the shallowest missing path component. If
+// OnErrorTraverseParents was not set, this equals the original path.
+func (e *StatError) ShortestMissing() RelPath {
+	return e.shortestMissing
+}

--- a/common/fsx/stat_test.go
+++ b/common/fsx/stat_test.go
@@ -1,0 +1,108 @@
+package fsx_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/typesanitizer/happygo/common/check"
+	. "github.com/typesanitizer/happygo/common/check/prelude"
+	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/pathx/pathx_testkit"
+	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/syscaps"
+)
+
+func TestFSStat(t *testing.T) {
+	h := check.New(t)
+
+	h.Run("Unit", func(h check.Harness) {
+		h.Parallel()
+
+		parent := h.T().TempDir()
+		target := filepath.Join(parent, "target")
+		h.NoErrorf(os.Mkdir(target, 0o755), "Mkdir(%q)", target)
+
+		link := filepath.Join(parent, "link")
+		if err := os.Symlink(target, link); err != nil {
+			h.T().Skipf("skipping: symlinks unavailable: %v", err)
+		}
+
+		repoFS := Do(syscaps.FS(NewAbsPath(link)))(h)
+
+		followed := Do(repoFS.Stat(NewRelPath("."), fsx.StatOptions{
+			FollowFinalSymlink:     true,
+			OnErrorTraverseParents: false,
+		}))(h)
+		h.Assertf(followed.IsDir(), "Stat(., FollowFinalSymlink=true).IsDir() = false, want true")
+		h.Assertf(followed.Mode()&os.ModeSymlink == 0,
+			"Stat(., FollowFinalSymlink=true).Mode() = %v, want non-symlink", followed.Mode())
+
+		notFollowed := Do(repoFS.Stat(NewRelPath("."), fsx.StatOptions{
+			FollowFinalSymlink:     false,
+			OnErrorTraverseParents: false,
+		}))(h)
+		h.Assertf(!notFollowed.IsDir(), "Stat(., FollowFinalSymlink=false).IsDir() = true, want false")
+		h.Assertf(notFollowed.Mode()&os.ModeSymlink != 0,
+			"Stat(., FollowFinalSymlink=false).Mode() = %v, want symlink", notFollowed.Mode())
+	})
+
+	h.Run("ShortestMissingProperties", func(h check.Harness) {
+		h.Parallel()
+
+		root := NewAbsPath(h.T().TempDir())
+		componentsGen := rapid.SliceOfN(pathx_testkit.ComponentGen(), 1, 6)
+		rapid.Check(h.T(), func(t *rapid.T) {
+			h := check.NewBasic(t)
+			components := componentsGen.Draw(t, "components")
+			existingPrefixLen := rapid.IntRange(0, len(components)-1).Draw(t, "existingPrefixLen")
+			followFinalSymlink := rapid.Bool().Draw(t, "followFinalSymlink")
+
+			repoFS := Do(fsx.MemMap(root))(h)
+			if existingPrefixLen > 0 {
+				existingPrefix := joinedRelPath(components[:existingPrefixLen])
+				h.NoErrorf(repoFS.MkdirAll(existingPrefix, 0o755), "MkdirAll(%q)", existingPrefix)
+			}
+
+			rel := joinedRelPath(components)
+			opts := fsx.StatOptions{
+				FollowFinalSymlink:     followFinalSymlink,
+				OnErrorTraverseParents: false,
+			}
+			_, err := repoFS.Stat(rel, opts)
+			statErr := requireStatError(h, err, rel, opts)
+			check.AssertSame(h, rel, statErr.ShortestMissing(),
+				"ShortestMissing() with OnErrorTraverseParents=false")
+
+			opts.OnErrorTraverseParents = true
+			_, err = repoFS.Stat(rel, opts)
+			statErr = requireStatError(h, err, rel, opts)
+			wantShortestMissing := joinedRelPath(components[:existingPrefixLen+1])
+			check.AssertSame(h, wantShortestMissing, statErr.ShortestMissing(),
+				"ShortestMissing() with OnErrorTraverseParents=true")
+		})
+	})
+}
+
+func joinedRelPath(components []string) RelPath {
+	if len(components) == 0 {
+		return NewRelPath(".")
+	}
+	return NewRelPath(filepath.Join(components...))
+}
+
+func requireStatError(h check.BasicHarness, err error, rel RelPath, opts fsx.StatOptions) *fsx.StatError {
+	call := fmt.Sprintf("Stat(%q, fsx.StatOptions{FollowFinalSymlink: %t, OnErrorTraverseParents: %t})",
+		rel, opts.FollowFinalSymlink, opts.OnErrorTraverseParents)
+	h.Assertf(err != nil, "%s unexpectedly succeeded", call)
+
+	statErr, ok := errorx.FindInChainAs[*fsx.StatError](err).Get()
+	h.Assertf(ok, "%s error type = %T, want chain containing *fsx.StatError", call, err)
+	h.Assertf(errorx.GetRootCauseAsValue(err, fsx.ErrNotExist),
+		"%s error %v does not satisfy root cause == fsx.ErrNotExist", call, err)
+	return statErr
+}

--- a/common/syscaps/syscaps.go
+++ b/common/syscaps/syscaps.go
@@ -35,7 +35,9 @@ func Env() envx.Env {
 
 // FS returns a rooted filesystem backed by the host operating system.
 func FS(root AbsPath) (fsx.FS, error) {
-	return fsx.NewRootedFS(root, afero.NewOsFs())
+	base, ok := afero.NewOsFs().(fsx.BaseFS)
+	assert.Invariantf(ok, "NewOsFs return value should implement fsx.BaseFS, but got type %T", base)
+	return fsx.NewRootedFS(root, base)
 }
 
 // CmdRunner executes commands using ambient system capabilities.

--- a/misc/cmd/happydo/list.go
+++ b/misc/cmd/happydo/list.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
 	"slices"
 
 	. "github.com/typesanitizer/happygo/common/core"
@@ -86,9 +85,9 @@ func (w Workspace) goModules(logger *logx.Logger, provenance ListProvenance) ([]
 		}
 		name := entry.BaseName()
 		goModRel := rootRel.JoinComponents(name.String(), "go.mod")
-		if _, err := w.FS.Stat(goModRel); err != nil {
-			if !os.IsNotExist(err) {
-				logger.Warn("stat go.mod", "dir", name, "err", err)
+		if _, statErr := w.FS.Stat(goModRel, fsx.StatOptions{FollowFinalSymlink: true, OnErrorTraverseParents: false}); statErr != nil {
+			if !errorx.GetRootCauseAsValue(statErr, fsx.ErrNotExist) {
+				logger.Warn("stat go.mod", "dir", name, "err", statErr)
 			}
 			continue
 		}


### PR DESCRIPTION
1. Adds an option to control if the function should behave
   more like stat(2) or lstat(2). It's good to make this
   an explicit choice for clarity at call-sites instead
   of having separate APIs.
2. Adds an option to walk backwards and find the shortest
   path which didn't exist, in case of the path not existing.

This is preparatory work for filesystem walking as well as
changes to the happydo CLI, where we:

1. Don't want to follow symlinks automatically.
2. If the user provided a path, then we want to provide
   more informative error messages compared to just
   "this deep path didn't exist".
