### PR TITLE
chore(fsx): Make FS an interface & simplify testing APIs

### DIFF
--- a/common/fsx/fsx.go
+++ b/common/fsx/fsx.go
@@ -61,9 +61,21 @@ type BaseFS interface {
 	afero.Lstater
 }
 
-// FS is a rooted filesystem wrapper. All methods operate on paths relative
-// to Root().
-type FS struct {
+// FS is a rooted filesystem. All methods operate on paths relative to Root().
+type FS interface {
+	Root() AbsPath
+	ReadDir(rel RelPath) iter.Seq[Result[DirEntry]]
+	Open(rel RelPath) (File, error)
+	ReadFile(rel RelPath) ([]byte, error)
+	WriteFile(rel RelPath, data []byte, perm os.FileMode) error
+	MkdirAll(rel RelPath, perm os.FileMode) error
+	MkdirTemp(dir RelPath, pattern string) (RelPath, error)
+	RemoveAll(rel RelPath) error
+	Stat(rel RelPath, opts StatOptions) (os.FileInfo, error)
+}
+
+// rootedFS is the standard FS implementation backed by an afero filesystem.
+type rootedFS struct {
 	// Stored separately because afero.BasePathFs does not expose its configured
 	// root path back to callers, but fsx needs to provide Root().
 	root AbsPath
@@ -74,7 +86,7 @@ type FS struct {
 func MemMap(root AbsPath) (FS, error) {
 	backing := afero.NewMemMapFs()
 	if err := backing.MkdirAll(root.String(), 0o755); err != nil {
-		return FS{}, errorx.Wrapf("+stacks", err, "create fs root %s", root)
+		return nil, errorx.Wrapf("+stacks", err, "create fs root %s", root)
 	}
 	base, ok := backing.(BaseFS)
 	assert.Invariantf(ok, "NewMemMapFs return value should implement BaseFS, but got type %T", backing)
@@ -87,19 +99,19 @@ func MemMap(root AbsPath) (FS, error) {
 func NewRootedFS(root AbsPath, backing BaseFS) (FS, error) {
 	info, err := backing.Stat(root.String())
 	if err != nil {
-		return FS{}, errorx.Wrapf("+stacks", err, "stat fs root %s", root)
+		return nil, errorx.Wrapf("+stacks", err, "stat fs root %s", root)
 	}
 	if !info.IsDir() {
-		return FS{}, errorx.Newf("nostack", "fs root %s is not a directory", root)
+		return nil, errorx.Newf("nostack", "fs root %s is not a directory", root)
 	}
 
 	rootedBase, ok := afero.NewBasePathFs(backing, root.String()).(BaseFS)
 	assert.Invariantf(ok, "NewBasePathFs return value should implement BaseFS, but got type %T", backing)
-	return FS{root: root, base: rootedBase}, nil
+	return rootedFS{root: root, base: rootedBase}, nil
 }
 
 // Root returns the absolute path this FS is rooted at.
-func (fs FS) Root() AbsPath {
+func (fs rootedFS) Root() AbsPath {
 	return fs.root
 }
 
@@ -108,7 +120,7 @@ func (fs FS) Root() AbsPath {
 // Errors produced mid-iteration are surfaced as [Failure] elements
 // rather than being returned eagerly. Callers should stop iterating on the
 // first failure.
-func (fs FS) ReadDir(rel RelPath) iter.Seq[Result[DirEntry]] {
+func (fs rootedFS) ReadDir(rel RelPath) iter.Seq[Result[DirEntry]] {
 	return iterx.Map(iterx.Unbatch(fs.readDirBatches(rel)), func(entryRes Result[iofs.DirEntry]) Result[DirEntry] {
 		entry, err := entryRes.Get()
 		if err != nil {
@@ -118,7 +130,7 @@ func (fs FS) ReadDir(rel RelPath) iter.Seq[Result[DirEntry]] {
 	})
 }
 
-func (fs FS) readDirBatches(rel RelPath) iter.Seq[Result[[]iofs.DirEntry]] {
+func (fs rootedFS) readDirBatches(rel RelPath) iter.Seq[Result[[]iofs.DirEntry]] {
 	return func(yield func(Result[[]iofs.DirEntry]) bool) {
 		f, err := fs.base.Open(rel.String())
 		if err != nil {
@@ -158,23 +170,23 @@ func (fs FS) readDirBatches(rel RelPath) iter.Seq[Result[[]iofs.DirEntry]] {
 }
 
 // Open opens the file at the given root-relative path for reading.
-func (fs FS) Open(rel RelPath) (File, error) {
+func (fs rootedFS) Open(rel RelPath) (File, error) {
 	return fs.base.Open(rel.String())
 }
 
 // ReadFile reads the file at the given root-relative path.
-func (fs FS) ReadFile(rel RelPath) ([]byte, error) {
+func (fs rootedFS) ReadFile(rel RelPath) ([]byte, error) {
 	return afero.ReadFile(fs.base, rel.String())
 }
 
 // WriteFile writes data to the file at the given root-relative path.
-func (fs FS) WriteFile(rel RelPath, data []byte, perm os.FileMode) error {
+func (fs rootedFS) WriteFile(rel RelPath, data []byte, perm os.FileMode) error {
 	return afero.WriteFile(fs.base, rel.String(), data, perm)
 }
 
 // MkdirAll creates the directory at the given root-relative path along with
 // any necessary parents.
-func (fs FS) MkdirAll(rel RelPath, perm os.FileMode) error {
+func (fs rootedFS) MkdirAll(rel RelPath, perm os.FileMode) error {
 	return fs.base.MkdirAll(rel.String(), perm)
 }
 
@@ -182,7 +194,7 @@ func (fs FS) MkdirAll(rel RelPath, perm os.FileMode) error {
 // whose name begins with pattern, and returns the resulting root-relative path.
 //
 // Pre-condition: pattern is non-empty and contains no path separators.
-func (fs FS) MkdirTemp(dir RelPath, pattern string) (RelPath, error) {
+func (fs rootedFS) MkdirTemp(dir RelPath, pattern string) (RelPath, error) {
 	assert.Preconditionf(pattern != "", "pattern is empty")
 	assert.Preconditionf(!pathx.HasPathSeparators(pattern), "pattern contains path separator: %q", pattern)
 	// afero.TempDir returns filepath.Join(dir, pattern+rand) relative to fs.base,
@@ -196,6 +208,6 @@ func (fs FS) MkdirTemp(dir RelPath, pattern string) (RelPath, error) {
 
 // RemoveAll removes the file or directory at the given root-relative path
 // along with any children it contains.
-func (fs FS) RemoveAll(rel RelPath) error {
+func (fs rootedFS) RemoveAll(rel RelPath) error {
 	return fs.base.RemoveAll(rel.String())
 }

--- a/common/fsx/fsx_testkit/fsx_testkit.go
+++ b/common/fsx/fsx_testkit/fsx_testkit.go
@@ -2,26 +2,22 @@
 package fsx_testkit
 
 import (
+	"iter"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 
-	"github.com/spf13/afero" //nolint:depguard // fsx_testkit needs to build test backing filesystems.
-
-	"github.com/typesanitizer/happygo/common/assert"
 	"github.com/typesanitizer/happygo/common/check"
 	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/errorx"
 	"github.com/typesanitizer/happygo/common/fsx"
 )
 
-func NewMemFS(h check.Harness, tree map[string]string) fsx.FS {
+func NewMemFS(h check.Harness) fsx.FS {
 	h.T().Helper()
 	root := FakeRoot()
 	fs, err := fsx.MemMap(root)
 	h.NoErrorf(err, "MemMap(%q)", root)
-	WriteTree(h, fs, tree)
 	return fs
 }
 
@@ -45,19 +41,11 @@ func WriteTree(h check.Harness, fs fsx.FS, tree map[string]string) {
 	}
 }
 
-// NewFaultyFS returns an in-memory fsx.FS rooted at root that injects
-// failures for configured operations.
-func NewFaultyFS(h check.Harness, root AbsPath, tree map[string]string, faults ...Fault) fsx.FS {
+// NewFaultyFS returns an fsx.FS wrapper that injects failures for configured
+// operations.
+func NewFaultyFS(h check.Harness, base fsx.FS, faults ...Fault) fsx.FS {
 	h.T().Helper()
-	backing, ok := afero.NewMemMapFs().(fsx.BaseFS)
-	h.Assertf(ok, "NewMemMapFs() = %T, want fsx.BaseFS", backing)
-	h.NoErrorf(backing.MkdirAll(root.String(), 0o755), "MkdirAll(%q)", root)
-	memMapFS, err := fsx.NewRootedFS(root, backing)
-	h.NoErrorf(err, "NewRootedFS(%q)", root)
-	WriteTree(h, memMapFS, tree)
-	fs, err := fsx.NewRootedFS(root, newFaultyBaseFS(backing, root, faults...))
-	h.NoErrorf(err, "NewRootedFS(%q, FaultyFS)", root)
-	return fs
+	return newFaultyFS(base, faults...)
 }
 
 // FaultOp identifies the filesystem operation to fail.
@@ -74,46 +62,52 @@ type Fault struct {
 	Rel RelPath
 }
 
-// faultyFS wraps an fsx.BaseFS and injects failures for configured operations.
+// faultyFS wraps an fsx.FS and injects failures for configured operations.
 type faultyFS struct {
-	fsx.BaseFS
-	root   AbsPath
+	fsx.FS
 	faults map[Fault]struct{}
 }
 
-func newFaultyBaseFS(base fsx.BaseFS, root AbsPath, faults ...Fault) *faultyFS {
+func newFaultyFS(base fsx.FS, faults ...Fault) *faultyFS {
 	faultSet := make(map[Fault]struct{}, len(faults))
 	for _, f := range faults {
 		faultSet[f] = struct{}{}
 	}
-	return &faultyFS{BaseFS: base, root: root, faults: faultSet}
+	return &faultyFS{FS: base, faults: faultSet}
 }
 
-func (fs *faultyFS) Stat(absPath string) (os.FileInfo, error) {
-	if fs.hasFault(FaultOp_Stat, absPath) {
+func (fs *faultyFS) Stat(rel RelPath, opts fsx.StatOptions) (os.FileInfo, error) {
+	if fs.hasFault(FaultOp_Stat, rel) {
 		return nil, injectedFSError()
 	}
-	return fs.BaseFS.Stat(absPath)
+	return fs.FS.Stat(rel, opts)
 }
 
-func (fs *faultyFS) LstatIfPossible(absPath string) (os.FileInfo, bool, error) {
-	if fs.hasFault(FaultOp_Stat, absPath) {
-		return nil, false, injectedFSError()
-	}
-	return fs.BaseFS.LstatIfPossible(absPath)
-}
-
-func (fs *faultyFS) Open(absPath string) (fsx.File, error) {
-	if fs.hasFault(FaultOp_Open, absPath) {
+func (fs *faultyFS) Open(rel RelPath) (fsx.File, error) {
+	if fs.hasFault(FaultOp_Open, rel) {
 		return nil, injectedFSError()
 	}
-	return fs.BaseFS.Open(absPath)
+	return fs.FS.Open(rel)
 }
 
-func (fs *faultyFS) hasFault(op FaultOp, absPath string) bool {
-	rel, err := filepath.Rel(fs.root.String(), absPath)
-	assert.Invariantf(err == nil, "filepath.Rel(%q, %q): %v", fs.root, absPath, err)
-	_, hit := fs.faults[Fault{Op: op, Rel: NewRelPath(rel)}]
+func (fs *faultyFS) ReadFile(rel RelPath) ([]byte, error) {
+	if fs.hasFault(FaultOp_Open, rel) {
+		return nil, injectedFSError()
+	}
+	return fs.FS.ReadFile(rel)
+}
+
+func (fs *faultyFS) ReadDir(rel RelPath) iter.Seq[Result[fsx.DirEntry]] {
+	if fs.hasFault(FaultOp_Open, rel) {
+		return func(yield func(Result[fsx.DirEntry]) bool) {
+			yield(Failure[fsx.DirEntry](injectedFSError()))
+		}
+	}
+	return fs.FS.ReadDir(rel)
+}
+
+func (fs *faultyFS) hasFault(op FaultOp, rel RelPath) bool {
+	_, hit := fs.faults[Fault{Op: op, Rel: rel}]
 	return hit
 }
 

--- a/common/fsx/fsx_walk/walk_test.go
+++ b/common/fsx/fsx_walk/walk_test.go
@@ -36,7 +36,8 @@ func TestWalk(t *testing.T) {
 		h.Run("SkipSubtree", func(h check.Harness) {
 			h.Parallel()
 
-			fs := fsx_testkit.NewMemFS(h, map[string]string{
+			fs := fsx_testkit.NewMemFS(h)
+			fsx_testkit.WriteTree(h, fs, map[string]string{
 				"a/":           "",
 				"a/skip/":      "",
 				"a/skip/y.txt": "y",
@@ -83,7 +84,8 @@ func testGitIgnore(h check.Harness) {
 	h.Run("RespectGitIgnore", func(h check.Harness) {
 		h.Parallel()
 
-		fs := fsx_testkit.NewMemFS(h, map[string]string{
+		fs := fsx_testkit.NewMemFS(h)
+		fsx_testkit.WriteTree(h, fs, map[string]string{
 			".git": "gitdir: root\n",
 			".gitignore": `.git
 ignored/
@@ -109,7 +111,8 @@ ignored/
 	h.Run("RequiresFSRootRepo", func(h check.Harness) {
 		h.Parallel()
 
-		fs := fsx_testkit.NewMemFS(h, map[string]string{
+		fs := fsx_testkit.NewMemFS(h)
+		fsx_testkit.WriteTree(h, fs, map[string]string{
 			".gitignore": "*.txt\n",
 			"file.txt":   "x",
 		})
@@ -135,7 +138,8 @@ func testFaults(h check.Harness) {
 	h.Run("InitialRootStat", func(h check.Harness) {
 		h.Parallel()
 
-		fs := fsx_testkit.NewMemFS(h, map[string]string{"a.txt": "a"})
+		fs := fsx_testkit.NewMemFS(h)
+		fsx_testkit.WriteTree(h, fs, map[string]string{"a.txt": "a"})
 		h.NoErrorf(fs.RemoveAll(pathx.Dot()), "RemoveAll(.)")
 
 		_, err := fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: false})
@@ -149,7 +153,7 @@ func testFaults(h check.Harness) {
 	h.Run("InitialGitStat", func(h check.Harness) {
 		h.Parallel()
 
-		fs := fsx_testkit.NewFaultyFS(h, fsx_testkit.FakeRoot(), map[string]string{}, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Stat, Rel: pathx.NewRelPath(".git")})
+		fs := fsx_testkit.NewFaultyFS(h, fsx_testkit.NewMemFS(h), fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Stat, Rel: pathx.NewRelPath(".git")})
 
 		_, err := fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true})
 		_ = requireWalkError(h, err, fsx_walk.WalkErrorKind_IOFailed)
@@ -158,10 +162,12 @@ func testFaults(h check.Harness) {
 	h.Run("IterateGitStat", func(h check.Harness) {
 		h.Parallel()
 
-		fs := fsx_testkit.NewFaultyFS(h, fsx_testkit.FakeRoot(), map[string]string{
+		baseFS := fsx_testkit.NewMemFS(h)
+		fsx_testkit.WriteTree(h, baseFS, map[string]string{
 			".git": "gitdir: root\n",
 			"a/":   "",
-		}, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Stat, Rel: pathx.NewRelPath("a/.git")})
+		})
+		fs := fsx_testkit.NewFaultyFS(h, baseFS, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Stat, Rel: pathx.NewRelPath("a/.git")})
 
 		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
 		_ = requireWalkError(h, firstWalkError(h, entries), fsx_walk.WalkErrorKind_IOFailed)
@@ -170,10 +176,12 @@ func testFaults(h check.Harness) {
 	h.Run("IterateGitIgnoreRead", func(h check.Harness) {
 		h.Parallel()
 
-		fs := fsx_testkit.NewFaultyFS(h, fsx_testkit.FakeRoot(), map[string]string{
+		baseFS := fsx_testkit.NewMemFS(h)
+		fsx_testkit.WriteTree(h, baseFS, map[string]string{
 			".git": "gitdir: root\n",
 			"a/":   "",
-		}, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Open, Rel: pathx.NewRelPath("a/.gitignore")})
+		})
+		fs := fsx_testkit.NewFaultyFS(h, baseFS, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Open, Rel: pathx.NewRelPath("a/.gitignore")})
 
 		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
 		_ = requireWalkError(h, firstWalkError(h, entries), fsx_walk.WalkErrorKind_IOFailed)
@@ -182,9 +190,11 @@ func testFaults(h check.Harness) {
 	h.Run("IterateReadDir", func(h check.Harness) {
 		h.Parallel()
 
-		fs := fsx_testkit.NewFaultyFS(h, fsx_testkit.FakeRoot(), map[string]string{
+		baseFS := fsx_testkit.NewMemFS(h)
+		fsx_testkit.WriteTree(h, baseFS, map[string]string{
 			"a/": "",
-		}, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Open, Rel: pathx.NewRelPath("a")})
+		})
+		fs := fsx_testkit.NewFaultyFS(h, baseFS, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Open, Rel: pathx.NewRelPath("a")})
 
 		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: false}))(h)
 		_ = requireWalkError(h, firstWalkError(h, entries), fsx_walk.WalkErrorKind_IOFailed)
@@ -192,7 +202,8 @@ func testFaults(h check.Harness) {
 }
 
 func testGitIgnore_OnExplicitSubtree(h check.Harness) {
-	fs := fsx_testkit.NewMemFS(h, map[string]string{
+	fs := fsx_testkit.NewMemFS(h)
+	fsx_testkit.WriteTree(h, fs, map[string]string{
 		".git": "gitdir: root\n",
 		".gitignore": `.git
 blocked/
@@ -245,7 +256,8 @@ blocked/
 }
 
 func testGitIgnore_ResetsAtNestedRepo(h check.Harness) {
-	fs := fsx_testkit.NewMemFS(h, map[string]string{
+	fs := fsx_testkit.NewMemFS(h)
+	fsx_testkit.WriteTree(h, fs, map[string]string{
 		".git": "gitdir: root\n",
 		".gitignore": `.git
 *.txt
@@ -283,7 +295,8 @@ func testGitIgnore_ResetsAtNestedRepo(h check.Harness) {
 func testGitIgnore_SkipsIgnoredNestedRepo(h check.Harness) {
 	h.Parallel()
 
-	fs := fsx_testkit.NewMemFS(h, map[string]string{
+	fs := fsx_testkit.NewMemFS(h)
+	fsx_testkit.WriteTree(h, fs, map[string]string{
 		".git": "gitdir: root\n",
 		".gitignore": `.git
 nested/
@@ -302,7 +315,8 @@ nested/
 func testGitIgnore_PreservesAllParseErrors(h check.Harness) {
 	h.Parallel()
 
-	fs := fsx_testkit.NewMemFS(h, map[string]string{
+	fs := fsx_testkit.NewMemFS(h)
+	fsx_testkit.WriteTree(h, fs, map[string]string{
 		".git": "gitdir: root\n",
 		".gitignore": `!
 ** *
@@ -335,7 +349,8 @@ func testGitIgnore_PreservesAllParseErrors(h check.Harness) {
 func testGitIgnore_ConcurrentSiblingWarnings(h check.Harness) {
 	h.Parallel()
 
-	fs := fsx_testkit.NewMemFS(h, map[string]string{
+	fs := fsx_testkit.NewMemFS(h)
+	fsx_testkit.WriteTree(h, fs, map[string]string{
 		".git":         "gitdir: root\n",
 		"a/":           "",
 		"a/.gitignore": "!\n",

--- a/common/fsx/stat.go
+++ b/common/fsx/stat.go
@@ -19,7 +19,7 @@ import (
 // opts.OnErrorTraverseParents is true, StatError.ShortestMissing() returns the
 // shallowest ancestor that does not exist. Otherwise, ShortestMissing()
 // returns rel.
-func (fs FS) Stat(rel RelPath, opts StatOptions) (os.FileInfo, error) {
+func (fs rootedFS) Stat(rel RelPath, opts StatOptions) (os.FileInfo, error) {
 	var info os.FileInfo
 	var err error
 	if opts.FollowFinalSymlink {


### PR DESCRIPTION
The code ends up being a bit more verbose,
but this avoids coupling the initialization
with construction, so there's only ~one way
to create a tree, that's through WriteTree.