### PR TITLE
feat(fsx): Add FS-native API for walking

### DIFF
--- a/common/core/op/op.go
+++ b/common/core/op/op.go
@@ -17,3 +17,20 @@ const (
 func (res InsertResult) AsBool() bool {
 	return bool(res)
 }
+
+// PlatformSupport reports whether an operation is supported on the current
+// platform.
+type PlatformSupport bool
+
+const (
+	Supported   PlatformSupport = true
+	Unsupported PlatformSupport = false
+)
+
+func (s PlatformSupport) IsSupported() bool {
+	return bool(s)
+}
+
+func (s PlatformSupport) IsUnsupported() bool {
+	return !bool(s)
+}

--- a/common/fsx/fsx_testkit/fsx_testkit.go
+++ b/common/fsx/fsx_testkit/fsx_testkit.go
@@ -2,10 +2,124 @@
 package fsx_testkit
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 
+	"github.com/spf13/afero" //nolint:depguard // fsx_testkit needs to build test backing filesystems.
+
+	"github.com/typesanitizer/happygo/common/assert"
+	"github.com/typesanitizer/happygo/common/check"
 	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
 )
+
+func NewMemFS(h check.Harness, tree map[string]string) fsx.FS {
+	h.T().Helper()
+	root := FakeRoot()
+	fs, err := fsx.MemMap(root)
+	h.NoErrorf(err, "MemMap(%q)", root)
+	WriteTree(h, fs, tree)
+	return fs
+}
+
+// WriteTree creates files and directories in fs from a map.
+// Keys ending in "/" create directories (value must be "").
+// Other keys create files with the value as content.
+func WriteTree(h check.Harness, fs fsx.FS, tree map[string]string) {
+	h.T().Helper()
+	for path, content := range tree {
+		h.Assertf(path != "", "path must not be empty")
+		rel := NewRelPath(path)
+		if strings.HasSuffix(path, "/") {
+			h.Assertf(content == "", "directory path %q must have empty content", path)
+			h.NoErrorf(fs.MkdirAll(rel, 0o755), "MkdirAll(%q)", rel)
+			continue
+		}
+		if dir, ok := rel.Dir().Get(); ok {
+			h.NoErrorf(fs.MkdirAll(dir, 0o755), "MkdirAll(%q)", dir)
+		}
+		h.NoErrorf(fs.WriteFile(rel, []byte(content), 0o644), "WriteFile(%q)", rel)
+	}
+}
+
+// NewFaultyFS returns an in-memory fsx.FS rooted at root that injects
+// failures for configured operations.
+func NewFaultyFS(h check.Harness, root AbsPath, tree map[string]string, faults ...Fault) fsx.FS {
+	h.T().Helper()
+	backing, ok := afero.NewMemMapFs().(fsx.BaseFS)
+	h.Assertf(ok, "NewMemMapFs() = %T, want fsx.BaseFS", backing)
+	h.NoErrorf(backing.MkdirAll(root.String(), 0o755), "MkdirAll(%q)", root)
+	memMapFS, err := fsx.NewRootedFS(root, backing)
+	h.NoErrorf(err, "NewRootedFS(%q)", root)
+	WriteTree(h, memMapFS, tree)
+	fs, err := fsx.NewRootedFS(root, newFaultyBaseFS(backing, root, faults...))
+	h.NoErrorf(err, "NewRootedFS(%q, FaultyFS)", root)
+	return fs
+}
+
+// FaultOp identifies the filesystem operation to fail.
+type FaultOp uint8
+
+const (
+	FaultOp_Stat FaultOp = iota + 1
+	FaultOp_Open
+)
+
+// Fault describes one injected filesystem failure.
+type Fault struct {
+	Op  FaultOp
+	Rel RelPath
+}
+
+// faultyFS wraps an fsx.BaseFS and injects failures for configured operations.
+type faultyFS struct {
+	fsx.BaseFS
+	root   AbsPath
+	faults map[Fault]struct{}
+}
+
+func newFaultyBaseFS(base fsx.BaseFS, root AbsPath, faults ...Fault) *faultyFS {
+	faultSet := make(map[Fault]struct{}, len(faults))
+	for _, f := range faults {
+		faultSet[f] = struct{}{}
+	}
+	return &faultyFS{BaseFS: base, root: root, faults: faultSet}
+}
+
+func (fs *faultyFS) Stat(absPath string) (os.FileInfo, error) {
+	if fs.hasFault(FaultOp_Stat, absPath) {
+		return nil, injectedFSError()
+	}
+	return fs.BaseFS.Stat(absPath)
+}
+
+func (fs *faultyFS) LstatIfPossible(absPath string) (os.FileInfo, bool, error) {
+	if fs.hasFault(FaultOp_Stat, absPath) {
+		return nil, false, injectedFSError()
+	}
+	return fs.BaseFS.LstatIfPossible(absPath)
+}
+
+func (fs *faultyFS) Open(absPath string) (fsx.File, error) {
+	if fs.hasFault(FaultOp_Open, absPath) {
+		return nil, injectedFSError()
+	}
+	return fs.BaseFS.Open(absPath)
+}
+
+func (fs *faultyFS) hasFault(op FaultOp, absPath string) bool {
+	rel, err := filepath.Rel(fs.root.String(), absPath)
+	assert.Invariantf(err == nil, "filepath.Rel(%q, %q): %v", fs.root, absPath, err)
+	_, hit := fs.faults[Fault{Op: op, Rel: NewRelPath(rel)}]
+	return hit
+}
+
+func injectedFSError() error {
+	return errorx.New("nostack", "injected fs error")
+}
 
 func FakeRoot() AbsPath {
 	if runtime.GOOS == "windows" {

--- a/common/fsx/fsx_testkit/symlink_other.go
+++ b/common/fsx/fsx_testkit/symlink_other.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package fsx_testkit
+
+import (
+	"os"
+
+	"github.com/typesanitizer/happygo/common/core/op"
+)
+
+// TrySymlink creates a symlink named link pointing at target if the platform
+// supports it.
+//
+// If the operation is supported, returns [op.Supported] and the error from
+// the operation.
+//
+// If the operation is not supported, returns [op.Unsupported] and nil.
+func TrySymlink(target, link string) (op.PlatformSupport, error) {
+	return op.Supported, os.Symlink(target, link)
+}

--- a/common/fsx/fsx_testkit/symlink_windows.go
+++ b/common/fsx/fsx_testkit/symlink_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package fsx_testkit
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/typesanitizer/happygo/common/core/op"
+	"github.com/typesanitizer/happygo/common/errorx"
+)
+
+// TrySymlink creates a symlink named link pointing at target if the platform
+// supports it.
+//
+// If the operation is supported, returns [op.Supported] and the error from
+// the operation.
+//
+// If the operation is not supported, returns [op.Unsupported] and nil.
+func TrySymlink(target, link string) (op.PlatformSupport, error) {
+	err := os.Symlink(target, link)
+	switch {
+	case err == nil:
+		return op.Supported, nil
+	case errorx.GetRootCauseAsValue(err, syscall.EWINDOWS),
+		errorx.GetRootCauseAsValue(err, syscall.ERROR_PRIVILEGE_NOT_HELD):
+		return op.Unsupported, nil
+	default:
+		return op.Supported, err
+	}
+}

--- a/common/fsx/fsx_walk/errors.go
+++ b/common/fsx/fsx_walk/errors.go
@@ -1,0 +1,210 @@
+package fsx_walk
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/boyter/gocodewalker/go-gitignore"
+
+	"github.com/typesanitizer/happygo/common/assert"
+	"github.com/typesanitizer/happygo/common/core/option"
+	"github.com/typesanitizer/happygo/common/core/pathx"
+	"github.com/typesanitizer/happygo/common/source_code"
+)
+
+// WalkErrorKind classifies a [WalkError].
+type WalkErrorKind uint8
+
+const (
+	// WalkErrorKind_IOFailed indicates a filesystem I/O failure (stat, read
+	// directory, read file).
+	//
+	// Methods returning data:
+	//   - [WalkError.Path]: absolute path of the failing operation.
+	//   - [WalkError.Unwrap]: the underlying I/O error.
+	WalkErrorKind_IOFailed WalkErrorKind = iota + 1
+	// WalkErrorKind_RootNotDir indicates the walk root exists but is not a
+	// directory.
+	//
+	// Methods returning data:
+	//   - [WalkError.Path]: absolute path of the walk root.
+	WalkErrorKind_RootNotDir
+	// WalkErrorKind_ParseGitIgnore indicates a .gitignore file could not be
+	// parsed. This is non-fatal: the walk continues without that file's rules.
+	//
+	// Methods returning data:
+	//   - [WalkError.Path]: absolute path of the .gitignore file.
+	//   - [WalkError.Unwrap]: a non-nil [*GitIgnoreParseErrors] with 1+ errors.
+	WalkErrorKind_ParseGitIgnore
+	// WalkErrorKind_FSRootNotRepo indicates that [WalkOptions.RespectGitIgnore]
+	// is set but the filesystem root is not a git repository root.
+	//
+	// Methods returning data:
+	//   - [WalkError.Path]: absolute path of the filesystem root.
+	WalkErrorKind_FSRootNotRepo
+	// WalkErrorKind_RootIsIgnored indicates that the walk root is excluded by
+	// an ancestor .gitignore rule.
+	//
+	// Methods returning data:
+	//   - [WalkError.Path]: absolute path of the walk root.
+	//   - [WalkError.GitIgnorePattern]: the matching ignore pattern.
+	WalkErrorKind_RootIsIgnored
+)
+
+// WalkError is the structured error type returned by [WalkNonDet].
+type WalkError struct {
+	kind WalkErrorKind
+	// path is the absolute path that triggered the error.
+	// Set for all kinds.
+	path pathx.AbsPath
+	// err is the underlying error.
+	// Set for [WalkErrorKind_IOFailed] and [WalkErrorKind_ParseGitIgnore].
+	err error
+	// gitignorePattern is the matching ignore pattern.
+	// Set for [WalkErrorKind_RootIsIgnored].
+	gitignorePattern option.Option[source_code.Snippet]
+}
+
+// Kind returns the error kind.
+//
+// Valid for all [WalkErrorKind] values.
+func (e *WalkError) Kind() WalkErrorKind {
+	return e.kind
+}
+
+// Path returns the absolute path associated with the error.
+//
+// Valid for all [WalkErrorKind] values. The exact meaning of the path depends
+// on the kind; see the per-kind documentation on [WalkErrorKind].
+func (e *WalkError) Path() pathx.AbsPath {
+	return e.path
+}
+
+// GitIgnorePattern returns the matching .gitignore pattern.
+//
+// Pre-condition: [WalkError.Kind] == [WalkErrorKind_RootIsIgnored].
+func (e *WalkError) GitIgnorePattern() source_code.Snippet {
+	assert.Preconditionf(e.kind == WalkErrorKind_RootIsIgnored, "GitIgnorePattern() called on WalkError kind %v", e.kind)
+	pattern, ok := e.gitignorePattern.Get()
+	assert.Invariant(ok, "gitignorePattern not initialized")
+	return pattern
+}
+
+func (e *WalkError) Error() string {
+	switch e.kind {
+	case WalkErrorKind_IOFailed:
+		return fmt.Sprintf("%s: %v", e.path, e.err)
+	case WalkErrorKind_RootNotDir:
+		return fmt.Sprintf("walk root %s is not a directory", e.path)
+	case WalkErrorKind_ParseGitIgnore:
+		return fmt.Sprintf("parse %s: %v", e.path, e.err)
+	case WalkErrorKind_FSRootNotRepo:
+		return fmt.Sprintf("filesystem root %s is not a git repository root", e.path)
+	case WalkErrorKind_RootIsIgnored:
+		pattern := e.GitIgnorePattern()
+		return fmt.Sprintf(
+			"walk root %s is excluded by ancestor .gitignore pattern %q at %s",
+			e.path,
+			pattern.Text,
+			pattern.FilePosition(),
+		)
+	default:
+		return assert.PanicUnknownCase[string](e.kind)
+	}
+}
+
+// Unwrap returns the underlying error.
+//
+// For [WalkErrorKind_IOFailed], this is the underlying filesystem I/O error.
+// For [WalkErrorKind_ParseGitIgnore], this is a non-nil
+// [*GitIgnoreParseErrors]. For all other [WalkErrorKind] values, this returns
+// nil.
+func (e *WalkError) Unwrap() error {
+	return e.err
+}
+
+func newWalkError(kind WalkErrorKind, path pathx.AbsPath) *WalkError {
+	return &WalkError{kind, path, nil, option.None[source_code.Snippet]()}
+}
+
+func (e *WalkError) withErr(err error) *WalkError {
+	assert.Preconditionf(e.err == nil, "overwriting existing error: %v", e.err)
+	assert.Precondition(err != nil, "setting nil error")
+	e.err = err
+	return e
+}
+
+func (e *WalkError) withGitIgnorePattern(pattern source_code.Snippet) *WalkError {
+	assert.Preconditionf(e.gitignorePattern.IsNone(), "overwriting existing gitignore pattern: %v", e.gitignorePattern)
+	e.gitignorePattern = option.Some(pattern)
+	return e
+}
+
+// GitIgnoreParseErrors is the underlying error of a [WalkErrorKind_ParseGitIgnore]
+// [WalkError]. It carries every parse error from a single .gitignore file via
+// [GitIgnoreParseErrors.Unwrap], and exposes the corresponding source snippets
+// via [GitIgnoreParseErrors.Snippets].
+type GitIgnoreParseErrors struct {
+	errs     []gitignore.Error
+	snippets []source_code.Snippet
+}
+
+// newGitIgnoreParseErrors collects the parse errors and their source snippets
+// for inclusion in a [WalkErrorKind_ParseGitIgnore] WalkError.
+//
+// Pre-condition: errs is non-empty.
+func newGitIgnoreParseErrors(ignoreFile pathx.RelPath, content []byte, errs []gitignore.Error) *GitIgnoreParseErrors {
+	assert.Preconditionf(len(errs) > 0, "newGitIgnoreParseErrors called with no errors")
+	return &GitIgnoreParseErrors{
+		errs:     errs,
+		snippets: gitIgnoreErrorSnippets(ignoreFile, content, errs),
+	}
+}
+
+func (e *GitIgnoreParseErrors) Error() string {
+	var b strings.Builder
+	for i, err := range e.errs {
+		if i > 0 {
+			b.WriteString("; ")
+		}
+		pos := err.Position()
+		if pos.Zero() {
+			_, _ = fmt.Fprintf(&b, "%v", err.Underlying())
+			continue
+		}
+		_, _ = fmt.Fprintf(&b, "%s: %v", pos, err.Underlying())
+	}
+	return b.String()
+}
+
+func (e *GitIgnoreParseErrors) Unwrap() []error {
+	errs := make([]error, 0, len(e.errs))
+	for _, err := range e.errs {
+		errs = append(errs, err)
+	}
+	return errs
+}
+
+func (e *GitIgnoreParseErrors) Snippets() []source_code.Snippet {
+	return slices.Clone(e.snippets)
+}
+
+func gitIgnoreErrorSnippets(ignoreFile pathx.RelPath, content []byte, errs []gitignore.Error) []source_code.Snippet {
+	lines := strings.Split(string(content), "\n")
+	snippets := make([]source_code.Snippet, 0, len(errs))
+	for _, err := range errs {
+		pos := err.Position()
+		if pos.Zero() {
+			continue
+		}
+		lineIndex := pos.Line - 1
+		assert.Invariantf(0 <= lineIndex && lineIndex < len(lines), "gitignore error position %s outside source", pos)
+		snippets = append(snippets, source_code.Snippet{
+			Path:     ignoreFile,
+			Position: source_code.NewPosition(int32(pos.Line), int32(pos.Column)),
+			Text:     lines[lineIndex],
+		})
+	}
+	return snippets
+}

