### PR TITLE
feat(pathx): Add pathx.Dot() shorthand for NewRelPath(".")

### DIFF
--- a/common/core/pathx/pathx.go
+++ b/common/core/pathx/pathx.go
@@ -151,6 +151,11 @@ type RelPath struct {
 	value string
 }
 
+// Dot returns a relative path '.'.
+func Dot() RelPath {
+	return RelPath{"."}
+}
+
 // NewRelPath creates a RelPath from a relative path string.
 //
 // Pre-condition: path is non-empty and not absolute per [filepath.IsAbs].

--- a/common/core/pathx/pathx_testkit/pathx_testkit.go
+++ b/common/core/pathx/pathx_testkit/pathx_testkit.go
@@ -45,7 +45,7 @@ func SafeRelPathGen() *rapid.Generator[pathx.RelPath] {
 			}
 		}
 		if len(components) == 0 {
-			return pathx.NewRelPath(".")
+			return pathx.Dot()
 		}
 		// Use strings.Join to avoid the Clean operation invoked by filepath.Join.
 		return pathx.NewRelPath(strings.Join(components, string(filepath.Separator)))

--- a/common/fsx/stat_test.go
+++ b/common/fsx/stat_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/typesanitizer/happygo/common/check"
 	. "github.com/typesanitizer/happygo/common/check/prelude"
 	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/core/pathx/pathx_testkit"
 	"github.com/typesanitizer/happygo/common/errorx"
 	"github.com/typesanitizer/happygo/common/fsx"
@@ -34,7 +35,7 @@ func TestFSStat(t *testing.T) {
 
 		repoFS := Do(syscaps.FS(NewAbsPath(link)))(h)
 
-		followed := Do(repoFS.Stat(NewRelPath("."), fsx.StatOptions{
+		followed := Do(repoFS.Stat(pathx.Dot(), fsx.StatOptions{
 			FollowFinalSymlink:     true,
 			OnErrorTraverseParents: false,
 		}))(h)
@@ -42,7 +43,7 @@ func TestFSStat(t *testing.T) {
 		h.Assertf(followed.Mode()&os.ModeSymlink == 0,
 			"Stat(., FollowFinalSymlink=true).Mode() = %v, want non-symlink", followed.Mode())
 
-		notFollowed := Do(repoFS.Stat(NewRelPath("."), fsx.StatOptions{
+		notFollowed := Do(repoFS.Stat(pathx.Dot(), fsx.StatOptions{
 			FollowFinalSymlink:     false,
 			OnErrorTraverseParents: false,
 		}))(h)
@@ -90,7 +91,7 @@ func TestFSStat(t *testing.T) {
 
 func joinedRelPath(components []string) RelPath {
 	if len(components) == 0 {
-		return NewRelPath(".")
+		return pathx.Dot()
 	}
 	return NewRelPath(filepath.Join(components...))
 }

--- a/common/syscaps/syscaps_test.go
+++ b/common/syscaps/syscaps_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/typesanitizer/happygo/common/check/prelude"
 	"github.com/typesanitizer/happygo/common/collections"
 	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/internal/constants"
 	"github.com/typesanitizer/happygo/common/syscaps"
 )
@@ -24,7 +25,7 @@ func TestFSReadDirBatched(t *testing.T) {
 	rapid.Check(h.T(), func(t *rapid.T) {
 		h := check.NewBasic(t)
 		entryCount := rapid.IntRange(0, constants.ReadDirBatchSize*3).Draw(t, "entry_count")
-		parentDir := Do(repoFS.MkdirTemp(NewRelPath("."), "entries-"))(h)
+		parentDir := Do(repoFS.MkdirTemp(pathx.Dot(), "entries-"))(h)
 
 		want := collections.NewSet[string]()
 		for i := range entryCount {
@@ -75,6 +76,6 @@ func TestFSMkdirTempRejectsEmptyPattern(t *testing.T) {
 	repoFS := Do(syscaps.FS(NewAbsPath(t.TempDir())))(h)
 	want := assert.AssertionError{Fmt: "precondition violation: pattern is empty", Args: nil}
 	h.AssertPanicsWith(want, func() {
-		_, _ = repoFS.MkdirTemp(NewRelPath("."), "")
+		_, _ = repoFS.MkdirTemp(pathx.Dot(), "")
 	})
 }

--- a/misc/cmd/happydo/list.go
+++ b/misc/cmd/happydo/list.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/errorx"
 	"github.com/typesanitizer/happygo/common/fsx"
 	"github.com/typesanitizer/happygo/common/logx"
@@ -73,7 +74,7 @@ func (w Workspace) listGoModules(logger *logx.Logger, out io.Writer, provenance 
 }
 
 func (w Workspace) goModules(logger *logx.Logger, provenance ListProvenance) ([]fsx.Name, error) {
-	rootRel := NewRelPath(".")
+	rootRel := pathx.Dot()
 	var folders []fsx.Name
 	for entryRes := range w.FS.ReadDir(rootRel) {
 		entry, err := entryRes.Get()


### PR DESCRIPTION
This has come up a few times, so adding a shorthand.