### PR TITLE
feat(pathx): Add APIs to RelPath for ancestors and prefix trimming

### DIFF
--- a/common/core/pathx/pathx.go
+++ b/common/core/pathx/pathx.go
@@ -183,6 +183,23 @@ func (p RelPath) Join(rel RelPath) RelPath {
 	return NewRelPath(filepath.Join(p.value, rel.value))
 }
 
+// RelativeTo returns p expressed as a relative path from base.
+//
+// Pre-condition: base is an ancestor of p, or equal to p.
+// In particular, base == "." returns p unchanged, and base == p returns ".".
+func (p RelPath) RelativeTo(base RelPath) RelPath {
+	if base.value == "." {
+		return p
+	}
+	suffix, ok := strings.CutPrefix(p.value, base.value)
+	assert.Preconditionf(ok, "base %q is not an ancestor of %q", base.value, p.value)
+	if suffix == "" {
+		return Dot()
+	}
+	assert.Preconditionf(IsPathSeparator(suffix[0]), "base %q is not an ancestor of %q", base.value, p.value)
+	return RelPath{suffix[1:]}
+}
+
 // JoinComponents joins individual path components onto p.
 //
 // Pre-condition: all elements are non-empty and do not contain a path separator.
@@ -194,6 +211,33 @@ func (p RelPath) JoinComponents(pathElems ...string) RelPath {
 		parts = append(parts, elem)
 	}
 	return NewRelPath(filepath.Join(parts...))
+}
+
+// Ancestors returns an iterator over p's ancestor relative paths,
+// in shortest-first order. The receiver itself is not yielded.
+//
+// For example, "a/b/c" yields "a" then "a/b". A path of "."
+// or a single-component path yields nothing.
+func (p RelPath) Ancestors() iter.Seq[RelPath] {
+	return func(yield func(RelPath) bool) {
+		if p.value == "." {
+			return
+		}
+		n := len(p.value)
+		for i := range n {
+			if !IsPathSeparator(p.value[i]) {
+				continue
+			}
+			// A trailing separator means the ancestor would equal the
+			// receiver semantically; stop here.
+			if i == n-1 {
+				return
+			}
+			if !yield(RelPath{p.value[:i]}) {
+				return
+			}
+		}
+	}
 }
 
 func (p RelPath) Components() iter.Seq[string] {

--- a/common/core/pathx/pathx_test.go
+++ b/common/core/pathx/pathx_test.go
@@ -137,6 +137,75 @@ func TestRelPathComponents(t *testing.T) {
 	}
 }
 
+func TestRelPathAncestors(t *testing.T) {
+	h := check.New(t)
+
+	tests := []struct {
+		path string
+		want []string
+	}{
+		{path: ".", want: nil},
+		{path: "a", want: nil},
+		{path: "a/b", want: []string{"a"}},
+		{path: "a/b/c", want: []string{"a", filepath.Join("a", "b")}},
+		{path: "a/b/c/d", want: []string{"a", filepath.Join("a", "b"), filepath.Join("a", "b", "c")}},
+	}
+
+	for _, tt := range tests {
+		h.Run(tt.path, func(h check.Harness) {
+			got := iterx.Collect(iterx.Map(pathx.NewRelPath(tt.path).Ancestors(), pathx.RelPath.String))
+			check.AssertSame(h, tt.want, got, fmt.Sprintf("Ancestors(%q)", tt.path))
+		})
+	}
+}
+
+func TestRelPathRelativeTo(t *testing.T) {
+	h := check.New(t)
+
+	tests := []struct {
+		path string
+		base string
+		want string
+	}{
+		{path: "a", base: ".", want: "a"},
+		{path: "a/b/c", base: ".", want: filepath.Join("a", "b", "c")},
+		{path: "a", base: "a", want: "."},
+		{path: "a/b/c", base: "a/b/c", want: "."},
+		{path: "a/b", base: "a", want: "b"},
+		{path: "a/b/c", base: "a", want: filepath.Join("b", "c")},
+		{path: "a/b/c", base: "a/b", want: "c"},
+	}
+
+	for _, tt := range tests {
+		h.Run(fmt.Sprintf("%s_from_%s", tt.path, tt.base), func(h check.Harness) {
+			got := pathx.NewRelPath(tt.path).RelativeTo(pathx.NewRelPath(tt.base))
+			check.AssertSame(h, tt.want, got.String(),
+				fmt.Sprintf("RelativeTo(%q, %q)", tt.path, tt.base))
+		})
+	}
+
+	h.Run("PanicsOnNonAncestor", func(h check.Harness) {
+		want := assert.AssertionError{
+			Fmt:  "precondition violation: base %q is not an ancestor of %q",
+			Args: []any{"b", "a"},
+		}
+		h.AssertPanicsWith(want, func() {
+			_ = pathx.NewRelPath("a").RelativeTo(pathx.NewRelPath("b"))
+		})
+	})
+
+	h.Run("PanicsOnSiblingPrefix", func(h check.Harness) {
+		// "ab" has "a" as a string prefix but is not a path-descendant of "a".
+		want := assert.AssertionError{
+			Fmt:  "precondition violation: base %q is not an ancestor of %q",
+			Args: []any{"a", "ab"},
+		}
+		h.AssertPanicsWith(want, func() {
+			_ = pathx.NewRelPath("ab").RelativeTo(pathx.NewRelPath("a"))
+		})
+	})
+}
+
 func TestLexicallyContains(t *testing.T) {
 	h := check.New(t)
 	root := pathx.NewAbsPath(t.TempDir())


### PR DESCRIPTION
These are useful for filesystem walking, and it's a bit tricky
to implement the correct behavior when thinking of all the edge
cases. Exposing these as typed APIs offers a place to make the
pre-conditions clear, as well as reduce the risk of arbitrary
string operations on non-normalized paths.
