### PR TITLE
chore(lint): Forbid import of core inside common/

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,6 +74,13 @@ linters:
           deny:
             - pkg: "github.com/typesanitizer/happygo/common/syscaps$"
               desc: "ambient system capabilities should only be accessed via common/syscaps at program edges or in tests"
+        NoCommonCoreInsideCommon:
+          files:
+            - "common/**/*.go"
+          list-mode: lax
+          deny:
+            - pkg: "github.com/typesanitizer/happygo/common/core$"
+              desc: "common/core is an aggregate convenience package for other modules; code under common/ should import smaller common/core/* packages directly"
     importas:
       no-unaliased: true
       alias:

--- a/common/check/check.go
+++ b/common/check/check.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/core/pathx"
 )
 
@@ -134,20 +133,20 @@ func AssertSame[T any](h BasicHarness, want, got T, what string, opts ...cmp.Opt
 
 // SnapshotFS is the filesystem capability needed by snapshots.
 type SnapshotFS interface {
-	ReadFile(RelPath) ([]byte, error)
-	WriteFile(RelPath, []byte, os.FileMode) error
-	MkdirAll(RelPath, os.FileMode) error
+	ReadFile(pathx.RelPath) ([]byte, error)
+	WriteFile(pathx.RelPath, []byte, os.FileMode) error
+	MkdirAll(pathx.RelPath, os.FileMode) error
 }
 
 // Snapshot holds a path for file-based snapshot comparison.
 type Snapshot struct {
 	harness Harness
 	fs      SnapshotFS
-	path    RelPath
+	path    pathx.RelPath
 }
 
 // SnapshotAt returns a Snapshot for the given path in fs.
-func (h Harness) SnapshotAt(fs SnapshotFS, path RelPath) Snapshot {
+func (h Harness) SnapshotAt(fs SnapshotFS, path pathx.RelPath) Snapshot {
 	h.t.Helper()
 	return Snapshot{harness: h, fs: fs, path: path}
 }

--- a/common/cmdx/cmd.go
+++ b/common/cmdx/cmd.go
@@ -3,29 +3,30 @@ package cmdx
 import (
 	"al.essio.dev/pkg/shellescape"
 
-	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/option"
+	"github.com/typesanitizer/happygo/common/core/pathx"
 )
 
 // Cmd describes a command invocation.
 type Cmd struct {
 	name string
 	args []string
-	dir  Option[AbsPath]
+	dir  option.Option[pathx.AbsPath]
 }
 
 // New creates a Cmd from argv (name followed by arguments).
 func New(argv ...string) Cmd {
-	return Cmd{name: argv[0], args: argv[1:], dir: None[AbsPath]()}
+	return Cmd{name: argv[0], args: argv[1:], dir: option.None[pathx.AbsPath]()}
 }
 
 // In returns a copy of the Cmd with the working directory set.
-func (cmd Cmd) In(dir AbsPath) Cmd {
-	cmd.dir = Some(dir)
+func (cmd Cmd) In(dir pathx.AbsPath) Cmd {
+	cmd.dir = option.Some(dir)
 	return cmd
 }
 
 // Dir returns the optional working directory.
-func (cmd Cmd) Dir() Option[AbsPath] { return cmd.dir }
+func (cmd Cmd) Dir() option.Option[pathx.AbsPath] { return cmd.dir }
 
 // Argv returns the full command as [name, args...].
 func (cmd Cmd) Argv() []string {

--- a/common/collections/monotone_map.go
+++ b/common/collections/monotone_map.go
@@ -3,8 +3,8 @@ package collections
 import (
 	"iter"
 
-	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/core/op"
+	"github.com/typesanitizer/happygo/common/core/option"
 )
 
 // MonotoneMap is a mutable map that preserves insertion order of keys,
@@ -50,9 +50,9 @@ func (m MonotoneMap[K, V]) CloneWithout(omit Set[K]) MonotoneMap[K, V] {
 // Lookup returns the value for key, if present.
 //
 // Expected time: Θ(1).
-func (m MonotoneMap[K, V]) Lookup(key K) Option[V] {
+func (m MonotoneMap[K, V]) Lookup(key K) option.Option[V] {
 	value, ok := m.values[key]
-	return NewOption(value, ok)
+	return option.NewOption(value, ok)
 }
 
 // Len returns the number of entries.
@@ -89,11 +89,11 @@ func (m *MonotoneMap[K, V]) InsertOrKeep(key K, value V) op.InsertResult {
 // one existed.
 //
 // Expected time: Θ(1).
-func (m *MonotoneMap[K, V]) InsertOrReplace(key K, value V) Option[V] {
+func (m *MonotoneMap[K, V]) InsertOrReplace(key K, value V) option.Option[V] {
 	old, ok := m.values[key]
 	if !ok {
 		m.keys = append(m.keys, key)
 	}
 	m.values[key] = value
-	return NewOption(old, ok)
+	return option.NewOption(old, ok)
 }

--- a/common/envx/envx.go
+++ b/common/envx/envx.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/typesanitizer/happygo/common/assert"
 	"github.com/typesanitizer/happygo/common/collections"
-	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/core/op"
+	"github.com/typesanitizer/happygo/common/core/option"
 	"github.com/typesanitizer/happygo/common/core/pair"
 )
 
@@ -72,12 +72,12 @@ func NewIgnoringDupes(kvs iter.Seq[pair.KeyValue[string, string]]) Env {
 // Lookup returns the value for key, if present.
 //
 // Expected time: Θ(1).
-func (env Env) Lookup(key string) Option[string] {
+func (env Env) Lookup(key string) option.Option[string] {
 	entry, ok := env.entries.Lookup(canonicalKey(key)).Get()
 	if !ok {
-		return None[string]()
+		return option.None[string]()
 	}
-	return Some(entry.value)
+	return option.Some(entry.value)
 }
 
 // Entries returns the environment as "key=value" strings, similar to
@@ -122,21 +122,21 @@ func (env Env) InsertOrKeep(key string, value string) (Env, op.InsertResult) {
 // Θ(|env|).
 // Additional space: Θ(1) if env already stores the exact key-value pair.
 // Otherwise, Θ(|env|).
-func (env Env) InsertOrReplace(key string, value string) (Env, Option[string]) {
+func (env Env) InsertOrReplace(key string, value string) (Env, option.Option[string]) {
 	canonical := canonicalKey(key)
 	old, hadOld := env.entries.Lookup(canonical).Get()
 	// Preserve the latest inserted key spelling for Entries(). If only the
 	// spelling changes under canonicalization, we still need to replace.
 	if hadOld && old.key == key && old.value == value {
-		return env, Some(old.value)
+		return env, option.Some(old.value)
 	}
 
 	next := env.entries.CloneWithout(collections.NewSet[string]())
 	prev, ok := next.InsertOrReplace(canonical, envEntry{key: key, value: value}).Get()
 	if !ok {
-		return Env{entries: next}, None[string]()
+		return Env{entries: next}, option.None[string]()
 	}
-	return Env{entries: next}, Some(prev.value)
+	return Env{entries: next}, option.Some(prev.value)
 }
 
 // CloneWithout returns a shallow clone of env with keys in omit removed, if

--- a/common/envx/envx_path/find_executable.go
+++ b/common/envx/envx_path/find_executable.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/typesanitizer/happygo/common/assert"
-	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/envx"
 	"github.com/typesanitizer/happygo/common/errorx"
@@ -51,26 +50,26 @@ var NotExecutableErr = errorx.New("nostack", "not an executable file")
 //     to [NotExecutableErr].
 //
 // Pre-condition: name is non-empty and does not contain path separators.
-func FindExecutable(fs fsx.FS, env envx.Env, name string) (AbsPath, error) {
+func FindExecutable(fs fsx.FS, env envx.Env, name string) (pathx.AbsPath, error) {
 	assert.Preconditionf(name != "", "name is empty")
 	assert.Preconditionf(!pathx.HasPathSeparators(name), "name contains path separators: %q", name)
 
 	pathEnvVar, ok := env.Lookup("PATH").Get()
 	if !ok || pathEnvVar == "" {
-		return AbsPath{}, errorx.NewProblem(errorx.Code_InvalidArgument, "PATH must be set and non-empty")
+		return pathx.AbsPath{}, errorx.NewProblem(errorx.Code_InvalidArgument, "PATH must be set and non-empty")
 	}
 	var ignoredPaths []IgnoredPath
 	for searchDir := range searchDirs(pathEnvVar) {
-		var dir AbsPath
+		var dir pathx.AbsPath
 		if searchDir.isRelative {
-			dir = fs.Root().Join(NewRelPath(searchDir.pathEntry))
+			dir = fs.Root().Join(pathx.NewRelPath(searchDir.pathEntry))
 		} else {
-			dir = NewAbsPath(searchDir.pathEntry)
+			dir = pathx.NewAbsPath(searchDir.pathEntry)
 		}
 		if !dir.MakeRelativeTo(fs.Root()).IsSome() {
 			err := errorx.NewProblem(errorx.Code_AccessDenied,
 				fmt.Sprintf("PATH entry %q resolves outside filesystem root %q", searchDir.pathEntry, fs.Root()))
-			return AbsPath{}, wrapIgnored(err, ignoredPaths)
+			return pathx.AbsPath{}, wrapIgnored(err, ignoredPaths)
 		}
 		for candidatePath := range candidatePaths(env, dir.JoinComponents(name)) {
 			rootRel, ok := candidatePath.MakeRelativeTo(fs.Root()).Get()
@@ -106,13 +105,13 @@ func FindExecutable(fs fsx.FS, env envx.Env, name string) (AbsPath, error) {
 	}
 	err := errorx.Wrapf("nostack", os.ErrNotExist,
 		"failed to find executable %q in PATH %q", name, pathEnvVar)
-	return AbsPath{}, wrapIgnored(err, ignoredPaths)
+	return pathx.AbsPath{}, wrapIgnored(err, ignoredPaths)
 }
 
 // IgnoredPath records a candidate path that was found but skipped during
 // executable search.
 type IgnoredPath struct {
-	Path AbsPath
+	Path pathx.AbsPath
 	// Err is guaranteed to be non-nil.
 	Err error
 }
@@ -172,8 +171,8 @@ func searchDirs(pathEnvVar string) iter.Seq[searchDir] {
 // This largely matters for Windows because on Windows, the
 // search needs to look at extensions inferred via the PATHEXT
 // environment variable, in case base itself doesn't have an extension.
-func candidatePaths(env envx.Env, base AbsPath) iter.Seq[AbsPath] {
-	return func(yield func(AbsPath) bool) {
+func candidatePaths(env envx.Env, base pathx.AbsPath) iter.Seq[pathx.AbsPath] {
+	return func(yield func(pathx.AbsPath) bool) {
 		if runtime.GOOS != "windows" || filepath.Ext(base.String()) != "" {
 			yield(base)
 			return

--- a/common/envx/envx_path/find_executable_test.go
+++ b/common/envx/envx_path/find_executable_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/typesanitizer/happygo/common/assert"
 	"github.com/typesanitizer/happygo/common/check"
 	. "github.com/typesanitizer/happygo/common/check/prelude"
-	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/envx"
 	"github.com/typesanitizer/happygo/common/envx/envx_path"
 	"github.com/typesanitizer/happygo/common/errorx"
@@ -37,7 +37,7 @@ func testFindExecutableHappyPath(h check.Harness) {
 
 	h.Run("PATH behavior", func(h check.Harness) {
 		fs := newMemFS(h, fakeRoot.JoinComponents("path-behavior"))
-		binRel := NewRelPath("bin")
+		binRel := pathx.NewRelPath("bin")
 		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
 		exeRel := binRel.JoinComponents(exe.Name)
 		writeExecutable(h, fs, exeRel)
@@ -79,9 +79,9 @@ func testFindExecutableHappyPath(h check.Harness) {
 			h.T().Skip("Windows-specific exec.LookPath compatibility tests")
 		}
 
-		root := NewAbsPath(h.T().TempDir())
+		root := pathx.NewAbsPath(h.T().TempDir())
 		fs := Do(syscaps.FS(root))(h)
-		binRel := NewRelPath("bin")
+		binRel := pathx.NewRelPath("bin")
 		binDir := root.Join(binRel)
 		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
 
@@ -149,7 +149,7 @@ func testFindExecutableErrorCases(h check.Harness) {
 		}
 
 		fs := newMemFS(h, fakeRoot.JoinComponents("non-executable-candidates"))
-		binRel := NewRelPath("bin")
+		binRel := pathx.NewRelPath("bin")
 		exeRel := binRel.JoinComponents(exe.Name)
 		fsx_testkit.WriteFile(h, fs, exeRel, "#!/bin/sh\n")
 
@@ -183,9 +183,9 @@ func testFindExecutableErrorCases(h check.Harness) {
 	})
 
 	h.Run("exec.LookPath compatibility", func(h check.Harness) {
-		root := NewAbsPath(h.T().TempDir())
+		root := pathx.NewAbsPath(h.T().TempDir())
 		fs := Do(syscaps.FS(root))(h)
-		binRel := NewRelPath("bin")
+		binRel := pathx.NewRelPath("bin")
 		binDir := root.Join(binRel)
 		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
 		exeRel := binRel.JoinComponents(exe.Name)
@@ -278,7 +278,7 @@ func testFindExecutablePreconditions(h check.Harness) {
 	})
 }
 
-func newMemFS(h check.Harness, root AbsPath) fsx.FS {
+func newMemFS(h check.Harness, root pathx.AbsPath) fsx.FS {
 	h.T().Helper()
 	return Do(fsx.MemMap(root))(h)
 }
@@ -306,7 +306,7 @@ func hostOSExecutable() hostExecutable {
 	return hostExecutable{Name: "tool", LookupName: "tool"}
 }
 
-func writeExecutable(h check.Harness, fs fsx.FS, path RelPath) {
+func writeExecutable(h check.Harness, fs fsx.FS, path pathx.RelPath) {
 	h.T().Helper()
 	h.NoErrorf(fs.WriteFile(path, []byte("#!/bin/sh\n"), 0o755), "WriteFile(%q)", path)
 }

--- a/common/errorx/errorx.go
+++ b/common/errorx/errorx.go
@@ -9,7 +9,7 @@ import (
 
 	cockroach "github.com/cockroachdb/errors" //nolint:depguard // In designated wrapper package
 	"github.com/typesanitizer/happygo/common/assert"
-	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/option"
 	"github.com/typesanitizer/happygo/common/iterx"
 )
 
@@ -221,14 +221,14 @@ func GetRootCause(err error) RootCauseResult {
 // the root cause (if one was found) to the type parameter.
 //
 // Pre-condition: err != nil, and err's nesting does not exceed [NESTING_LIMIT].
-func GetRootCauseAs[T error](err error) Option[T] {
+func GetRootCauseAs[T error](err error) option.Option[T] {
 	r := GetRootCause(err)
 	assert.Precondition(!r.HitNestingLimit(), "hit nesting limit during traversal; cannot cast root cause")
 	if r.HitMultiError() {
-		return None[T]()
+		return option.None[T]()
 	}
 	v, ok := r.GetRootCause().(T)
-	return NewOption(v, ok)
+	return option.NewOption(v, ok)
 }
 
 // FindInChainAs traverses the error chain and returns the first error
@@ -242,11 +242,11 @@ func GetRootCauseAs[T error](err error) Option[T] {
 // wraps some other errors.
 //
 // Pre-condition: err != nil, and err's nesting does not exceed [NESTING_LIMIT].
-func FindInChainAs[T error](err error) Option[T] {
-	return iterx.Find(Chain(err), func(link ChainLink) Option[T] {
+func FindInChainAs[T error](err error) option.Option[T] {
+	return iterx.Find(Chain(err), func(link ChainLink) option.Option[T] {
 		assert.Precondition(!link.HitNestingLimit(), "hit nesting limit during traversal")
 		v, ok := link.Current().(T)
-		return NewOption(v, ok)
+		return option.NewOption(v, ok)
 	})
 }
 

--- a/common/fsx/fsx.go
+++ b/common/fsx/fsx.go
@@ -16,8 +16,8 @@ import (
 	"github.com/typesanitizer/happygo/common/fsx/fsx_name"
 
 	"github.com/typesanitizer/happygo/common/assert"
-	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/core/pathx"
+	"github.com/typesanitizer/happygo/common/core/result"
 	"github.com/typesanitizer/happygo/common/errorx"
 	"github.com/typesanitizer/happygo/common/internal/constants"
 	"github.com/typesanitizer/happygo/common/iterx"
@@ -63,27 +63,27 @@ type BaseFS interface {
 
 // FS is a rooted filesystem. All methods operate on paths relative to Root().
 type FS interface {
-	Root() AbsPath
-	ReadDir(rel RelPath) iter.Seq[Result[DirEntry]]
-	Open(rel RelPath) (File, error)
-	ReadFile(rel RelPath) ([]byte, error)
-	WriteFile(rel RelPath, data []byte, perm os.FileMode) error
-	MkdirAll(rel RelPath, perm os.FileMode) error
-	MkdirTemp(dir RelPath, pattern string) (RelPath, error)
-	RemoveAll(rel RelPath) error
-	Stat(rel RelPath, opts StatOptions) (os.FileInfo, error)
+	Root() pathx.AbsPath
+	ReadDir(rel pathx.RelPath) iter.Seq[result.Result[DirEntry]]
+	Open(rel pathx.RelPath) (File, error)
+	ReadFile(rel pathx.RelPath) ([]byte, error)
+	WriteFile(rel pathx.RelPath, data []byte, perm os.FileMode) error
+	MkdirAll(rel pathx.RelPath, perm os.FileMode) error
+	MkdirTemp(dir pathx.RelPath, pattern string) (pathx.RelPath, error)
+	RemoveAll(rel pathx.RelPath) error
+	Stat(rel pathx.RelPath, opts StatOptions) (os.FileInfo, error)
 }
 
 // rootedFS is the standard FS implementation backed by an afero filesystem.
 type rootedFS struct {
 	// Stored separately because afero.BasePathFs does not expose its configured
 	// root path back to callers, but fsx needs to provide Root().
-	root AbsPath
+	root pathx.AbsPath
 	base BaseFS
 }
 
 // MemMap returns an in-memory FS rooted at root.
-func MemMap(root AbsPath) (FS, error) {
+func MemMap(root pathx.AbsPath) (FS, error) {
 	backing := afero.NewMemMapFs()
 	if err := backing.MkdirAll(root.String(), 0o755); err != nil {
 		return nil, errorx.Wrapf("+stacks", err, "create fs root %s", root)
@@ -96,7 +96,7 @@ func MemMap(root AbsPath) (FS, error) {
 // NewRootedFS returns an FS rooted at root and backed by backing.
 //
 // Pre-condition: root must already exist in backing and be a directory.
-func NewRootedFS(root AbsPath, backing BaseFS) (FS, error) {
+func NewRootedFS(root pathx.AbsPath, backing BaseFS) (FS, error) {
 	info, err := backing.Stat(root.String())
 	if err != nil {
 		return nil, errorx.Wrapf("+stacks", err, "stat fs root %s", root)
@@ -111,7 +111,7 @@ func NewRootedFS(root AbsPath, backing BaseFS) (FS, error) {
 }
 
 // Root returns the absolute path this FS is rooted at.
-func (fs rootedFS) Root() AbsPath {
+func (fs rootedFS) Root() pathx.AbsPath {
 	return fs.root
 }
 
@@ -120,21 +120,21 @@ func (fs rootedFS) Root() AbsPath {
 // Errors produced mid-iteration are surfaced as [Failure] elements
 // rather than being returned eagerly. Callers should stop iterating on the
 // first failure.
-func (fs rootedFS) ReadDir(rel RelPath) iter.Seq[Result[DirEntry]] {
-	return iterx.Map(iterx.Unbatch(fs.readDirBatches(rel)), func(entryRes Result[iofs.DirEntry]) Result[DirEntry] {
+func (fs rootedFS) ReadDir(rel pathx.RelPath) iter.Seq[result.Result[DirEntry]] {
+	return iterx.Map(iterx.Unbatch(fs.readDirBatches(rel)), func(entryRes result.Result[iofs.DirEntry]) result.Result[DirEntry] {
 		entry, err := entryRes.Get()
 		if err != nil {
-			return Failure[DirEntry](err)
+			return result.Failure[DirEntry](err)
 		}
-		return Success[DirEntry](dirEntry{entry: entry})
+		return result.Success[DirEntry](dirEntry{entry: entry})
 	})
 }
 
-func (fs rootedFS) readDirBatches(rel RelPath) iter.Seq[Result[[]iofs.DirEntry]] {
-	return func(yield func(Result[[]iofs.DirEntry]) bool) {
+func (fs rootedFS) readDirBatches(rel pathx.RelPath) iter.Seq[result.Result[[]iofs.DirEntry]] {
+	return func(yield func(result.Result[[]iofs.DirEntry]) bool) {
 		f, err := fs.base.Open(rel.String())
 		if err != nil {
-			yield(Failure[[]iofs.DirEntry](err))
+			yield(result.Failure[[]iofs.DirEntry](err))
 			return
 		}
 		defer func() {
@@ -147,7 +147,7 @@ func (fs rootedFS) readDirBatches(rel RelPath) iter.Seq[Result[[]iofs.DirEntry]]
 		for {
 			entries, err := rdf.ReadDir(constants.ReadDirBatchSize)
 			if len(entries) > 0 {
-				if !yield(Success(entries)) {
+				if !yield(result.Success(entries)) {
 					return
 				}
 			}
@@ -162,7 +162,7 @@ func (fs rootedFS) readDirBatches(rel RelPath) iter.Seq[Result[[]iofs.DirEntry]]
 			case io.EOF:
 				return
 			default:
-				yield(Failure[[]iofs.DirEntry](err))
+				yield(result.Failure[[]iofs.DirEntry](err))
 				return
 			}
 		}
@@ -170,23 +170,23 @@ func (fs rootedFS) readDirBatches(rel RelPath) iter.Seq[Result[[]iofs.DirEntry]]
 }
 
 // Open opens the file at the given root-relative path for reading.
-func (fs rootedFS) Open(rel RelPath) (File, error) {
+func (fs rootedFS) Open(rel pathx.RelPath) (File, error) {
 	return fs.base.Open(rel.String())
 }
 
 // ReadFile reads the file at the given root-relative path.
-func (fs rootedFS) ReadFile(rel RelPath) ([]byte, error) {
+func (fs rootedFS) ReadFile(rel pathx.RelPath) ([]byte, error) {
 	return afero.ReadFile(fs.base, rel.String())
 }
 
 // WriteFile writes data to the file at the given root-relative path.
-func (fs rootedFS) WriteFile(rel RelPath, data []byte, perm os.FileMode) error {
+func (fs rootedFS) WriteFile(rel pathx.RelPath, data []byte, perm os.FileMode) error {
 	return afero.WriteFile(fs.base, rel.String(), data, perm)
 }
 
 // MkdirAll creates the directory at the given root-relative path along with
 // any necessary parents.
-func (fs rootedFS) MkdirAll(rel RelPath, perm os.FileMode) error {
+func (fs rootedFS) MkdirAll(rel pathx.RelPath, perm os.FileMode) error {
 	return fs.base.MkdirAll(rel.String(), perm)
 }
 
@@ -194,20 +194,20 @@ func (fs rootedFS) MkdirAll(rel RelPath, perm os.FileMode) error {
 // whose name begins with pattern, and returns the resulting root-relative path.
 //
 // Pre-condition: pattern is non-empty and contains no path separators.
-func (fs rootedFS) MkdirTemp(dir RelPath, pattern string) (RelPath, error) {
+func (fs rootedFS) MkdirTemp(dir pathx.RelPath, pattern string) (pathx.RelPath, error) {
 	assert.Preconditionf(pattern != "", "pattern is empty")
 	assert.Preconditionf(!pathx.HasPathSeparators(pattern), "pattern contains path separator: %q", pattern)
 	// afero.TempDir returns filepath.Join(dir, pattern+rand) relative to fs.base,
 	// so the returned path is already root-relative rather than just a basename.
 	tmpDir, err := afero.TempDir(fs.base, dir.String(), pattern)
 	if err != nil {
-		return RelPath{}, err
+		return pathx.RelPath{}, err
 	}
-	return NewRelPath(tmpDir), nil
+	return pathx.NewRelPath(tmpDir), nil
 }
 
 // RemoveAll removes the file or directory at the given root-relative path
 // along with any children it contains.
-func (fs rootedFS) RemoveAll(rel RelPath) error {
+func (fs rootedFS) RemoveAll(rel pathx.RelPath) error {
 	return fs.base.RemoveAll(rel.String())
 }

--- a/common/fsx/fsx_testkit/fsx_testkit.go
+++ b/common/fsx/fsx_testkit/fsx_testkit.go
@@ -8,7 +8,8 @@ import (
 	"strings"
 
 	"github.com/typesanitizer/happygo/common/check"
-	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/pathx"
+	"github.com/typesanitizer/happygo/common/core/result"
 	"github.com/typesanitizer/happygo/common/errorx"
 	"github.com/typesanitizer/happygo/common/fsx"
 	"github.com/typesanitizer/happygo/common/syscaps"
@@ -17,7 +18,7 @@ import (
 // TempDirFS returns a host FS rooted at a new test temporary directory.
 func TempDirFS(h check.Harness) fsx.FS {
 	h.T().Helper()
-	fs, err := syscaps.FS(NewAbsPath(h.T().TempDir()))
+	fs, err := syscaps.FS(pathx.NewAbsPath(h.T().TempDir()))
 	h.NoErrorf(err, "FS(TempDir())")
 	return fs
 }
@@ -31,7 +32,7 @@ func NewMemFS(h check.Harness) fsx.FS {
 }
 
 // WriteFile writes a single file, creating parent directories as needed.
-func WriteFile(h check.Harness, fs fsx.FS, path RelPath, content string) {
+func WriteFile(h check.Harness, fs fsx.FS, path pathx.RelPath, content string) {
 	h.T().Helper()
 	if dir, ok := path.Dir().Get(); ok {
 		h.NoErrorf(fs.MkdirAll(dir, 0o755), "MkdirAll(%q)", dir)
@@ -46,7 +47,7 @@ func WriteTree(h check.Harness, fs fsx.FS, tree map[string]string) {
 	h.T().Helper()
 	for path, content := range tree {
 		h.Assertf(path != "", "path must not be empty")
-		rel := NewRelPath(path)
+		rel := pathx.NewRelPath(path)
 		if strings.HasSuffix(path, "/") {
 			h.Assertf(content == "", "directory path %q must have empty content", path)
 			h.NoErrorf(fs.MkdirAll(rel, 0o755), "MkdirAll(%q)", rel)
@@ -74,7 +75,7 @@ const (
 // Fault describes one injected filesystem failure.
 type Fault struct {
 	Op  FaultOp
-	Rel RelPath
+	Rel pathx.RelPath
 }
 
 // faultyFS wraps an fsx.FS and injects failures for configured operations.
@@ -91,37 +92,37 @@ func newFaultyFS(base fsx.FS, faults ...Fault) *faultyFS {
 	return &faultyFS{FS: base, faults: faultSet}
 }
 
-func (fs *faultyFS) Stat(rel RelPath, opts fsx.StatOptions) (os.FileInfo, error) {
+func (fs *faultyFS) Stat(rel pathx.RelPath, opts fsx.StatOptions) (os.FileInfo, error) {
 	if fs.hasFault(FaultOp_Stat, rel) {
 		return nil, injectedFSError()
 	}
 	return fs.FS.Stat(rel, opts)
 }
 
-func (fs *faultyFS) Open(rel RelPath) (fsx.File, error) {
+func (fs *faultyFS) Open(rel pathx.RelPath) (fsx.File, error) {
 	if fs.hasFault(FaultOp_Open, rel) {
 		return nil, injectedFSError()
 	}
 	return fs.FS.Open(rel)
 }
 
-func (fs *faultyFS) ReadFile(rel RelPath) ([]byte, error) {
+func (fs *faultyFS) ReadFile(rel pathx.RelPath) ([]byte, error) {
 	if fs.hasFault(FaultOp_Open, rel) {
 		return nil, injectedFSError()
 	}
 	return fs.FS.ReadFile(rel)
 }
 
-func (fs *faultyFS) ReadDir(rel RelPath) iter.Seq[Result[fsx.DirEntry]] {
+func (fs *faultyFS) ReadDir(rel pathx.RelPath) iter.Seq[result.Result[fsx.DirEntry]] {
 	if fs.hasFault(FaultOp_Open, rel) {
-		return func(yield func(Result[fsx.DirEntry]) bool) {
-			yield(Failure[fsx.DirEntry](injectedFSError()))
+		return func(yield func(result.Result[fsx.DirEntry]) bool) {
+			yield(result.Failure[fsx.DirEntry](injectedFSError()))
 		}
 	}
 	return fs.FS.ReadDir(rel)
 }
 
-func (fs *faultyFS) hasFault(op FaultOp, rel RelPath) bool {
+func (fs *faultyFS) hasFault(op FaultOp, rel pathx.RelPath) bool {
 	_, hit := fs.faults[Fault{Op: op, Rel: rel}]
 	return hit
 }
@@ -130,9 +131,9 @@ func injectedFSError() error {
 	return errorx.New("nostack", "injected fs error")
 }
 
-func FakeRoot() AbsPath {
+func FakeRoot() pathx.AbsPath {
 	if runtime.GOOS == "windows" {
-		return NewAbsPath(`C:\virtual-root`)
+		return pathx.NewAbsPath(`C:\virtual-root`)
 	}
-	return NewAbsPath("/virtual-root")
+	return pathx.NewAbsPath("/virtual-root")
 }

--- a/common/fsx/fsx_walk/walk_test.go
+++ b/common/fsx/fsx_walk/walk_test.go
@@ -12,8 +12,9 @@ import (
 
 	"github.com/typesanitizer/happygo/common/check"
 	. "github.com/typesanitizer/happygo/common/check/prelude"
-	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/core/option"
 	"github.com/typesanitizer/happygo/common/core/pathx"
+	"github.com/typesanitizer/happygo/common/core/result"
 	"github.com/typesanitizer/happygo/common/fsx/fsx_testkit"
 	"github.com/typesanitizer/happygo/common/fsx/fsx_walk"
 	"github.com/typesanitizer/happygo/common/iterx"
@@ -21,7 +22,7 @@ import (
 	"github.com/typesanitizer/happygo/common/syscaps"
 )
 
-type WalkResultSeq = iter.Seq[Result[fsx_walk.FSWalkEntry]]
+type WalkResultSeq = iter.Seq[result.Result[fsx_walk.FSWalkEntry]]
 
 func TestWalk(t *testing.T) {
 	h := check.New(t)
@@ -462,17 +463,17 @@ func joinWalkPath(prefix, name string) string {
 
 func firstWalkError(h check.Harness, entries WalkResultSeq) error {
 	h.T().Helper()
-	var impl func(WalkResultSeq) Option[error]
-	impl = func(entries WalkResultSeq) Option[error] {
-		return iterx.Find(entries, func(entryRes Result[fsx_walk.FSWalkEntry]) Option[error] {
+	var impl func(WalkResultSeq) option.Option[error]
+	impl = func(entries WalkResultSeq) option.Option[error] {
+		return iterx.Find(entries, func(entryRes result.Result[fsx_walk.FSWalkEntry]) option.Option[error] {
 			entry, err := entryRes.Get()
 			if err != nil {
-				return Some(err)
+				return option.Some(err)
 			}
 			if entry.IsDir() {
 				return impl(entry.ChildrenNonDet())
 			}
-			return None[error]()
+			return option.None[error]()
 		})
 	}
 	err, ok := impl(entries).Get()

--- a/common/fsx/stat.go
+++ b/common/fsx/stat.go
@@ -3,7 +3,6 @@ package fsx
 import (
 	"os"
 
-	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/core/pathx"
 )
 
@@ -19,7 +18,7 @@ import (
 // opts.OnErrorTraverseParents is true, StatError.ShortestMissing() returns the
 // shallowest ancestor that does not exist. Otherwise, ShortestMissing()
 // returns rel.
-func (fs rootedFS) Stat(rel RelPath, opts StatOptions) (os.FileInfo, error) {
+func (fs rootedFS) Stat(rel pathx.RelPath, opts StatOptions) (os.FileInfo, error) {
 	var info os.FileInfo
 	var err error
 	if opts.FollowFinalSymlink {
@@ -58,7 +57,7 @@ func (fs rootedFS) Stat(rel RelPath, opts StatOptions) (os.FileInfo, error) {
 		}
 	}
 	if lo < len(seps) {
-		return nil, &StatError{fsError: err, shortestMissing: NewRelPath(raw[:seps[lo]])}
+		return nil, &StatError{fsError: err, shortestMissing: pathx.NewRelPath(raw[:seps[lo]])}
 	}
 	// All ancestors exist; the leaf itself is the shallowest missing.
 	return nil, &StatError{fsError: err, shortestMissing: rel}
@@ -80,7 +79,7 @@ type StatOptions struct {
 // missing ancestor when OnErrorTraverseParents was set.
 type StatError struct {
 	fsError         error
-	shortestMissing RelPath
+	shortestMissing pathx.RelPath
 }
 
 func (e *StatError) Error() string {
@@ -93,6 +92,6 @@ func (e *StatError) Unwrap() error {
 
 // ShortestMissing returns the shallowest missing path component. If
 // OnErrorTraverseParents was not set, this equals the original path.
-func (e *StatError) ShortestMissing() RelPath {
+func (e *StatError) ShortestMissing() pathx.RelPath {
 	return e.shortestMissing
 }

--- a/common/fsx/stat_test.go
+++ b/common/fsx/stat_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/typesanitizer/happygo/common/check"
 	. "github.com/typesanitizer/happygo/common/check/prelude"
-	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/core/pathx/pathx_testkit"
 	"github.com/typesanitizer/happygo/common/errorx"
@@ -35,7 +34,7 @@ func TestFSStat(t *testing.T) {
 			h.T().Skipf("symlinks not supported on this platform")
 		}
 
-		repoFS := Do(syscaps.FS(NewAbsPath(link)))(h)
+		repoFS := Do(syscaps.FS(pathx.NewAbsPath(link)))(h)
 
 		followed := Do(repoFS.Stat(pathx.Dot(), fsx.StatOptions{
 			FollowFinalSymlink:     true,
@@ -57,7 +56,7 @@ func TestFSStat(t *testing.T) {
 	h.Run("ShortestMissingProperties", func(h check.Harness) {
 		h.Parallel()
 
-		root := NewAbsPath(h.T().TempDir())
+		root := pathx.NewAbsPath(h.T().TempDir())
 		componentsGen := rapid.SliceOfN(pathx_testkit.ComponentGen(), 1, 6)
 		rapid.Check(h.T(), func(t *rapid.T) {
 			h := check.NewBasic(t)
@@ -91,14 +90,14 @@ func TestFSStat(t *testing.T) {
 	})
 }
 
-func joinedRelPath(components []string) RelPath {
+func joinedRelPath(components []string) pathx.RelPath {
 	if len(components) == 0 {
 		return pathx.Dot()
 	}
-	return NewRelPath(filepath.Join(components...))
+	return pathx.NewRelPath(filepath.Join(components...))
 }
 
-func requireStatError(h check.BasicHarness, err error, rel RelPath, opts fsx.StatOptions) *fsx.StatError {
+func requireStatError(h check.BasicHarness, err error, rel pathx.RelPath, opts fsx.StatOptions) *fsx.StatError {
 	call := fmt.Sprintf("Stat(%q, fsx.StatOptions{FollowFinalSymlink: %t, OnErrorTraverseParents: %t})",
 		rel, opts.FollowFinalSymlink, opts.OnErrorTraverseParents)
 	h.Assertf(err != nil, "%s unexpectedly succeeded", call)

--- a/common/syscaps/syscaps.go
+++ b/common/syscaps/syscaps.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/typesanitizer/happygo/common/assert"
 	"github.com/typesanitizer/happygo/common/cmdx"
-	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/core/pair"
+	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/envx"
 	"github.com/typesanitizer/happygo/common/errorx"
 	"github.com/typesanitizer/happygo/common/fsx"
@@ -34,7 +34,7 @@ func Env() envx.Env {
 }
 
 // FS returns a rooted filesystem backed by the host operating system.
-func FS(root AbsPath) (fsx.FS, error) {
+func FS(root pathx.AbsPath) (fsx.FS, error) {
 	base, ok := afero.NewOsFs().(fsx.BaseFS)
 	assert.Invariantf(ok, "NewOsFs return value should implement fsx.BaseFS, but got type %T", base)
 	return fsx.NewRootedFS(root, base)

--- a/common/syscaps/syscaps_test.go
+++ b/common/syscaps/syscaps_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/typesanitizer/happygo/common/check"
 	. "github.com/typesanitizer/happygo/common/check/prelude"
 	"github.com/typesanitizer/happygo/common/collections"
-	. "github.com/typesanitizer/happygo/common/core"
 	"github.com/typesanitizer/happygo/common/core/pathx"
 	"github.com/typesanitizer/happygo/common/fsx/fsx_testkit"
 	"github.com/typesanitizer/happygo/common/internal/constants"
@@ -57,7 +56,7 @@ func TestFSReadDirOnFileReturnsError(t *testing.T) {
 
 	repoFS := fsx_testkit.TempDirFS(h)
 
-	fileRel := NewRelPath("file.txt")
+	fileRel := pathx.NewRelPath("file.txt")
 	h.NoErrorf(repoFS.WriteFile(fileRel, []byte("data"), 0o644), "WriteFile(%q)", fileRel)
 
 	gotAny := false


### PR DESCRIPTION
common/core is meant as a convenience import for other modules;
importing it inside common/ itself introduces risks around
overly serializing the build graph, as well as greater risk
of cycles more generally.
