### PR TITLE
feat: Add Polyform Noncommercial license and checking

### DIFF
--- a/common/assert/assert.go
+++ b/common/assert/assert.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package assert provides precondition and invariant checks that panic on violation.
 package assert
 

--- a/common/check/check.go
+++ b/common/check/check.go
@@ -1,8 +1,13 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package check provides test assertion and snapshot helpers.
 package check
 
 import (
 	"flag"
+	"io"
 	"os"
 	"testing"
 
@@ -117,6 +122,12 @@ func (h Harness) Run(name string, f func(Harness)) {
 func (h Harness) T() *testing.T {
 	h.t.Helper()
 	return h.t
+}
+
+// Close closes c, failing the test if closing fails.
+func (h Harness) Close(c io.Closer) {
+	h.t.Helper()
+	h.NoErrorf(c.Close(), "closing resource")
 }
 
 // AssertSame compares want and got using cmp.Diff and fails with a diff if they differ.

--- a/common/check/internal/type_assertions.go
+++ b/common/check/internal/type_assertions.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package internal
 
 import (

--- a/common/check/prelude/prelude.go
+++ b/common/check/prelude/prelude.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package prelude provides terse test helpers intended for dot-import in tests.
 package prelude
 

--- a/common/cmdx/cmd.go
+++ b/common/cmdx/cmd.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package cmdx
 
 import (

--- a/common/cmdx/run.go
+++ b/common/cmdx/run.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package cmdx
 
 import (

--- a/common/cmpx/cmpx.go
+++ b/common/cmpx/cmpx.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package cmpx
 
 // CompareBool implements false < true

--- a/common/cmpx/cmpx_test.go
+++ b/common/cmpx/cmpx_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package cmpx_test
 
 import (

--- a/common/collections/map.go
+++ b/common/collections/map.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package collections
 
 import (

--- a/common/collections/monotone_map.go
+++ b/common/collections/monotone_map.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package collections
 
 import (

--- a/common/collections/monotone_map_test.go
+++ b/common/collections/monotone_map_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package collections
 
 import (

--- a/common/collections/set.go
+++ b/common/collections/set.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package collections
 
 import (

--- a/common/collections/set_test.go
+++ b/common/collections/set_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package collections
 
 import (

--- a/common/collections/slice.go
+++ b/common/collections/slice.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package collections
 
 // FilterSlice returns a new slice containing only elements for which pred returns true.

--- a/common/collections/stack.go
+++ b/common/collections/stack.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package collections
 
 import "github.com/typesanitizer/happygo/common/assert"

--- a/common/collections/stack_test.go
+++ b/common/collections/stack_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package collections_test
 
 import (

--- a/common/core/op/op.go
+++ b/common/core/op/op.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package op provides small operation-result newtypes for APIs where a named
 // boolean result is clearer than a raw bool.
 //

--- a/common/core/option.go
+++ b/common/core/option.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package core provides foundational generic types.
 package core
 

--- a/common/core/option/option.go
+++ b/common/core/option/option.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package option provides a generic optional value type.
 package option
 

--- a/common/core/option/option_test.go
+++ b/common/core/option/option_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package option_test
 
 import (

--- a/common/core/pair/pair.go
+++ b/common/core/pair/pair.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package pair
 
 type KeyValue[K, V any] struct {

--- a/common/core/pathx.go
+++ b/common/core/pathx.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package core
 
 import "github.com/typesanitizer/happygo/common/core/pathx"

--- a/common/core/pathx/lexical.go
+++ b/common/core/pathx/lexical.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package pathx
 
 // LexicallyNormalize is adapted from the Go standard library's

--- a/common/core/pathx/pathx.go
+++ b/common/core/pathx/pathx.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package pathx provides typed path wrappers for host platform paths.
 //
 // These types improve code clarity and catch potential bugs (e.g. accidentally
@@ -13,6 +17,7 @@ import (
 
 	"github.com/typesanitizer/happygo/common/assert"
 	"github.com/typesanitizer/happygo/common/core/option"
+	"github.com/typesanitizer/happygo/common/fsx/fsx_name"
 )
 
 // AbsPath carries an absolute path that has gone through [LexicallyNormalize].
@@ -62,9 +67,33 @@ func (p AbsPath) rootLen() int {
 	return rootLen
 }
 
-func (p AbsPath) Split() (AbsPath, string) {
+func (p AbsPath) Split() (AbsPath, fsx_name.Name) {
 	dir, file := filepath.Split(p.value)
-	return NewAbsPath(dir), file
+	return NewAbsPath(dir), fsx_name.New(file)
+}
+
+// Ancestors returns an iterator over p's ancestor absolute paths,
+// in shortest-first order. The receiver itself is not yielded.
+//
+// For example, "/a/b/c" yields "/a" then "/a/b". A filesystem root
+// or a path directly below a filesystem root yields nothing.
+func (p AbsPath) Ancestors() iter.Seq[AbsPath] {
+	return func(yield func(AbsPath) bool) {
+		rootLen := p.rootLen()
+		for i := rootLen; i < len(p.value); i++ {
+			if !IsPathSeparator(p.value[i]) {
+				continue
+			}
+			// A trailing separator means the ancestor would equal the
+			// receiver semantically; stop here.
+			if i == len(p.value)-1 {
+				return
+			}
+			if !yield(AbsPath{p.value[:i]}) {
+				return
+			}
+		}
+	}
 }
 
 // LexicallyContains reports whether child is lexically contained within p.

--- a/common/core/pathx/pathx_test.go
+++ b/common/core/pathx/pathx_test.go
@@ -1,9 +1,14 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package pathx_test
 
 import (
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -107,12 +112,29 @@ func TestSplit(t *testing.T) {
 			components := componentsGen.Draw(t, "components")
 			path := root.JoinComponents(components...)
 			dir, file := path.Split()
-			check.AssertSame(basic, components[len(components)-1], file, "Split() file")
+			check.AssertSame(basic, components[len(components)-1], file.String(), "Split() file")
 
-			reconstructed := dir.Join(pathx.NewRelPath(file))
+			reconstructed := dir.Join(pathx.NewRelPath(file.String()))
 			check.AssertSame(basic, path.String(), reconstructed.String(), "Split() round-trip")
 		})
 	})
+}
+
+func TestAbsPathAncestors(t *testing.T) {
+	h := check.New(t)
+
+	path := pathx.NewAbsPath(h.T().TempDir()).JoinComponents("a", "b", "c")
+	got := iterx.Collect(iterx.Map(path.Ancestors(), pathx.AbsPath.String))
+	var reverse []string
+	for parent, ok := path.Dir().Get(); ok; parent, ok = parent.Dir().Get() {
+		if parent.Dir().IsNone() {
+			break
+		}
+		reverse = append(reverse, parent.String())
+	}
+	slices.Reverse(reverse)
+	want := reverse
+	check.AssertSame(h, want, got, "Ancestors()")
 }
 
 func TestRelPathComponents(t *testing.T) {

--- a/common/core/pathx/pathx_testkit/pathx_testkit.go
+++ b/common/core/pathx/pathx_testkit/pathx_testkit.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package pathx_testkit provides rapid generators for pathx types.
 package pathx_testkit
 

--- a/common/core/result.go
+++ b/common/core/result.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package core
 
 import "github.com/typesanitizer/happygo/common/core/result"

--- a/common/core/result/result.go
+++ b/common/core/result/result.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package result provides a generic Result[T] type holding either a value or
 // an error.
 package result

--- a/common/core/result/result_test.go
+++ b/common/core/result/result_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package result_test
 
 import (

--- a/common/core/todos.go
+++ b/common/core/todos.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package core
 
 import "fmt"

--- a/common/enum/enum.go
+++ b/common/enum/enum.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package enum
 
 import "github.com/typesanitizer/happygo/common/assert"

--- a/common/envx/envx.go
+++ b/common/envx/envx.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package envx provides an immutable environment mapping.
 package envx
 

--- a/common/envx/envx_path/errdot.go
+++ b/common/envx/envx_path/errdot.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package envx_path
 
 import "os/exec"

--- a/common/envx/envx_path/find_executable.go
+++ b/common/envx/envx_path/find_executable.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package envx_path provides environment-sensitive PATH lookup helpers.
 package envx_path
 

--- a/common/envx/envx_path/find_executable_test.go
+++ b/common/envx/envx_path/find_executable_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package envx_path_test
 
 import (

--- a/common/errorx/errorx.go
+++ b/common/errorx/errorx.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package errorx wraps cockroachdb/errors for consistent error handling.
 // All error creation in first-party code should go through this package.
 package errorx

--- a/common/errorx/errorx_test.go
+++ b/common/errorx/errorx_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package errorx
 
 import (

--- a/common/errorx/problem.go
+++ b/common/errorx/problem.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package errorx
 
 import (

--- a/common/fsx/fsx.go
+++ b/common/fsx/fsx.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package fsx provides a rooted filesystem wrapper over [afero.Fs] that
 // operates on [RelPath] values anchored at a repo-root [AbsPath].
 //
@@ -29,6 +33,18 @@ var ErrNotExist = iofs.ErrNotExist
 // File is an open file handle returned by [FS.Open] and similar methods.
 // It is an alias for [afero.File] so callers need not import afero directly.
 type File = afero.File
+
+type OpenMode int
+
+const (
+	OpenMode_ReadOnly OpenMode = iota + 1
+	OpenMode_WriteOnly
+	OpenMode_ReadWrite
+)
+
+type OpenOptions struct {
+	Mode OpenMode
+}
 
 // DirEntry is a single entry returned by [FS.ReadDir].
 type DirEntry interface {
@@ -65,7 +81,7 @@ type BaseFS interface {
 type FS interface {
 	Root() pathx.AbsPath
 	ReadDir(rel pathx.RelPath) iter.Seq[result.Result[DirEntry]]
-	Open(rel pathx.RelPath) (File, error)
+	Open(rel pathx.RelPath, opts OpenOptions) (File, error)
 	ReadFile(rel pathx.RelPath) ([]byte, error)
 	WriteFile(rel pathx.RelPath, data []byte, perm os.FileMode) error
 	MkdirAll(rel pathx.RelPath, perm os.FileMode) error
@@ -169,9 +185,22 @@ func (fs rootedFS) readDirBatches(rel pathx.RelPath) iter.Seq[result.Result[[]io
 	}
 }
 
-// Open opens the file at the given root-relative path for reading.
-func (fs rootedFS) Open(rel pathx.RelPath) (File, error) {
-	return fs.base.Open(rel.String())
+// Open opens the file at the given root-relative path.
+func (fs rootedFS) Open(rel pathx.RelPath, opts OpenOptions) (File, error) {
+	return fs.base.OpenFile(rel.String(), openFlags(opts.Mode), 0)
+}
+
+func openFlags(mode OpenMode) int {
+	switch mode {
+	case OpenMode_ReadOnly:
+		return os.O_RDONLY
+	case OpenMode_WriteOnly:
+		return os.O_WRONLY
+	case OpenMode_ReadWrite:
+		return os.O_RDWR
+	default:
+		return assert.PanicUnknownCase[int](mode)
+	}
 }
 
 // ReadFile reads the file at the given root-relative path.

--- a/common/fsx/fsx_name/name.go
+++ b/common/fsx/fsx_name/name.go
@@ -1,11 +1,15 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package fsx_name
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/typesanitizer/happygo/common/assert"
-	"github.com/typesanitizer/happygo/common/core/pathx"
 )
 
 // --- Aliases for external use ---
@@ -53,10 +57,17 @@ func Parse(s string) (Name, error) {
 	if s == "" {
 		return Name{}, &NameParseError{ParseErrorKind_EmptyName, ""}
 	}
-	if pathx.HasPathSeparators(s) {
+	if hasPathSeparators(s) {
 		return Name{}, &NameParseError{ParseErrorKind_HasPathSeparators, s}
 	}
 	return Name{s}, nil
+}
+
+func hasPathSeparators(s string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.ContainsAny(s, `\\/`)
+	}
+	return strings.Contains(s, "/")
 }
 
 // See ParseError for doc comment.

--- a/common/fsx/fsx_testkit/fsx_testkit.go
+++ b/common/fsx/fsx_testkit/fsx_testkit.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package fsx_testkit provides test helpers for fsx.FS values.
 package fsx_testkit
 
@@ -99,11 +103,11 @@ func (fs *faultyFS) Stat(rel pathx.RelPath, opts fsx.StatOptions) (os.FileInfo, 
 	return fs.FS.Stat(rel, opts)
 }
 
-func (fs *faultyFS) Open(rel pathx.RelPath) (fsx.File, error) {
+func (fs *faultyFS) Open(rel pathx.RelPath, opts fsx.OpenOptions) (fsx.File, error) {
 	if fs.hasFault(FaultOp_Open, rel) {
 		return nil, injectedFSError()
 	}
-	return fs.FS.Open(rel)
+	return fs.FS.Open(rel, opts)
 }
 
 func (fs *faultyFS) ReadFile(rel pathx.RelPath) ([]byte, error) {

--- a/common/fsx/fsx_testkit/symlink_other.go
+++ b/common/fsx/fsx_testkit/symlink_other.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 //go:build !windows
 
 package fsx_testkit

--- a/common/fsx/fsx_testkit/symlink_windows.go
+++ b/common/fsx/fsx_testkit/symlink_windows.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 //go:build windows
 
 package fsx_testkit

--- a/common/fsx/fsx_walk/errors.go
+++ b/common/fsx/fsx_walk/errors.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package fsx_walk
 
 import (

--- a/common/fsx/fsx_walk/example_test.go
+++ b/common/fsx/fsx_walk/example_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package fsx_walk_test
 
 import (

--- a/common/fsx/fsx_walk/walk.go
+++ b/common/fsx/fsx_walk/walk.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package fsx_walk provides directory walking over fsx.FS with optional
 // .gitignore handling.
 package fsx_walk
@@ -152,6 +156,9 @@ func (seq walkDirSeq) iterate(yield func(result.Result[FSWalkEntry]) bool) {
 		}
 
 		name := de.BaseName()
+		if seq.w.opts.RespectGitIgnore && name.String() == ".git" {
+			continue
+		}
 		child := seq.dir.JoinComponents(name.String())
 		isDir := de.IsDir()
 

--- a/common/fsx/fsx_walk/walk_test.go
+++ b/common/fsx/fsx_walk/walk_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package fsx_walk_test
 
 import (
@@ -108,6 +112,21 @@ ignored/
 			[]string{".gitignore", "sub", "sub/.gitignore", "sub/file.txt", "sub/keep.log"},
 			got,
 		)
+	})
+
+	h.Run("HidesGitMetadata", func(h check.Harness) {
+		h.Parallel()
+
+		fs := fsx_testkit.NewMemFS(h)
+		fsx_testkit.WriteTree(h, fs, map[string]string{
+			".git":       "gitdir: root\n",
+			".gitignore": "",
+			"file.txt":   "x",
+		})
+
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+		got := collectPaths(h, entries)
+		checkVisitedPaths(h, []string{".gitignore", "file.txt"}, got)
 	})
 
 	h.Run("RequiresFSRootRepo", func(h check.Harness) {
@@ -279,7 +298,7 @@ func testGitIgnore_ResetsAtNestedRepo(h check.Harness) {
 		checkVisitedPaths(
 			h,
 			[]string{
-				".gitignore", "nested", "nested/.git", "nested/child",
+				".gitignore", "nested", "nested/child",
 				"nested/child/file.txt", "nested/inside.txt",
 			},
 			got,

--- a/common/fsx/name.go
+++ b/common/fsx/name.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package fsx
 
 import "github.com/typesanitizer/happygo/common/fsx/fsx_name"

--- a/common/fsx/stat.go
+++ b/common/fsx/stat.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package fsx
 
 import (

--- a/common/fsx/stat_test.go
+++ b/common/fsx/stat_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package fsx_test
 
 import (

--- a/common/internal/constants/constants.go
+++ b/common/internal/constants/constants.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package constants collects shared internal constants.
 package constants
 

--- a/common/internal/pathx/pathx.go
+++ b/common/internal/pathx/pathx.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package pathx provides filepath utilities.
 package pathx
 

--- a/common/iterx/iterx.go
+++ b/common/iterx/iterx.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package iterx
 
 import (

--- a/common/iterx/iterx_test.go
+++ b/common/iterx/iterx_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package iterx_test
 
 import (

--- a/common/logx/cmd_loggers.go
+++ b/common/logx/cmd_loggers.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package logx
 
 import (

--- a/common/logx/log_ctx.go
+++ b/common/logx/log_ctx.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package logx
 
 import (

--- a/common/logx/logx.go
+++ b/common/logx/logx.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package logx provides a configured structured logger.
 // All logging in this project should use a logger obtained from this package.
 package logx

--- a/common/source_code/source_code.go
+++ b/common/source_code/source_code.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package source_code provides source-backed positions and snippets.
 package source_code
 

--- a/common/syscaps/syscaps.go
+++ b/common/syscaps/syscaps.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 // Package syscaps provides controlled access to ambient system capabilities.
 package syscaps
 

--- a/common/syscaps/syscaps_test.go
+++ b/common/syscaps/syscaps_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package syscaps_test
 
 import (

--- a/licenses/Polyform-Noncommercial-1.0.0.md
+++ b/licenses/Polyform-Noncommercial-1.0.0.md
@@ -1,0 +1,73 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/misc/cmd/happydo/list.go
+++ b/misc/cmd/happydo/list.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package main
 
 import (
@@ -15,7 +19,7 @@ import (
 
 func loadWorkspaceConfig(repoFS fsx.FS) (_ config.WorkspaceConfig, retErr error) {
 	path := NewRelPath("misc/repo-configuration.json")
-	f, err := repoFS.Open(path)
+	f, err := repoFS.Open(path, fsx.OpenOptions{Mode: fsx.OpenMode_ReadOnly})
 	if err != nil {
 		return config.WorkspaceConfig{}, errorx.Wrapf("+stacks", err, "open %s", path)
 	}

--- a/misc/cmd/happydo/list_test.go
+++ b/misc/cmd/happydo/list_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package main
 
 import (

--- a/misc/cmd/happydo/main.go
+++ b/misc/cmd/happydo/main.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package main
 
 import (

--- a/misc/cmd/happydo/sync_branch.go
+++ b/misc/cmd/happydo/sync_branch.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package main
 
 import (

--- a/misc/cmd/happydo/sync_branch_test.go
+++ b/misc/cmd/happydo/sync_branch_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package main
 
 import (

--- a/misc/cmd/happydo/sync_pr.go
+++ b/misc/cmd/happydo/sync_pr.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package main
 
 import (

--- a/misc/cmd/happydo/sync_pr_test.go
+++ b/misc/cmd/happydo/sync_pr_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package main
 
 import (

--- a/misc/cmd/happydo/update.go
+++ b/misc/cmd/happydo/update.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package main
 
 import (

--- a/misc/internal/config/types.go
+++ b/misc/internal/config/types.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package config
 
 import (

--- a/misc/internal/config/validate.go
+++ b/misc/internal/config/validate.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package config
 
 import (

--- a/misc/internal/config/validate_test.go
+++ b/misc/internal/config/validate_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package config
 
 import (

--- a/misc/internal/config/workspace_config.go
+++ b/misc/internal/config/workspace_config.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package config
 
 import (

--- a/misc/internal/licenses/licenses_test.go
+++ b/misc/internal/licenses/licenses_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package licenses
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"iter"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/typesanitizer/happygo/common/check"
+	. "github.com/typesanitizer/happygo/common/check/prelude"
+	. "github.com/typesanitizer/happygo/common/core"
+	"github.com/typesanitizer/happygo/common/errorx"
+	"github.com/typesanitizer/happygo/common/fsx"
+	"github.com/typesanitizer/happygo/common/fsx/fsx_walk"
+	"github.com/typesanitizer/happygo/common/syscaps"
+	"github.com/typesanitizer/happygo/misc/internal/config"
+)
+
+const firstPartyGoLicenseHeader = `// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+`
+
+func TestFirstPartyGoLicenseHeaders(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("license header check is sensitive to Git checkout line endings on Windows")
+	}
+
+	h := check.New(t)
+
+	workingDir := DoMsg(syscaps.WorkingDirectory())(h, "resolving working directory")
+	repoRoot := repoRootFromMiscDir(h, workingDir)
+	repoFS := DoMsg(syscaps.FS(repoRoot))(h, "opening repo FS rooted at %s", repoRoot)
+	wsConfig := loadWorkspaceConfig(h, repoFS)
+
+	results := visitFirstPartyGoFiles(h, repoFS, wsConfig, func(rel RelPath) Option[string] {
+		if ensureLicenseHeader(h, repoFS, rel) {
+			return None[string]()
+		}
+		return Some(rel.String())
+	})
+
+	var missing []string
+	for _, res := range results {
+		if path, ok := res.Get(); ok {
+			missing = append(missing, path)
+		}
+	}
+	slices.Sort(missing)
+
+	h.Assertf(len(missing) == 0,
+		"the following first-party Go files are missing the license header:\n%s\n"+
+			"hint: Run `go test ./misc/internal/licenses -update`",
+		strings.Join(missing, "\n"))
+}
+
+func repoRootFromMiscDir(h check.Harness, workingDir AbsPath) AbsPath {
+	h.T().Helper()
+
+	misc := fsx.NewName("misc")
+	for ancestor := range workingDir.Ancestors() {
+		if parent, baseName := ancestor.Split(); baseName == misc {
+			return parent
+		}
+	}
+	h.Assertf(false, "working directory %s is not within misc/", workingDir)
+	panic("unreachable")
+}
+
+func loadWorkspaceConfig(h check.Harness, repoFS fsx.FS) config.WorkspaceConfig {
+	h.T().Helper()
+
+	path := NewRelPath("misc/repo-configuration.json")
+	f := DoMsg(repoFS.Open(path, fsx.OpenOptions{Mode: fsx.OpenMode_ReadOnly}))(h, "opening %s", path)
+	defer h.Close(f)
+
+	return DoMsg(config.Load(f))(h, "loading %s", path)
+}
+
+func visitFirstPartyGoFiles[T any](
+	h check.Harness,
+	repoFS fsx.FS,
+	wsConfig config.WorkspaceConfig,
+	visit func(RelPath) T,
+) []T {
+	h.T().Helper()
+
+	var wg sync.WaitGroup
+	resultCh := make(chan T)
+	sem := semaphore.NewWeighted(int64(2 * runtime.GOMAXPROCS(0)))
+	enqueueVisit := func(rel RelPath) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h.NoErrorf(sem.Acquire(context.Background(), 1), "acquire license check semaphore")
+			defer sem.Release(1)
+			resultCh <- visit(rel)
+		}()
+	}
+
+	for entryRes := range repoFS.ReadDir(NewRelPath(".")) {
+		entry := DoMsg(entryRes.Get())(h, "reading repository root %s", repoFS.Root())
+		if !entry.IsDir() {
+			continue
+		}
+
+		name := entry.BaseName()
+		if _, isForked := wsConfig.ForkedFolders[name]; isForked {
+			continue
+		}
+
+		moduleRoot := NewRelPath(".").JoinComponents(name.String())
+		goModInfo, err := repoFS.Stat(moduleRoot.JoinComponents("go.mod"), fsx.StatOptions{
+			FollowFinalSymlink:     false,
+			OnErrorTraverseParents: false,
+		})
+		if err != nil && errorx.GetRootCauseAsValue(err, fsx.ErrNotExist) {
+			continue
+		}
+		h.NoErrorf(err, "checking for go.mod under %s", moduleRoot)
+		h.Assertf(goModInfo.Mode().IsRegular(), "%s/go.mod is not a regular file", moduleRoot)
+
+		h.T().Helper()
+
+		entries := DoMsg(fsx_walk.WalkNonDet(repoFS, moduleRoot, fsx_walk.WalkOptions{RespectGitIgnore: true}))(h, "walking %s", moduleRoot)
+		visitWalkEntries(h, moduleRoot, entries, enqueueVisit)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	var results []T
+	for res := range resultCh {
+		results = append(results, res)
+	}
+	return results
+}
+
+func visitWalkEntries(
+	h check.Harness,
+	parent RelPath,
+	entries iter.Seq[Result[fsx_walk.FSWalkEntry]],
+	visit func(RelPath),
+) {
+	h.T().Helper()
+
+	for entryRes := range entries {
+		entry := DoMsg(entryRes.Get())(h, "walking %s", parent)
+		entryName := entry.Name().String()
+		rel := parent.JoinComponents(entryName)
+		if entry.IsDir() {
+			visitWalkEntries(h, rel, entry.ChildrenNonDet(), visit)
+			continue
+		}
+		if strings.HasSuffix(rel.String(), ".go") {
+			visit(rel)
+		}
+	}
+}
+
+// ensureLicenseHeader reports whether rel has the required header, updating it when -update is set.
+func ensureLicenseHeader(h check.Harness, repoFS fsx.FS, rel RelPath) bool {
+	mode := fsx.OpenMode_ReadOnly
+	if check.IsUpdateFlagSet() {
+		mode = fsx.OpenMode_ReadWrite
+	}
+	f := DoMsg(repoFS.Open(rel, fsx.OpenOptions{Mode: mode}))(h, "open %s", rel)
+	defer h.Close(f)
+
+	var want bytes.Buffer
+	want.WriteString(firstPartyGoLicenseHeader)
+
+	var got bytes.Buffer
+	_, err := io.CopyN(&got, f, int64(want.Len()))
+	if err != nil && err != io.EOF {
+		h.NoErrorf(err, "read license header prefix from %s", rel)
+	}
+	if bytes.Equal(got.Bytes(), want.Bytes()) {
+		return true
+	}
+	if !check.IsUpdateFlagSet() {
+		return false
+	}
+
+	DoMsg(io.Copy(&got, f))(h, "read rest of %s", rel)
+	if end, ok := findLicenseHeaderEnd(got.Bytes()).Get(); ok {
+		got.Next(end)
+	}
+	want.Write(got.Bytes())
+
+	DoMsg(f.Seek(0, io.SeekStart))(h, "seek to start of %s", rel)
+	h.NoErrorf(f.Truncate(0), "truncate %s", rel)
+	_ = DoMsg(want.WriteTo(f))(h, "write updated %s", rel) // WriteTo succeeds => buffer was drained
+	return true
+}
+
+// findLicenseHeaderEnd returns the end offset of an existing header with an SPDX line.
+func findLicenseHeaderEnd(data []byte) Option[int] {
+	spdxPrefix := []byte("\n// SPDX-License-Identifier: ")
+	start := bytes.Index(data, spdxPrefix)
+	if start < 0 {
+		return None[int]()
+	}
+	endRel := bytes.IndexByte(data[start+len(spdxPrefix):], '\n')
+	if endRel < 0 {
+		return None[int]()
+	}
+	end := start + len(spdxPrefix) + endRel + 1
+	// Include blank line after the header, since firstPartyGoLicenseHeader includes it too
+	if end < len(data) && data[end] == '\n' {
+		end++
+	}
+	return Some(end)
+}

--- a/misc/mappings_test.go
+++ b/misc/mappings_test.go
@@ -1,3 +1,7 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
 package misc_test
 
 import (
@@ -28,7 +32,7 @@ func TestWorkspaceConfig(t *testing.T) {
 	h.Assertf(ok, "working directory %s must have a parent", workingDir)
 	repoFS := DoMsg(syscaps.FS(repoRoot))(h, "opening repo FS")
 
-	f := DoMsg(repoFS.Open(NewRelPath("misc/repo-configuration.json")))(h, "opening repo-configuration.json")
+	f := DoMsg(repoFS.Open(NewRelPath("misc/repo-configuration.json"), fsx.OpenOptions{Mode: fsx.OpenMode_ReadOnly}))(h, "opening repo-configuration.json")
 	t.Cleanup(func() { _ = f.Close() })
 
 	wsConfig := Do(config.Load(f))(h)


### PR DESCRIPTION
Adds a simple test that all the first-party code
has a license header to avoid accidentally merging
code without one. I think we'll eventually want to have
some OSS code as well; avoiding adding more configuration
knobs to the repo-configuration.json for now.

We can cross that bridge when we get there.