--- a/common/fsx/fsx_walk/example_test.go
+++ b/common/fsx/fsx_walk/example_test.go
@@ -1,0 +1,91 @@
+package fsx_walk_test
+
+import (
+	"fmt"
+	"iter"
+	"sort"
+
+	"github.com/typesanitizer/happygo/common/collections"
+	"github.com/typesanitizer/happygo/common/core/pathx"
+	"github.com/typesanitizer/happygo/common/core/result"
+	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/fsx/fsx_walk"
+)
+
+// Example_iterative shows how to drive a [fsx_walk.WalkNonDet] result
+// iteratively, using a [collections.Stack] of pending child iterators
+// instead of recursion. This pattern is useful when recursion depth
+// is unbounded or when descent decisions depend on caller state.
+func Example_iterative() {
+	root, err := pathx.ResolveAbsPath("example-root")
+	if err != nil {
+		panic(err)
+	}
+	fs, err := fsx.MemMap(root)
+	if err != nil {
+		panic(err)
+	}
+	mustWrite := func(path, content string) {
+		rel := pathx.NewRelPath(path)
+		if dir, ok := rel.Dir().Get(); ok {
+			if err := fs.MkdirAll(dir, 0o755); err != nil {
+				panic(err)
+			}
+		}
+		if err := fs.WriteFile(rel, []byte(content), 0o644); err != nil {
+			panic(err)
+		}
+	}
+	mustWrite("a/b.txt", "b")
+	mustWrite("a/sub/c.txt", "c")
+	mustWrite("d.txt", "d")
+
+	entries, err := fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: false})
+	if err != nil {
+		panic(err)
+	}
+
+	type frame struct {
+		prefix string
+		next   func() (result.Result[fsx_walk.FSWalkEntry], bool)
+		stop   func()
+	}
+	push := func(stack *collections.Stack[frame], prefix string, seq iter.Seq[result.Result[fsx_walk.FSWalkEntry]]) {
+		next, stop := iter.Pull(seq)
+		stack.Push(frame{prefix: prefix, next: next, stop: stop})
+	}
+
+	stack := collections.NewStack[frame]()
+	push(&stack, "", entries)
+
+	var paths []string
+	for !stack.IsEmpty() {
+		top := stack.Pop()
+		entryRes, ok := top.next()
+		if !ok {
+			top.stop()
+			continue
+		}
+		// Re-push: the current frame still has more siblings to yield.
+		stack.Push(top)
+		entry, err := entryRes.Get()
+		if err != nil {
+			panic(err)
+		}
+		path := top.prefix + entry.Name().String()
+		paths = append(paths, path)
+		if entry.IsDir() {
+			push(&stack, path+"/", entry.ChildrenNonDet())
+		}
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		fmt.Println(p)
+	}
+	// Output:
+	// a
+	// a/b.txt
+	// a/sub
+	// a/sub/c.txt
+	// d.txt
+}

