### PR TITLE
feat: Add a simple Pair data type

### DIFF
--- a/common/core/pair.go
+++ b/common/core/pair.go
@@ -1,0 +1,15 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package core
+
+import "github.com/typesanitizer/happygo/common/core/pair"
+
+// Pair holds two values of (potentially different) types.
+type Pair[A, B any] = pair.Pair[A, B]
+
+// NewPair constructs a Pair from its two components.
+func NewPair[A, B any](first A, second B) Pair[A, B] {
+	return pair.NewPair(first, second)
+}

--- a/common/core/pair/pair.go
+++ b/common/core/pair/pair.go
@@ -12,3 +12,16 @@ type KeyValue[K, V any] struct {
 func NewKeyValue[K, V any](k K, v V) KeyValue[K, V] {
 	return KeyValue[K, V]{k, v}
 }
+
+type Pair[A, B any] struct {
+	First  A
+	Second B
+}
+
+func NewPair[A, B any](first A, second B) Pair[A, B] {
+	return Pair[A, B]{first, second}
+}
+
+func (p Pair[A, B]) Unpack() (A, B) {
+	return p.First, p.Second
+}


### PR DESCRIPTION
This is to avoid having variants of functions
which work for 1 return value and 2 return values.
