### PR TITLE
chore(check): Remove filesystem APIs from Harness

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,10 @@ linters:
           files:
             - $all
             - "!**/main.go"
+            # depguard special syntax: $test matches all *_test.go files.
+            # See https://golangci-lint.run/docs/linters/configuration/#depguard
             - "!$test"
+            - "!**/*_testkit/*.go"
           list-mode: lax
           deny:
             - pkg: "github.com/typesanitizer/happygo/common/syscaps$"

--- a/common/check/check.go
+++ b/common/check/check.go
@@ -3,8 +3,6 @@ package check
 
 import (
 	"flag"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -131,38 +129,6 @@ func AssertSame[T any](h BasicHarness, want, got T, what string, opts ...cmp.Opt
 	if diff := cmp.Diff(want, got, allOpts...); diff != "" {
 		h.Assertf(false, "%s mismatch (-want +got):\n%s", what, diff)
 	}
-}
-
-// WriteTree creates files and directories under root from a map.
-// Keys ending in "/" create directories (value must be "").
-// Other keys create files with the value as content.
-// All paths must be relative and stay within root.
-func (h Harness) WriteTree(rootStr string, tree map[string]string) {
-	h.t.Helper()
-	root, err := pathx.ResolveAbsPath(rootStr)
-	h.NoErrorf(err, "resolving absolute path for %q", rootStr)
-	for path, content := range tree {
-		h.Assertf(!filepath.IsAbs(path), "path %q must be relative to root %q", path, root.String())
-		rel := NewRelPath(path)
-		full := root.Join(rel)
-		h.Assertf(full.MakeRelativeTo(root).IsSome(), "path %q escapes root %q", path, root.String())
-		if strings.HasSuffix(path, "/") {
-			h.Assertf(content == "", "directory path %q must have empty content", path)
-			h.NoErrorf(full.MkdirAll(0o755), "creating directory %s", full.String())
-			continue
-		}
-		h.NoErrorf(full.Dir().MkdirAll(0o755), "creating parent directory for %s", full.String())
-		h.NoErrorf(full.WriteFile([]byte(content), 0o644), "writing file %s", full.String())
-	}
-}
-
-// WriteFile writes a single file, creating parent directories as needed.
-func (h Harness) WriteFile(path string, content string) {
-	h.t.Helper()
-	absPath, err := pathx.ResolveAbsPath(path)
-	h.NoErrorf(err, "resolving absolute path for %q", path)
-	dir, file := absPath.Split()
-	h.WriteTree(dir.String(), map[string]string{file: content})
 }
 
 // InputPath keeps both user-provided and resolved path forms.

--- a/common/envx/envx_path/find_executable_test.go
+++ b/common/envx/envx_path/find_executable_test.go
@@ -150,9 +150,8 @@ func testFindExecutableErrorCases(h check.Harness) {
 
 		fs := newMemFS(h, fakeRoot.JoinComponents("non-executable-candidates"))
 		binRel := NewRelPath("bin")
-		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
 		exeRel := binRel.JoinComponents(exe.Name)
-		h.NoErrorf(fs.WriteFile(exeRel, []byte("#!/bin/sh\n"), 0o644), "WriteFile(%q)", exeRel)
+		fsx_testkit.WriteFile(h, fs, exeRel, "#!/bin/sh\n")
 
 		env := testEnv(map[string]string{"PATH": fs.Root().Join(binRel).String()})
 		_, err := envx_path.FindExecutable(fs, env, exe.LookupName)

--- a/common/fsx/fsx_testkit/fsx_testkit.go
+++ b/common/fsx/fsx_testkit/fsx_testkit.go
@@ -11,7 +11,16 @@ import (
 	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/errorx"
 	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/syscaps"
 )
+
+// TempDirFS returns a host FS rooted at a new test temporary directory.
+func TempDirFS(h check.Harness) fsx.FS {
+	h.T().Helper()
+	fs, err := syscaps.FS(NewAbsPath(h.T().TempDir()))
+	h.NoErrorf(err, "FS(TempDir())")
+	return fs
+}
 
 func NewMemFS(h check.Harness) fsx.FS {
 	h.T().Helper()
@@ -19,6 +28,15 @@ func NewMemFS(h check.Harness) fsx.FS {
 	fs, err := fsx.MemMap(root)
 	h.NoErrorf(err, "MemMap(%q)", root)
 	return fs
+}
+
+// WriteFile writes a single file, creating parent directories as needed.
+func WriteFile(h check.Harness, fs fsx.FS, path RelPath, content string) {
+	h.T().Helper()
+	if dir, ok := path.Dir().Get(); ok {
+		h.NoErrorf(fs.MkdirAll(dir, 0o755), "MkdirAll(%q)", dir)
+	}
+	h.NoErrorf(fs.WriteFile(path, []byte(content), 0o644), "WriteFile(%q)", path)
 }
 
 // WriteTree creates files and directories in fs from a map.
@@ -34,10 +52,7 @@ func WriteTree(h check.Harness, fs fsx.FS, tree map[string]string) {
 			h.NoErrorf(fs.MkdirAll(rel, 0o755), "MkdirAll(%q)", rel)
 			continue
 		}
-		if dir, ok := rel.Dir().Get(); ok {
-			h.NoErrorf(fs.MkdirAll(dir, 0o755), "MkdirAll(%q)", dir)
-		}
-		h.NoErrorf(fs.WriteFile(rel, []byte(content), 0o644), "WriteFile(%q)", rel)
+		WriteFile(h, fs, rel, content)
 	}
 }
 

--- a/common/fsx/fsx_walk/walk_test.go
+++ b/common/fsx/fsx_walk/walk_test.go
@@ -58,8 +58,9 @@ func TestWalk(t *testing.T) {
 		h.Run("SymlinkNotFollowed", func(h check.Harness) {
 			h.Parallel()
 
-			parent := h.T().TempDir()
-			h.WriteTree(parent, map[string]string{"target/file.txt": "x"})
+			parentFS := fsx_testkit.TempDirFS(h)
+			parent := parentFS.Root().String()
+			fsx_testkit.WriteTree(h, parentFS, map[string]string{"target/file.txt": "x"})
 
 			target := filepath.Join(parent, "target")
 			link := filepath.Join(parent, "link")

--- a/common/syscaps/syscaps_test.go
+++ b/common/syscaps/syscaps_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/typesanitizer/happygo/common/collections"
 	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/core/pathx"
+	"github.com/typesanitizer/happygo/common/fsx/fsx_testkit"
 	"github.com/typesanitizer/happygo/common/internal/constants"
-	"github.com/typesanitizer/happygo/common/syscaps"
 )
 
 func TestFSReadDirBatched(t *testing.T) {
 	h := check.New(t)
 	h.Parallel()
 
-	repoFS := Do(syscaps.FS(NewAbsPath(t.TempDir())))(h)
+	repoFS := fsx_testkit.TempDirFS(h)
 
 	rapid.Check(h.T(), func(t *rapid.T) {
 		h := check.NewBasic(t)
@@ -55,7 +55,7 @@ func TestFSReadDirOnFileReturnsError(t *testing.T) {
 	h := check.New(t)
 	h.Parallel()
 
-	repoFS := Do(syscaps.FS(NewAbsPath(t.TempDir())))(h)
+	repoFS := fsx_testkit.TempDirFS(h)
 
 	fileRel := NewRelPath("file.txt")
 	h.NoErrorf(repoFS.WriteFile(fileRel, []byte("data"), 0o644), "WriteFile(%q)", fileRel)
@@ -73,7 +73,7 @@ func TestFSMkdirTempRejectsEmptyPattern(t *testing.T) {
 	h := check.New(t)
 	h.Parallel()
 
-	repoFS := Do(syscaps.FS(NewAbsPath(t.TempDir())))(h)
+	repoFS := fsx_testkit.TempDirFS(h)
 	want := assert.AssertionError{Fmt: "precondition violation: pattern is empty", Args: nil}
 	h.AssertPanicsWith(want, func() {
 		_, _ = repoFS.MkdirTemp(pathx.Dot(), "")

--- a/misc/cmd/happydo/list_test.go
+++ b/misc/cmd/happydo/list_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 
 	"github.com/typesanitizer/happygo/common/check"
-	. "github.com/typesanitizer/happygo/common/check/prelude"
-	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/envx"
 	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/fsx/fsx_testkit"
 	"github.com/typesanitizer/happygo/common/logx"
 	"github.com/typesanitizer/happygo/common/syscaps"
 	"github.com/typesanitizer/happygo/misc/internal/config"
@@ -19,16 +18,14 @@ func TestList(t *testing.T) {
 	h := check.New(t)
 	h.Parallel()
 
-	root := t.TempDir()
-	h.WriteTree(root, map[string]string{
+	repoFS := fsx_testkit.TempDirFS(h)
+	fsx_testkit.WriteTree(h, repoFS, map[string]string{
 		"alpha/go.mod": "module alpha\n",
 		"beta/go.mod":  "module beta\n",
 		"gamma/go.mod": "module gamma\n",
 		"delta/":       "",
 		"file.txt":     "not a dir\n",
 	})
-
-	repoFS := Do(syscaps.FS(NewAbsPath(root)))(h)
 
 	ws := Workspace{
 		FS:     repoFS,


### PR DESCRIPTION
We want to get rid of APIs which make use of ambient authority.

While test packages, files and (now) `_testkit` packages
are exempt from this, it's generally a good idea for test
code to also follow the pattern of passing around a
filesystem value, because it will need that anyway when
invoking production code.