--- a/common/fsx/fsx_walk/walk.go
+++ b/common/fsx/fsx_walk/walk.go
@@ -1,0 +1,365 @@
+// Package fsx_walk provides directory walking over fsx.FS with optional
+// .gitignore handling.
+package fsx_walk
+
+import (
+	"bytes"
+	"iter"
+	"slices"
+
+	"github.com/boyter/gocodewalker/go-gitignore"
+
+	"github.com/typesanitizer/happygo/common/assert"
+	"github.com/typesanitizer/happygo/common/core/option"
+	"github.com/typesanitizer/happygo/common/core/pathx"
+	"github.com/typesanitizer/happygo/common/core/result"
+	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/iterx"
+	"github.com/typesanitizer/happygo/common/source_code"
+)
+
+// WalkNonDet returns an iterator over the entries in the [root] directory.
+//
+// The iterator yields entries in non-deterministic order.
+// Directory entries carry a lazy [FSWalkEntry.ChildrenNonDet] iterator;
+// descending into a directory is the caller's choice.
+// Stopping early is done by breaking out of the iteration.
+//
+// Initial errors — returned via the error return (no iterator is created):
+//   - [WalkErrorKind_IOFailed]: root cannot be stat'd or an ancestor .gitignore
+//     cannot be read.
+//   - [WalkErrorKind_RootNotDir]: root exists but is not a directory (e.g. a
+//     symlink or regular file).
+//   - [WalkErrorKind_FSRootNotRepo]: [WalkOptions.RespectGitIgnore] is set but
+//     the filesystem root is not a git repository root.
+//   - [WalkErrorKind_RootIsIgnored]: [WalkOptions.RespectGitIgnore] is set and
+//     root is excluded by an ancestor .gitignore rule.
+//
+// Inside the Result for an iterator, there are two kinds of errors.
+//
+// - Terminal errors, after which no further elements are yielded for that directory.
+//   - [WalkErrorKind_IOFailed]: a directory could not be read, or some other stat
+//     operation (e.g. for .git/.gitignore) failed with an error other than
+//     "does not exist".
+//
+// - Non-terminal errors, after which further elements may be yielded:
+//   - [WalkErrorKind_ParseGitIgnore]: a .gitignore file could not be parsed.
+//     The walk continues without that file's rules.
+//     If this error is returned, WalkError.Unwrap() returns a multi-error which
+//     carries all parsing errors via Unwrap() []error.
+func WalkNonDet(fs fsx.FS, root pathx.RelPath, opts WalkOptions) (iter.Seq[result.Result[FSWalkEntry]], error) {
+	info, err := fs.Stat(root, fsx.StatOptions{FollowFinalSymlink: false, OnErrorTraverseParents: true})
+	if err != nil {
+		return nil, newWalkError(WalkErrorKind_IOFailed, fs.Root().Join(root)).withErr(err)
+	}
+	if !info.IsDir() {
+		return nil, newWalkError(WalkErrorKind_RootNotDir, fs.Root().Join(root))
+	}
+
+	w := &walker{fs: fs, opts: opts}
+	if opts.RespectGitIgnore {
+		repoRoot, err := w.isGitRepoRoot(pathx.Dot())
+		if err != nil {
+			return nil, err
+		}
+		if !repoRoot {
+			return nil, newWalkError(WalkErrorKind_FSRootNotRepo, fs.Root())
+		}
+	}
+
+	var matchers []gitIgnoreMatcher
+	var warnings []*WalkError
+	if opts.RespectGitIgnore && root.String() != "." {
+		matchers, warnings, err = w.ancestorGitIgnores(root)
+		if err != nil {
+			return nil, err
+		}
+	}
+	warningSeq := iterx.Map(iterx.FromSlice(warnings), fail)
+	return iterx.Chain(warningSeq, w.walkDir(root, matchers)), nil
+}
+
+// NOTE(id: fsx-walk-concurrent-children): fsx_walk must not share mutable
+// traversal state across child iterators for distinct directories. Keep walker
+// immutable; per-directory state such as parse warnings must flow through
+// return values.
+type walker struct {
+	fs   fsx.FS
+	opts WalkOptions
+}
+
+func (w *walker) walkDir(dir pathx.RelPath, parentMatchers []gitIgnoreMatcher) iter.Seq[result.Result[FSWalkEntry]] {
+	return walkDirSeq{w: w, dir: dir, parentMatchers: parentMatchers}.iterate
+}
+
+type gitIgnoreMatcher struct {
+	matcher gitignore.GitIgnore
+	// dir is the directory containing the .gitignore, relative to the fs root.
+	dir        pathx.RelPath
+	ignoreFile pathx.RelPath
+}
+
+type walkDirSeq struct {
+	w              *walker
+	dir            pathx.RelPath
+	parentMatchers []gitIgnoreMatcher
+}
+
+// iterate yields the entries of seq.dir.
+//
+// Terminal [Failure] errors (no further elements yielded):
+//   - [WalkErrorKind_IOFailed]: the .git stat for the repo-root check failed,
+//     a .gitignore could not be read, or [fsx.FS.ReadDir] returned an error.
+//
+// Non-terminal [Failure] errors (iteration continues):
+//   - [WalkErrorKind_ParseGitIgnore]: the directory's .gitignore could not be
+//     parsed. The walk continues without that file's rules.
+func (seq walkDirSeq) iterate(yield func(result.Result[FSWalkEntry]) bool) {
+	activeMatchers := seq.parentMatchers
+	if seq.w.opts.RespectGitIgnore {
+		// If this directory is a nested repo root, discard inherited matchers
+		// so the new repo starts with a clean ignore state.
+		repoRoot, walkErr := seq.w.isGitRepoRoot(seq.dir)
+		if walkErr != nil {
+			yield(fail(walkErr))
+			return
+		}
+		if repoRoot {
+			activeMatchers = nil
+		}
+		var warnings []*WalkError
+		activeMatchers, warnings, walkErr = seq.w.childGitIgnores(seq.dir, activeMatchers)
+		if walkErr != nil {
+			yield(fail(walkErr))
+			return
+		}
+		for _, warning := range warnings {
+			if !yield(fail(warning)) {
+				return
+			}
+		}
+	}
+	// Clip so that children sharing this slice can't corrupt each other
+	// via spare capacity when childGitIgnores appends.
+	activeMatchers = slices.Clip(activeMatchers)
+
+	for entryRes := range seq.w.fs.ReadDir(seq.dir) {
+		de, err := entryRes.Get()
+		if err != nil {
+			yield(fail(newWalkError(WalkErrorKind_IOFailed, seq.w.fs.Root().Join(seq.dir)).withErr(err)))
+			return
+		}
+
+		name := de.BaseName()
+		child := seq.dir.JoinComponents(name.String())
+		isDir := de.IsDir()
+
+		if seq.w.opts.RespectGitIgnore {
+			_, ignored := seq.w.identifyPatternIgnoring(activeMatchers, child, isDir).Get()
+			if ignored {
+				continue
+			}
+		}
+
+		var entry FSWalkEntry
+		if isDir {
+			entry = FSWalkEntry{name: name, children: seq.w.walkDir(child, activeMatchers)}
+		} else {
+			entry = FSWalkEntry{name: name, children: nil}
+		}
+
+		if !yield(result.Success(entry)) {
+			return
+		}
+	}
+}
+
+// WalkOptions configures [WalkNonDet].
+type WalkOptions struct {
+	// RespectGitIgnore enables .gitignore handling while walking.
+	//
+	// NOTE: This does not cover the following situations:
+	// - .git/info/exclude files
+	// - global configuration via core.excludesFile
+	// - Handling for the GIT_DIR environment variable
+	RespectGitIgnore bool
+}
+
+// FSWalkEntry is a single entry yielded by [WalkNonDet].
+//
+// It is either a file (carrying just its name) or a directory
+// (carrying its name and a lazily-evaluated iterator of children).
+// Use [FSWalkEntry.IsDir] to distinguish the two cases.
+type FSWalkEntry struct {
+	name     fsx.Name
+	children iter.Seq[result.Result[FSWalkEntry]] // nil for files
+}
+
+// Name returns the basename of this entry.
+func (e FSWalkEntry) Name() fsx.Name {
+	return e.name
+}
+
+// IsDir reports whether this entry is a directory.
+func (e FSWalkEntry) IsDir() bool {
+	return e.children != nil
+}
+
+// ChildrenNonDet returns an iterator over the directory's children.
+//
+// Pre-condition: e.IsDir() is true.
+func (e FSWalkEntry) ChildrenNonDet() iter.Seq[result.Result[FSWalkEntry]] {
+	assert.Preconditionf(e.IsDir(), "ChildrenNonDet() called on file entry %q", e.name)
+	return e.children
+}
+
+// ancestorGitIgnores returns the .gitignore matchers inherited from ancestors
+// of root. It does not load root's own .gitignore — that is loaded lazily by
+// [walkDirSeq.iterate].
+//
+// Pre-conditions:
+//   - [WalkOptions.RespectGitIgnore] is enabled.
+//   - root is not ".".
+//   - (Unchecked) the filesystem root has been verified as a git repo root.
+//
+// Errors:
+//   - [WalkErrorKind_RootIsIgnored]: an ancestor .gitignore rule excludes root
+//     (or excludes root itself relative to its enclosing matchers).
+//   - [WalkErrorKind_IOFailed]: a .git stat or .gitignore read failed along the
+//     ancestor path.
+func (w *walker) ancestorGitIgnores(root pathx.RelPath) ([]gitIgnoreMatcher, []*WalkError, error) {
+	assert.Preconditionf(w.opts.RespectGitIgnore, "ancestorGitIgnores called with RespectGitIgnore=false")
+	assert.Preconditionf(root != pathx.Dot(), "ancestorGitIgnores called with root=.")
+
+	matchers, warnings, err := w.childGitIgnores(pathx.Dot(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for ancestor := range root.Ancestors() {
+		if pattern, ignored := w.identifyPatternIgnoring(matchers, ancestor, true).Get(); ignored {
+			return nil, nil, newWalkError(WalkErrorKind_RootIsIgnored, w.fs.Root().Join(root)).withGitIgnorePattern(pattern)
+		}
+		repoRoot, err := w.isGitRepoRoot(ancestor)
+		if err != nil {
+			return nil, nil, err
+		}
+		if repoRoot {
+			matchers = nil
+		}
+		var childWarnings []*WalkError
+		matchers, childWarnings, err = w.childGitIgnores(ancestor, matchers)
+		if err != nil {
+			return nil, nil, err
+		}
+		warnings = append(warnings, childWarnings...)
+	}
+
+	if pattern, ignored := w.identifyPatternIgnoring(matchers, root, true).Get(); ignored {
+		return nil, nil, newWalkError(WalkErrorKind_RootIsIgnored, w.fs.Root().Join(root)).withGitIgnorePattern(pattern)
+	}
+	return matchers, warnings, nil
+}
+
+// childGitIgnores returns the matcher set that applies while visiting dir's
+// children.
+//
+// If dir has a .gitignore file, its matcher is appended after parent so that
+// deeper directories see the usual nested precedence.
+//
+// Pre-condition: [WalkOptions.RespectGitIgnore] is enabled.
+func (w *walker) childGitIgnores(dir pathx.RelPath, parent []gitIgnoreMatcher) ([]gitIgnoreMatcher, []*WalkError, *WalkError) {
+	assert.Preconditionf(w.opts.RespectGitIgnore, "childGitIgnores called with RespectGitIgnore=false")
+	matcher, warnings, walkErr := w.loadGitIgnore(dir)
+	if walkErr != nil {
+		return nil, nil, walkErr
+	}
+	if matcher == nil {
+		return parent, warnings, nil
+	}
+	return append(parent, *matcher), warnings, nil
+}
+
+func (w *walker) isGitRepoRoot(dir pathx.RelPath) (bool, *WalkError) {
+	gitRel := dir.JoinComponents(".git")
+	info, err := w.fs.Stat(gitRel, fsx.StatOptions{FollowFinalSymlink: false, OnErrorTraverseParents: false})
+	if err != nil {
+		if errorx.GetRootCauseAsValue(err, fsx.ErrNotExist) {
+			return false, nil
+		}
+		return false, newWalkError(WalkErrorKind_IOFailed, w.fs.Root().Join(gitRel)).withErr(err)
+	}
+	mode := info.Mode()
+	return mode.IsDir() || mode.IsRegular(), nil
+}
+
+func (w *walker) loadGitIgnore(dir pathx.RelPath) (*gitIgnoreMatcher, []*WalkError, *WalkError) {
+	ignoreRel := dir.JoinComponents(".gitignore")
+	content, err := w.fs.ReadFile(ignoreRel)
+	if err != nil {
+		if errorx.GetRootCauseAsValue(err, fsx.ErrNotExist) {
+			return nil, nil, nil
+		}
+		return nil, nil, newWalkError(WalkErrorKind_IOFailed, w.fs.Root().Join(ignoreRel)).withErr(err)
+	}
+
+	var parseErrs []gitignore.Error
+	// Oddity: gitignore.New expects that the second argument is the _absolute path_
+	// to the directory containing the .gitignore file, so that it can correctly
+	// interpret repo-root-relative paths in the .gitignore.
+	//
+	// I don't fully understand why this makes sense, I don't think it does,
+	// but leaving this for now to avoid having to fork yet more code/
+	// hand-roll this ourselves...
+	matcher := gitignore.New(bytes.NewReader(content), w.fs.Root().Join(dir).String(), func(err gitignore.Error) bool {
+		parseErrs = append(parseErrs, err)
+		return true
+	})
+	if len(parseErrs) > 0 {
+		warning := newWalkError(WalkErrorKind_ParseGitIgnore, w.fs.Root().Join(ignoreRel)).withErr(newGitIgnoreParseErrors(ignoreRel, content, parseErrs))
+		return nil, []*WalkError{warning}, nil
+	}
+	return &gitIgnoreMatcher{matcher: matcher, dir: dir, ignoreFile: ignoreRel}, nil, nil
+}
+
+// identifyPatternIgnoring looks through the matchers with last-wins
+// semantics, and checks if rel should be ignored overall.
+//
+// If rel should be ignored, then the most appropriate pattern
+// from the matchers is returned. Otherwise, None is returned.
+//
+// isDir denotes whether rel corresponds to a directory path.
+func (w *walker) identifyPatternIgnoring(matchers []gitIgnoreMatcher, rel pathx.RelPath, isDir bool) option.Option[source_code.Snippet] {
+	ignored := option.None[source_code.Snippet]()
+	// Always walk all matches from start-to-end, because later
+	// entries correspond to nearer .gitignore files, which override
+	// patterns in more distant .gitignore files.
+	for _, m := range matchers {
+		// gitignore.GitIgnore.Relative expects a path relative to the directory
+		// containing the .gitignore (i.e. m.dir), not relative to the fs root.
+		match := m.matcher.Relative(rel.RelativeTo(m.dir).String(), isDir)
+		if match == nil {
+			continue
+		}
+		if match.Ignore() {
+			ignored = option.Some(sourceCodeSnippet(m.ignoreFile, match))
+		} else { // !ignore => keep, so reset 'ignored'.
+			ignored = option.None[source_code.Snippet]()
+		}
+	}
+	return ignored
+}
+
+func fail(e *WalkError) result.Result[FSWalkEntry] {
+	return result.Failure[FSWalkEntry](e)
+}
+
+func sourceCodeSnippet(ignoreFile pathx.RelPath, match gitignore.Match) source_code.Snippet {
+	position := match.Position()
+	return source_code.Snippet{
+		Path:     ignoreFile,
+		Position: source_code.NewPosition(int32(position.Line), int32(position.Column)),
+		Text:     match.String(),
+	}
+}

--- a/common/fsx/fsx_walk/walk_test.go
+++ b/common/fsx/fsx_walk/walk_test.go
@@ -1,0 +1,475 @@
+package fsx_walk_test
+
+import (
+	"iter"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/typesanitizer/happygo/common/check"
+	. "github.com/typesanitizer/happygo/common/check/prelude"
+	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/pathx"
+	"github.com/typesanitizer/happygo/common/fsx/fsx_testkit"
+	"github.com/typesanitizer/happygo/common/fsx/fsx_walk"
+	"github.com/typesanitizer/happygo/common/iterx"
+	"github.com/typesanitizer/happygo/common/source_code"
+	"github.com/typesanitizer/happygo/common/syscaps"
+)
+
+type WalkResultSeq = iter.Seq[Result[fsx_walk.FSWalkEntry]]
+
+func TestWalk(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("GitIgnore", testGitIgnore)
+	h.Run("Faults", testFaults)
+
+	h.Run("Traversal", func(h check.Harness) {
+		h.Parallel()
+
+		h.Run("SkipSubtree", func(h check.Harness) {
+			h.Parallel()
+
+			fs := fsx_testkit.NewMemFS(h, map[string]string{
+				"a/":           "",
+				"a/skip/":      "",
+				"a/skip/y.txt": "y",
+				"a/x.txt":      "x",
+				"b.txt":        "b",
+			})
+
+			entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: false}))(h)
+			got := collectPaths(h, entries, collectOptions{skipDir: func(name string) bool {
+				return name == "a/skip"
+			}})
+			checkVisitedPaths(h, []string{"a", "a/skip", "a/x.txt", "b.txt"}, got)
+		})
+	})
+	h.Run("Root", func(h check.Harness) {
+		h.Parallel()
+
+		h.Run("SymlinkNotFollowed", func(h check.Harness) {
+			h.Parallel()
+
+			parent := h.T().TempDir()
+			h.WriteTree(parent, map[string]string{"target/file.txt": "x"})
+
+			target := filepath.Join(parent, "target")
+			link := filepath.Join(parent, "link")
+			support := Do(fsx_testkit.TrySymlink(target, link))(h)
+			if support.IsUnsupported() {
+				h.T().Skipf("symlinks not supported on this platform")
+			}
+
+			fs := Do(syscaps.FS(pathx.NewAbsPath(link)))(h)
+
+			_, err := fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: false})
+			walkErr := requireWalkError(h, err, fsx_walk.WalkErrorKind_RootNotDir)
+			h.Assertf(strings.Contains(walkErr.Error(), "not a directory"),
+				"WalkError.Error() = %q, want not-a-directory message", walkErr.Error())
+		})
+	})
+}
+
+func testGitIgnore(h check.Harness) {
+	h.Parallel()
+
+	h.Run("RespectGitIgnore", func(h check.Harness) {
+		h.Parallel()
+
+		fs := fsx_testkit.NewMemFS(h, map[string]string{
+			".git": "gitdir: root\n",
+			".gitignore": `.git
+ignored/
+*.log
+`,
+			"ignored/":         "",
+			"ignored/file.txt": "ignored",
+			"sub/":             "",
+			"sub/.gitignore":   "!keep.log\n",
+			"sub/drop.log":     "drop",
+			"sub/file.txt":     "file",
+			"sub/keep.log":     "keep",
+		})
+
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+		got := collectPaths(h, entries)
+		checkVisitedPaths(h,
+			[]string{".gitignore", "sub", "sub/.gitignore", "sub/file.txt", "sub/keep.log"},
+			got,
+		)
+	})
+
+	h.Run("RequiresFSRootRepo", func(h check.Harness) {
+		h.Parallel()
+
+		fs := fsx_testkit.NewMemFS(h, map[string]string{
+			".gitignore": "*.txt\n",
+			"file.txt":   "x",
+		})
+
+		_, err := fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true})
+		walkErr := requireWalkError(h, err, fsx_walk.WalkErrorKind_FSRootNotRepo)
+		check.AssertSame(h, fs.Root(), walkErr.Path(), "WalkError.Path()")
+		h.Assertf(strings.Contains(walkErr.Error(), "not a git repository root"),
+			"WalkError.Error() = %q, want repository-root message", walkErr.Error())
+		h.NoErrorf(walkErr.Unwrap(), "WalkError.Unwrap()")
+	})
+
+	h.Run("ExplicitSubtree", testGitIgnore_OnExplicitSubtree)
+	h.Run("NestedRepoReset", testGitIgnore_ResetsAtNestedRepo)
+	h.Run("IgnoredNestedRepo", testGitIgnore_SkipsIgnoredNestedRepo)
+	h.Run("ParseErrors", testGitIgnore_PreservesAllParseErrors)
+	h.Run("ConcurrentSiblingWarnings", testGitIgnore_ConcurrentSiblingWarnings)
+}
+
+func testFaults(h check.Harness) {
+	h.Parallel()
+
+	h.Run("InitialRootStat", func(h check.Harness) {
+		h.Parallel()
+
+		fs := fsx_testkit.NewMemFS(h, map[string]string{"a.txt": "a"})
+		h.NoErrorf(fs.RemoveAll(pathx.Dot()), "RemoveAll(.)")
+
+		_, err := fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: false})
+		walkErr := requireWalkError(h, err, fsx_walk.WalkErrorKind_IOFailed)
+		check.AssertSame(h, fs.Root(), walkErr.Path(), "WalkError.Path()")
+		h.Assertf(walkErr.Unwrap() != nil, "WalkError.Unwrap() = nil, want underlying error")
+		h.Assertf(strings.Contains(walkErr.Error(), fs.Root().String()),
+			"got: WalkError.Error() = %q\nwant: root path %v to appear in it", walkErr.Error(), fs.Root())
+	})
+
+	h.Run("InitialGitStat", func(h check.Harness) {
+		h.Parallel()
+
+		fs := fsx_testkit.NewFaultyFS(h, fsx_testkit.FakeRoot(), map[string]string{}, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Stat, Rel: pathx.NewRelPath(".git")})
+
+		_, err := fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true})
+		_ = requireWalkError(h, err, fsx_walk.WalkErrorKind_IOFailed)
+	})
+
+	h.Run("IterateGitStat", func(h check.Harness) {
+		h.Parallel()
+
+		fs := fsx_testkit.NewFaultyFS(h, fsx_testkit.FakeRoot(), map[string]string{
+			".git": "gitdir: root\n",
+			"a/":   "",
+		}, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Stat, Rel: pathx.NewRelPath("a/.git")})
+
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+		_ = requireWalkError(h, firstWalkError(h, entries), fsx_walk.WalkErrorKind_IOFailed)
+	})
+
+	h.Run("IterateGitIgnoreRead", func(h check.Harness) {
+		h.Parallel()
+
+		fs := fsx_testkit.NewFaultyFS(h, fsx_testkit.FakeRoot(), map[string]string{
+			".git": "gitdir: root\n",
+			"a/":   "",
+		}, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Open, Rel: pathx.NewRelPath("a/.gitignore")})
+
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+		_ = requireWalkError(h, firstWalkError(h, entries), fsx_walk.WalkErrorKind_IOFailed)
+	})
+
+	h.Run("IterateReadDir", func(h check.Harness) {
+		h.Parallel()
+
+		fs := fsx_testkit.NewFaultyFS(h, fsx_testkit.FakeRoot(), map[string]string{
+			"a/": "",
+		}, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Open, Rel: pathx.NewRelPath("a")})
+
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: false}))(h)
+		_ = requireWalkError(h, firstWalkError(h, entries), fsx_walk.WalkErrorKind_IOFailed)
+	})
+}
+
+func testGitIgnore_OnExplicitSubtree(h check.Harness) {
+	fs := fsx_testkit.NewMemFS(h, map[string]string{
+		".git": "gitdir: root\n",
+		".gitignore": `.git
+blocked/
+*.tmp
+`,
+		"blocked/":                "",
+		"blocked/.gitignore":      "!child/\n",
+		"blocked/child/":          "",
+		"blocked/child/file.txt":  "blocked",
+		"open/":                   "",
+		"open/.gitignore":         "drop/\n",
+		"open/child/":             "",
+		"open/child/drop/":        "",
+		"open/child/drop/file.go": "drop",
+		"open/child/file.go":      "open",
+		"open/child/root.tmp":     "ignored",
+	})
+
+	h.Run("Ignores root subtree when blocked by ancestor", func(h check.Harness) {
+		h.Parallel()
+		_, err := fsx_walk.WalkNonDet(fs, pathx.NewRelPath("blocked/child"), fsx_walk.WalkOptions{RespectGitIgnore: true})
+		walkErr := requireWalkError(h, err, fsx_walk.WalkErrorKind_RootIsIgnored)
+		check.AssertSame(h,
+			source_code.Snippet{
+				Path:     pathx.NewRelPath(".gitignore"),
+				Position: source_code.NewPosition(2, 1),
+				Text:     "blocked/",
+			},
+			walkErr.GitIgnorePattern(),
+			"GitIgnorePattern()",
+			cmp.AllowUnexported(source_code.Position{}),
+		)
+		h.Assertf(strings.Contains(walkErr.Error(), "blocked/"),
+			"WalkError.Error() = %q, want ignored pattern", walkErr.Error())
+	})
+
+	h.Run("Walks subtree with ancestor gitignore matchers", func(h check.Harness) {
+		h.Parallel()
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.NewRelPath("open/child"), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+		got := collectPaths(h, entries)
+		checkVisitedPaths(h, []string{"file.go"}, got)
+	})
+
+	h.Run("Walks subtree when gitignore is disabled", func(h check.Harness) {
+		h.Parallel()
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.NewRelPath("blocked/child"), fsx_walk.WalkOptions{RespectGitIgnore: false}))(h)
+		got := collectPaths(h, entries)
+		checkVisitedPaths(h, []string{"file.txt"}, got)
+	})
+}
+
+func testGitIgnore_ResetsAtNestedRepo(h check.Harness) {
+	fs := fsx_testkit.NewMemFS(h, map[string]string{
+		".git": "gitdir: root\n",
+		".gitignore": `.git
+*.txt
+`,
+		"root.txt":              "root",
+		"nested/":               "",
+		"nested/.git":           "gitdir: nested\n",
+		"nested/child/":         "",
+		"nested/child/file.txt": "inside",
+		"nested/inside.txt":     "inside",
+	})
+
+	h.Run("WhileWalking", func(h check.Harness) {
+		h.Parallel()
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+		got := collectPaths(h, entries)
+		checkVisitedPaths(
+			h,
+			[]string{
+				".gitignore", "nested", "nested/.git", "nested/child",
+				"nested/child/file.txt", "nested/inside.txt",
+			},
+			got,
+		)
+	})
+
+	h.Run("ExplicitSubtree", func(h check.Harness) {
+		h.Parallel()
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.NewRelPath("nested/child"), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+		got := collectPaths(h, entries)
+		checkVisitedPaths(h, []string{"file.txt"}, got)
+	})
+}
+
+func testGitIgnore_SkipsIgnoredNestedRepo(h check.Harness) {
+	h.Parallel()
+
+	fs := fsx_testkit.NewMemFS(h, map[string]string{
+		".git": "gitdir: root\n",
+		".gitignore": `.git
+nested/
+`,
+		"root.txt":          "root",
+		"nested/":           "",
+		"nested/.git":       "gitdir: nested\n",
+		"nested/inside.txt": "inside",
+	})
+
+	entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+	got := collectPaths(h, entries)
+	checkVisitedPaths(h, []string{".gitignore", "root.txt"}, got)
+}
+
+func testGitIgnore_PreservesAllParseErrors(h check.Harness) {
+	h.Parallel()
+
+	fs := fsx_testkit.NewMemFS(h, map[string]string{
+		".git": "gitdir: root\n",
+		".gitignore": `!
+** *
+`,
+		"a.txt": "a",
+	})
+
+	entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+	err := firstWalkError(h, entries)
+	walkErr := requireWalkError(h, err, fsx_walk.WalkErrorKind_ParseGitIgnore)
+	h.Assertf(strings.Count(walkErr.Error(), "invalid pattern") == 2,
+		"WalkError.Error() = %q, want 2 invalid pattern errors", walkErr.Error())
+	parseErrs, ok := walkErr.Unwrap().(interface{ Unwrap() []error })
+	h.Assertf(ok, "WalkError.Unwrap() = %T, want an error with Unwrap() []error", walkErr.Unwrap())
+	h.Assertf(len(parseErrs.Unwrap()) == 2, "parse error count = %d, want 2", len(parseErrs.Unwrap()))
+
+	parseSnippets, ok := walkErr.Unwrap().(interface{ Snippets() []source_code.Snippet })
+	h.Assertf(ok, "WalkError.Unwrap() = %T, want an error with Snippets() []source_code.Snippet", walkErr.Unwrap())
+	check.AssertSame(h,
+		[]source_code.Snippet{
+			{Path: pathx.NewRelPath(".gitignore"), Position: source_code.NewPosition(1, 2), Text: "!"},
+			{Path: pathx.NewRelPath(".gitignore"), Position: source_code.NewPosition(2, 4), Text: "** *"},
+		},
+		parseSnippets.Snippets(),
+		"parse error snippets",
+		cmp.AllowUnexported(source_code.Position{}),
+	)
+}
+
+func testGitIgnore_ConcurrentSiblingWarnings(h check.Harness) {
+	h.Parallel()
+
+	fs := fsx_testkit.NewMemFS(h, map[string]string{
+		".git":         "gitdir: root\n",
+		"a/":           "",
+		"a/.gitignore": "!\n",
+		"a/file.txt":   "a",
+		"b/":           "",
+		"b/.gitignore": "** *\n",
+		"b/file.txt":   "b",
+	})
+
+	entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+	children := make(map[string]WalkResultSeq)
+	for entryRes := range entries {
+		entry := Do(entryRes.Get())(h)
+		name := entry.Name().String()
+		if entry.IsDir() && (name == "a" || name == "b") {
+			children[name] = entry.ChildrenNonDet()
+		}
+	}
+	h.Assertf(len(children) == 2, "children = %v, want a and b", children)
+
+	type childResult struct {
+		name string
+		errs []error
+	}
+	start := make(chan struct{})
+	results := make(chan childResult, len(children))
+	var wg sync.WaitGroup
+	for name, seq := range children {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			var errs []error
+			for entryRes := range seq {
+				_, err := entryRes.Get()
+				if err != nil {
+					errs = append(errs, err)
+				}
+			}
+			results <- childResult{name: name, errs: errs}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	got := make(map[string][]string)
+	for res := range results {
+		for _, err := range res.errs {
+			walkErr := requireWalkError(h, err, fsx_walk.WalkErrorKind_ParseGitIgnore)
+			got[res.name] = append(got[res.name], walkErr.Path().String())
+		}
+	}
+	check.AssertSame(h,
+		map[string][]string{
+			"a": {fs.Root().Join(pathx.NewRelPath("a/.gitignore")).String()},
+			"b": {fs.Root().Join(pathx.NewRelPath("b/.gitignore")).String()},
+		},
+		got,
+		"parse warning paths",
+		cmpopts.SortSlices(strings.Compare),
+	)
+}
+
+func checkVisitedPaths(h check.Harness, want []string, got []string) {
+	h.T().Helper()
+	check.AssertSame(h, want, got, "visited paths", cmpopts.SortSlices(strings.Compare))
+}
+
+type collectOptions struct {
+	skipDir func(path string) bool
+}
+
+// collectPaths recursively collects all paths from the walk tree.
+func collectPaths(h check.Harness, entries WalkResultSeq, opts ...collectOptions) []string {
+	h.T().Helper()
+	var opt collectOptions
+	for _, v := range opts {
+		if v.skipDir != nil {
+			opt.skipDir = v.skipDir
+		}
+	}
+	var impl func(WalkResultSeq, string) []string
+	impl = func(entries WalkResultSeq, prefix string) []string {
+		var paths []string
+		for entryRes := range entries {
+			entry := Do(entryRes.Get())(h)
+			path := joinWalkPath(prefix, entry.Name().String())
+			paths = append(paths, path)
+			if entry.IsDir() {
+				if opt.skipDir != nil && opt.skipDir(path) {
+					continue
+				}
+				paths = append(paths, impl(entry.ChildrenNonDet(), path)...)
+			}
+		}
+		return paths
+	}
+	return impl(entries, "")
+}
+
+func joinWalkPath(prefix, name string) string {
+	if prefix == "" {
+		return name
+	}
+	return prefix + "/" + name
+}
+
+func firstWalkError(h check.Harness, entries WalkResultSeq) error {
+	h.T().Helper()
+	var impl func(WalkResultSeq) Option[error]
+	impl = func(entries WalkResultSeq) Option[error] {
+		return iterx.Find(entries, func(entryRes Result[fsx_walk.FSWalkEntry]) Option[error] {
+			entry, err := entryRes.Get()
+			if err != nil {
+				return Some(err)
+			}
+			if entry.IsDir() {
+				return impl(entry.ChildrenNonDet())
+			}
+			return None[error]()
+		})
+	}
+	err, ok := impl(entries).Get()
+	h.Assertf(ok, "walk completed without an error")
+	return err
+}
+
+func requireWalkError(h check.Harness, err error, wantKind fsx_walk.WalkErrorKind) *fsx_walk.WalkError {
+	h.T().Helper()
+	h.Assertf(err != nil, "WalkNonDet unexpectedly succeeded")
+	walkErr, ok := err.(*fsx_walk.WalkError) // direct cast for result of Walk is OK
+	h.Assertf(ok, "WalkNonDet error type = %T, want *WalkError", err)
+	h.Assertf(walkErr.Kind() == wantKind,
+		"WalkNonDet error kind = %v, want %v", walkErr.Kind(), wantKind)
+	return walkErr
+}

--- a/common/fsx/stat_test.go
+++ b/common/fsx/stat_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/typesanitizer/happygo/common/core/pathx/pathx_testkit"
 	"github.com/typesanitizer/happygo/common/errorx"
 	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/fsx/fsx_testkit"
 	"github.com/typesanitizer/happygo/common/syscaps"
 )
 
