### PR TITLE
chore(pathx): Remove AbsPath APIs using ambient authority

### DIFF
--- a/common/core/pathx/pathx.go
+++ b/common/core/pathx/pathx.go
@@ -7,7 +7,6 @@ package pathx
 
 import (
 	"iter"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -36,38 +35,36 @@ func (p AbsPath) String() string {
 	return p.value
 }
 
-func (p AbsPath) Dir() AbsPath {
-	return NewAbsPath(filepath.Dir(p.value))
+// Dir returns the parent directory of p, or None if p is a filesystem root.
+func (p AbsPath) Dir() option.Option[AbsPath] {
+	rootLen := p.rootLen()
+	if len(p.value) == rootLen {
+		return option.None[AbsPath]()
+	}
+	if IsPathSeparator(p.value[len(p.value)-1]) {
+		return option.Some(AbsPath{p.value[:len(p.value)-1]})
+	}
+	lastSep := len(p.value) - 1
+	for lastSep >= rootLen && !IsPathSeparator(p.value[lastSep]) {
+		lastSep--
+	}
+	if lastSep < rootLen {
+		return option.Some(AbsPath{p.value[:rootLen]})
+	}
+	return option.Some(AbsPath{p.value[:lastSep]})
+}
+
+func (p AbsPath) rootLen() int {
+	rootLen := len(filepath.VolumeName(p.value))
+	if rootLen < len(p.value) && IsPathSeparator(p.value[rootLen]) {
+		rootLen++
+	}
+	return rootLen
 }
 
 func (p AbsPath) Split() (AbsPath, string) {
 	dir, file := filepath.Split(p.value)
 	return NewAbsPath(dir), file
-}
-
-// ResolveAbsPath resolves a possibly-relative path to an AbsPath
-// using [filepath.Abs].
-//
-// Pre-condition: path is non-empty.
-func ResolveAbsPath(path string) (AbsPath, error) {
-	assert.Preconditionf(path != "", "path is empty")
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return AbsPath{}, err
-	}
-	return NewAbsPath(absPath), nil
-}
-
-func (p AbsPath) MkdirAll(perm os.FileMode) error {
-	return os.MkdirAll(p.value, perm)
-}
-
-func (p AbsPath) ReadFile() ([]byte, error) {
-	return os.ReadFile(p.value)
-}
-
-func (p AbsPath) WriteFile(data []byte, perm os.FileMode) error {
-	return os.WriteFile(p.value, data, perm)
 }
 
 // LexicallyContains reports whether child is lexically contained within p.

--- a/common/core/pathx/pathx_test.go
+++ b/common/core/pathx/pathx_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/typesanitizer/happygo/common/assert"
 	"github.com/typesanitizer/happygo/common/check"
-	. "github.com/typesanitizer/happygo/common/check/prelude"
 	"github.com/typesanitizer/happygo/common/core/option"
 	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/core/pathx/pathx_testkit"
@@ -229,6 +228,59 @@ func TestLexicallyContains(t *testing.T) {
 	}
 }
 
