### PR TITLE
chore(ci): Reduce artifact retention to 1 day

### DIFF
--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -85,3 +85,4 @@ runs:
       with:
         name: go-${{ inputs.toolchain }}-${{ inputs.os }}
         path: go-${{ inputs.toolchain }}-${{ inputs.os }}.tgz
+        retention-days: 1


### PR DESCRIPTION
Turns out, cache storage and artifact storage is a bit different,
and we somehow had 180GB+ of artifacts because of data uploaded
by one job for other downstream jobs.

Initially, I incorrectly assumed that artifacts would get
auto-deleted within a fairly quick period like 7 days.