@@ -29,8 +30,9 @@ func TestFSStat(t *testing.T) {
 		h.NoErrorf(os.Mkdir(target, 0o755), "Mkdir(%q)", target)
 
 		link := filepath.Join(parent, "link")
-		if err := os.Symlink(target, link); err != nil {
-			h.T().Skipf("skipping: symlinks unavailable: %v", err)
+		support := Do(fsx_testkit.TrySymlink(target, link))(h)
+		if support.IsUnsupported() {
+			h.T().Skipf("symlinks not supported on this platform")
 		}
 
 		repoFS := Do(syscaps.FS(NewAbsPath(link)))(h)

--- a/common/go.mod
+++ b/common/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	al.essio.dev/pkg/shellescape v1.6.0
+	github.com/boyter/gocodewalker v1.5.1
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/log v0.4.2
 	github.com/cockroachdb/errors v1.12.0


### PR DESCRIPTION
One of the common operations we need to do inside the
happydo task runner is do a recursive walk of certain
directories while respecting gitignore and having custom
rules, like not descending into certain directories
like testdata/ etc.

This patch adds an iterator-based API which allows a
caller to traverse the directories serially as well as
in parallel.

1. Unlike the stdlib, it is based off our fsx.FS,
   so it allows callers to substitute their own filesystem.
2. Unlike afero.Walk, it:
   - Exposes an iterator structure, to allow the caller
     to run the iteration in parallel as needed.
   - Exposes typed paths
3. Unlike boyter/gocodewalker, it is correct when nested
   .git directories appear (this should not happen in the
   happygo monorepo, but the additional complexity for this
   is not much higher, so we prefer correctness).

It has some limitations:

1. It does not respect the GIT_DIR environment variable.
2. It does not account for .git/info/exclude.