+func TestAbsPathDir(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("Unix", func(h check.Harness) {
+		h.Parallel()
+		if runtime.GOOS == "windows" {
+			h.T().Skip("Unix path semantics")
+		}
+		tests := []struct {
+			path string
+			want option.Option[string]
+		}{
+			{path: "/", want: option.None[string]()},
+			{path: "/a", want: option.Some("/")},
+			{path: "/a/b", want: option.Some("/a")},
+			{path: "/a/b/", want: option.Some("/a/b")},
+		}
+		for _, tt := range tests {
+			h.Run(tt.path, func(h check.Harness) {
+				dir, ok := pathx.NewAbsPath(tt.path).Dir().Get()
+				got := option.NewOption(dir.String(), ok)
+				h.Assertf(option.Compare(tt.want, got) == 0,
+					"Dir(%q) = %v, want %v", tt.path, got, tt.want)
+			})
+		}
+	})
+
+	h.Run("Windows", func(h check.Harness) {
+		h.Parallel()
+		if runtime.GOOS != "windows" {
+			h.T().Skip("Windows path semantics")
+		}
+		tests := []struct {
+			path string
+			want option.Option[string]
+		}{
+			{path: `C:\`, want: option.None[string]()},
+			{path: `C:\a`, want: option.Some(`C:\`)},
+			{path: `C:\a\b`, want: option.Some(`C:\a`)},
+			{path: `C:\a\b\`, want: option.Some(`C:\a\b`)},
+		}
+		for _, tt := range tests {
+			h.Run(tt.path, func(h check.Harness) {
+				dir, ok := pathx.NewAbsPath(tt.path).Dir().Get()
+				got := option.NewOption(dir.String(), ok)
+				h.Assertf(option.Compare(tt.want, got) == 0,
+					"Dir(%q) = %v, want %v", tt.path, got, tt.want)
+			})
+		}
+	})
+}
+
 func TestRelPathDir(t *testing.T) {
 	h := check.New(t)
 	h.Parallel()
@@ -425,11 +477,6 @@ func TestPathFormatting(t *testing.T) {
 	}
 }
 
-func TestResolveAbsPath(t *testing.T) {
-	h := check.New(t)
-	_ = Do(pathx.ResolveAbsPath("."))(h)
-}
-
 func TestRejectsEmptyPaths(t *testing.T) {
 	h := check.New(t)
 	want := assert.AssertionError{Fmt: "precondition violation: path is empty", Args: nil}
@@ -440,7 +487,6 @@ func TestRejectsEmptyPaths(t *testing.T) {
 	}{
 		{name: "NewAbsPath", call: func() { _ = pathx.NewAbsPath("") }},
 		{name: "NewRelPath", call: func() { _ = pathx.NewRelPath("") }},
-		{name: "ResolveAbsPath", call: func() { _, _ = pathx.ResolveAbsPath("") }},
 	}
 
 	for _, tt := range tests {

--- a/common/fsx/fsx_walk/example_test.go
+++ b/common/fsx/fsx_walk/example_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/core/result"
 	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/fsx/fsx_testkit"
 	"github.com/typesanitizer/happygo/common/fsx/fsx_walk"
 )
 
@@ -17,10 +18,7 @@ import (
 // instead of recursion. This pattern is useful when recursion depth
 // is unbounded or when descent decisions depend on caller state.
 func Example_iterative() {
-	root, err := pathx.ResolveAbsPath("example-root")
-	if err != nil {
-		panic(err)
-	}
+	root := fsx_testkit.FakeRoot().JoinComponents("example-root")
 	fs, err := fsx.MemMap(root)
 	if err != nil {
 		panic(err)

--- a/common/syscaps/syscaps.go
+++ b/common/syscaps/syscaps.go
@@ -33,6 +33,15 @@ func Env() envx.Env {
 	})
 }
 
+// WorkingDirectory returns the process working directory.
+func WorkingDirectory() (AbsPath, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return AbsPath{}, err
+	}
+	return NewAbsPath(wd), nil
+}
+
 // FS returns a rooted filesystem backed by the host operating system.
 func FS(root AbsPath) (fsx.FS, error) {
 	base, ok := afero.NewOsFs().(fsx.BaseFS)

--- a/misc/mappings_test.go
+++ b/misc/mappings_test.go
@@ -2,8 +2,6 @@ package misc_test
 
 import (
 	"maps"
-	"os"
-	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -15,8 +13,9 @@ import (
 	"github.com/typesanitizer/happygo/common/check"
 	. "github.com/typesanitizer/happygo/common/check/prelude"
 	"github.com/typesanitizer/happygo/common/collections"
-	"github.com/typesanitizer/happygo/common/core/pathx"
+	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/iterx"
+	"github.com/typesanitizer/happygo/common/syscaps"
 	"github.com/typesanitizer/happygo/misc/internal/config"
 )
 
@@ -24,15 +23,18 @@ func TestWorkspaceConfig(t *testing.T) {
 	h := check.New(t)
 	h.Parallel()
 
-	f := DoMsg(os.Open("repo-configuration.json"))(h, "opening repo-configuration.json")
+	workingDir := DoMsg(syscaps.WorkingDirectory())(h, "resolving working directory")
+	repoRoot, ok := workingDir.Dir().Get()
+	h.Assertf(ok, "working directory %s must have a parent", workingDir)
+	repoFS := DoMsg(syscaps.FS(repoRoot))(h, "opening repo FS")
+
+	f := DoMsg(repoFS.Open(NewRelPath("misc/repo-configuration.json")))(h, "opening repo-configuration.json")
 	t.Cleanup(func() { _ = f.Close() })
 
 	wsConfig := Do(config.Load(f))(h)
 
 	configFolders := iterx.Collect(iterx.Map(maps.Keys(wsConfig.ForkedFolders), fsx.Name.String))
 	slices.Sort(configFolders)
-
-	repoRoot := DoMsg(pathx.ResolveAbsPath(".."))(h, "resolving repo root").String()
 
 	forkedProjects := map[string]config.GitHubRepo{
 		"go":    "golang/go",
@@ -62,7 +64,7 @@ func TestWorkspaceConfig(t *testing.T) {
 	h.Run("WorkflowProjectChoices", func(h check.Harness) {
 		h.Parallel()
 
-		workflowBytes := DoMsg(os.ReadFile(filepath.Join(repoRoot, ".github/workflows/upstream-sync.yml")))(h,
+		workflowBytes := DoMsg(repoFS.ReadFile(NewRelPath(".github/workflows/upstream-sync.yml")))(h,
 			"reading upstream-sync.yml")
 
 		var workflow struct {
@@ -90,7 +92,7 @@ func TestWorkspaceConfig(t *testing.T) {
 	h.Run("LinterExclusions", func(h check.Harness) {
 		h.Parallel()
 
-		lintBytes := DoMsg(os.ReadFile(filepath.Join(repoRoot, ".golangci.yml")))(h,
+		lintBytes := DoMsg(repoFS.ReadFile(NewRelPath(".golangci.yml")))(h,
 			"reading .golangci.yml")
 
 		var lintCfg struct {


### PR DESCRIPTION
We have capability-style APIs for the filesystem
which covers most things, so there's no need
to have these APIs on AbsPath which use ambient
authority.

It's also a bit dangerous to mix ambient authority
utilizing code with capability-passing code,
because you might expect that the code will be
limited to what capabilities you pass, but it does
something else behind your back.