### PR TITLE
feat(cache): Add env var to tune build cache cleanup interval

### DIFF
--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -47,12 +47,16 @@ runs:
     - name: Build (unix)
       if: runner.os != 'Windows'
       shell: bash
+      env:
+        HAPPYGO_TRIM_CACHE_LIMIT: ${{ inputs.toolchain == 'head' && '24h' || '' }}
       # make.bash cannot be invoked from other directories.
       working-directory: go/src
       run: ./make.bash
     - name: Build (windows)
       if: runner.os == 'Windows'
       shell: pwsh
+      env:
+        HAPPYGO_TRIM_CACHE_LIMIT: ${{ inputs.toolchain == 'head' && '24h' || '' }}
       # .\make.bat cannot be invoked from other directories.
       working-directory: go/src
       run: .\make.bat

--- a/go/src/cmd/go/internal/cache/cache.go
+++ b/go/src/cmd/go/internal/cache/cache.go
@@ -341,14 +341,29 @@ func (c *DiskCache) OutputFile(out OutputID) string {
 // We scan the cache for entries to delete at most once per trimInterval (1 day).
 //
 // When we do scan the cache, we delete entries that have not been used for
-// at least trimLimit (5 days). Statistics gathered from a month of usage by
+// at least defaultTrimLimit (5 days). Statistics gathered from a month of usage by
 // Go developers found that essentially all reuse of cached entries happened
 // within 5 days of the previous reuse. See golang.org/issue/22990.
 const (
-	mtimeInterval = 1 * time.Hour
-	trimInterval  = 24 * time.Hour
-	trimLimit     = 5 * 24 * time.Hour
+	mtimeInterval    = 1 * time.Hour
+	trimInterval     = 24 * time.Hour
+	defaultTrimLimit = 5 * 24 * time.Hour
 )
+
+func trimLimit() (time.Duration, error) {
+	value := os.Getenv("HAPPYGO_TRIM_CACHE_LIMIT")
+	if value == "" {
+		return defaultTrimLimit, nil
+	}
+	limit, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid HAPPYGO_TRIM_CACHE_LIMIT: %w", err)
+	}
+	if limit < 0 {
+		return 0, fmt.Errorf("invalid HAPPYGO_TRIM_CACHE_LIMIT %q: must be non-negative", value)
+	}
+	return limit, nil
+}
 
 // markUsed makes a best-effort attempt to update mtime on file,
 // so that mtime reflects cache access time.
@@ -377,6 +392,10 @@ func (c *DiskCache) Close() error { return c.Trim() }
 // Trim removes old cache entries that are likely not to be reused.
 func (c *DiskCache) Trim() error {
 	now := c.now()
+	limit, err := trimLimit()
+	if err != nil {
+		return err
+	}
 
 	// We maintain in dir/trim.txt the time of the last completed cache trim.
 	// If the cache has been trimmed recently enough, do nothing.
@@ -406,7 +425,7 @@ func (c *DiskCache) Trim() error {
 
 	// Write the new timestamp before we start trimming to reduce the chance that multiple invocations
 	// try to trim at the same time, causing contention in CI (#76314).
-	err := lockedfile.Transform(filepath.Join(c.dir, "trim.txt"), func(data []byte) ([]byte, error) {
+	err = lockedfile.Transform(filepath.Join(c.dir, "trim.txt"), func(data []byte) ([]byte, error) {
 		if skipTrim(data) {
 			// The timestamp in the file no longer meets the criteria for us to
 			// do a trim. It must have been updated by another go command invocation
@@ -426,7 +445,7 @@ func (c *DiskCache) Trim() error {
 	// Trim each of the 256 subdirectories.
 	// We subtract an additional mtimeInterval
 	// to account for the imprecision of our "last used" mtimes.
-	cutoff := now.Add(-trimLimit - mtimeInterval)
+	cutoff := now.Add(-limit - mtimeInterval)
 	for i := 0; i < 256; i++ {
 		subdir := filepath.Join(c.dir, fmt.Sprintf("%02x", i))
 		c.trimSubdir(subdir, cutoff)

--- a/go/src/cmd/go/internal/cache/cache_test.go
+++ b/go/src/cmd/go/internal/cache/cache_test.go
@@ -11,6 +11,7 @@ import (
 	"internal/testenv"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -132,6 +133,56 @@ func dummyID(x int) [HashSize]byte {
 	var out [HashSize]byte
 	binary.LittleEndian.PutUint64(out[:], uint64(x))
 	return out
+}
+
+func TestCacheTrimLimitEnv(t *testing.T) {
+	t.Setenv("HAPPYGO_TRIM_CACHE_LIMIT", "24h")
+
+	dir := t.TempDir()
+	c, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	const start = 1000000000
+	now := int64(start)
+	c.now = func() time.Time { return time.Unix(now, 0) }
+
+	oldID := ActionID(dummyID(1))
+	if err := PutBytes(c, oldID, []byte("old")); err != nil {
+		t.Fatal(err)
+	}
+
+	now = start + 2*86400
+	recentID := ActionID(dummyID(2))
+	if err := PutBytes(c, recentID, []byte("recent")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Trim(); err != nil {
+		if testenv.SyscallIsNotSupported(err) {
+			t.Skipf("skipping: Trim is unsupported (%v)", err)
+		}
+		t.Fatal(err)
+	}
+	if _, err := c.Get(oldID); err == nil {
+		t.Fatal("Trim did not remove entry older than HAPPYGO_TRIM_CACHE_LIMIT")
+	}
+	if _, err := c.Get(recentID); err != nil {
+		t.Fatalf("Trim removed recent entry: %v", err)
+	}
+}
+
+func TestCacheTrimLimitEnvInvalid(t *testing.T) {
+	t.Setenv("HAPPYGO_TRIM_CACHE_LIMIT", "not-a-duration")
+
+	dir := t.TempDir()
+	c, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := c.Trim(); err == nil || !strings.Contains(err.Error(), "HAPPYGO_TRIM_CACHE_LIMIT") {
+		t.Fatalf("Trim error = %v, want HAPPYGO_TRIM_CACHE_LIMIT error", err)
+	}
 }
 
 func TestCacheTrim(t *testing.T) {


### PR DESCRIPTION
Right now, the GitHub Actions for Ubuntu and Windows end up
spending 1min+ and 3min+ on saving/restoring caches resp.
Here is the cache size broken down by mtime age on Ubuntu:

   6h-1d:  2649.3 MiB
   1d-2d:  3652.9 MiB
   3d-4d:  2608.4 MiB
   4d-5d:  2086.7 MiB
   5d-6d:   521.7 MiB

The 5d-6d limit comes about because of hard-coded 5 day trim
limit default. However, in all likelihood, the old cache keys
are not being used at all, because the compiler itself is
changing.

Per https://go.dev/issue/22990, it looks like the 5 day
default was based on timings measured on developers' machines.
However, this is arguably not appropriate for a CI where we're
automatically merging changes from upstream on a daily basis.

Instead of working around the fixed interval by doing our own
cleanup separately, we make the limit configurable and use that
in the CI pipeline. So the caches for HEAD jobs (not stable/gotip)
should see more aggressive cleanup after 1 day.
