### PR TITLE
chore: Ban reflect.DeepEqual in linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,3 +118,5 @@ linters:
           msg: use check.NewBasic(t) instead of calling rapid.T methods directly
         - pattern: ^core\.Unimplementedf$
           msg: Unimplementedf is for local development only; do not merge code with unimplemented paths
+        - pattern: ^reflect\.DeepEqual$
+          msg: use check.AssertSame instead of reflect.DeepEqual in tests

--- a/common/core/pathx/pathx_test.go
+++ b/common/core/pathx/pathx_test.go
@@ -3,7 +3,6 @@ package pathx_test
 import (
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -18,6 +17,7 @@ import (
 	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/core/pathx/pathx_testkit"
 	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/iterx"
 )
 
 func TestMakeRelativeTo(t *testing.T) {
@@ -131,11 +131,8 @@ func TestRelPathComponents(t *testing.T) {
 
 	for _, tt := range tests {
 		h.Run(tt.path, func(h check.Harness) {
-			got := make([]string, 0)
-			for c := range pathx.NewRelPath(tt.path).Components() {
-				got = append(got, c)
-			}
-			h.Assertf(reflect.DeepEqual(got, tt.want), "Components(%q) = %#v, want %#v", tt.path, got, tt.want)
+			got := iterx.Collect(pathx.NewRelPath(tt.path).Components())
+			check.AssertSame(h, tt.want, got, fmt.Sprintf("Components(%q)", tt.path))
 		})
 	}
 }


### PR DESCRIPTION
Generally, this is a code smell. For tests,
we already depend on the go-cmp library,
which is what ought to be used.