### PR TITLE
fix(assert): Make sure that assertion functions are inlinable

### DIFF
--- a/common/assert/assert.go
+++ b/common/assert/assert.go
@@ -27,6 +27,11 @@ func panicWith[R any](msg string, args []any) R {
 	panic(AssertionError{Fmt: msg, Args: args})
 }
 
+//go:noinline
+func panicWithMessage[R any](format string, msg string) R {
+	panic(AssertionError{Fmt: format, Args: []any{msg}})
+}
+
 // Always panics with a formatted message if b is false.
 func Always(b bool, msg string, args ...any) {
 	if !b {
@@ -37,7 +42,9 @@ func Always(b bool, msg string, args ...any) {
 // Precondition panics if b is false, prefixing the message with
 // "precondition violation: ".
 func Precondition(b bool, msg string) {
-	Preconditionf(b, "%s", msg)
+	if !b {
+		panicWithMessage[int]("precondition violation: %s", msg)
+	}
 }
 
 // Preconditionf is like Precondition but with a formatted message.
@@ -48,7 +55,9 @@ func Preconditionf(b bool, msg string, args ...any) {
 // Invariant panics if b is false, prefixing the message with
 // "invariant violation: ".
 func Invariant(b bool, msg string) {
-	Invariantf(b, "%s", msg)
+	if !b {
+		panicWithMessage[int]("invariant violation: %s", msg)
+	}
 }
 
 // Invariantf is like Invariant, but with a formatted message.
@@ -59,7 +68,9 @@ func Invariantf(b bool, msg string, args ...any) {
 // Postcondition panics if b is false, prefixing the message with
 // "postcondition violation: ".
 func Postcondition(b bool, msg string) {
-	Postconditionf(b, "%s", msg)
+	if !b {
+		panicWithMessage[int]("postcondition violation: %s", msg)
+	}
 }
 
 // Postconditionf is like Postcondition but with a formatted message.
@@ -69,12 +80,16 @@ func Postconditionf(b bool, msg string, args ...any) {
 
 // PanicInvariantViolation panics indicating an invariant was violated.
 // The return type R allows using it in a return statement.
+//
+//go:noinline
 func PanicInvariantViolation[R any](msg string, args ...any) R {
 	return panicWith[R]("invariant violation: "+msg, args)
 }
 
 // PanicUnknownCase panics with a message indicating an unhandled enum value.
 // The return type R allows using it in a return statement.
+//
+//go:noinline
 func PanicUnknownCase[R any, T any](t T) R {
 	return panicWith[R]("unknown value for type %T: %v", []any{t, t})
 }

--- a/common/assert/internal/codegen/codegen.go
+++ b/common/assert/internal/codegen/codegen.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package codegen
+
+import "github.com/typesanitizer/happygo/common/assert"
+
+type enum int
+
+const enumKnown enum = 1
+
+//go:noinline
+func UseAlways(b bool) {
+	assert.Always(b, "always violation: %d", 1)
+}
+
+//go:noinline
+func UsePrecondition(b bool) {
+	assert.Precondition(b, "precondition violation: %d")
+}
+
+//go:noinline
+func UsePreconditionf(b bool) {
+	assert.Preconditionf(b, "precondition violation: %d", 1)
+}
+
+//go:noinline
+func UseInvariant(b bool) {
+	assert.Invariant(b, "invariant violation: %d")
+}
+
+//go:noinline
+func UseInvariantf(b bool) {
+	assert.Invariantf(b, "invariant violation: %d", 1)
+}
+
+//go:noinline
+func UsePostcondition(b bool) {
+	assert.Postcondition(b, "postcondition violation: %d")
+}
+
+//go:noinline
+func UsePostconditionf(b bool) {
+	assert.Postconditionf(b, "postcondition violation: %d", 1)
+}
+
+//go:noinline
+func UsePanicInvariantViolation() int {
+	return assert.PanicInvariantViolation[int]("invariant violation: %d", 1)
+}
+
+//go:noinline
+func UsePanicUnknownCase() int {
+	return assert.PanicUnknownCase[int](enumKnown)
+}

--- a/common/assert/internal/codegen/codegen_test.go
+++ b/common/assert/internal/codegen/codegen_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package codegen
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/typesanitizer/happygo/common/check"
+	"github.com/typesanitizer/happygo/common/cmdx"
+	"github.com/typesanitizer/happygo/common/logx"
+	"github.com/typesanitizer/happygo/common/syscaps"
+)
+
+func TestAssertInliningDiagnostics(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	outPath := filepath.Join(h.T().TempDir(), "codegen.test")
+	cmd := cmdx.New(
+		"go",
+		"test",
+		"-c",
+		"-o", outPath,
+		"-gcflags=github.com/typesanitizer/happygo/common/assert=-m=2",
+		"-gcflags=github.com/typesanitizer/happygo/common/assert/internal/codegen=-m=2",
+		".",
+	)
+	ctx := logx.NewLogCtx(context.Background(), logx.NewLogger(io.Discard, logx.ColorSupport_Disable))
+	output, err := syscaps.CmdRunner{Env: syscaps.Env()}.Run(ctx, cmd, cmdx.RunOptionsDefault().WithCaptureStderr())
+	h.NoErrorf(err, "go test -c failed\n%s", output.Stderr)
+
+	inlineFunctions := []string{
+		"Always",
+		"Precondition",
+		"Preconditionf",
+		"Invariant",
+		"Invariantf",
+		"Postcondition",
+		"Postconditionf",
+	}
+	for _, name := range inlineFunctions {
+		pattern := regexp.MustCompile(`(?m)^.*codegen\.go:\d+:\d+: inlining call to assert\.` + name + `\b`)
+		h.Assertf(pattern.MatchString(output.Stderr), "missing inline diagnostic for assert.%s\n%s", name, output.Stderr)
+	}
+
+	panicFunctions := []string{
+		"PanicInvariantViolation",
+		"PanicUnknownCase",
+	}
+	for _, name := range panicFunctions {
+		inlinePattern := regexp.MustCompile(`inlining call to assert\.` + name + `\b`)
+		h.Assertf(!inlinePattern.MatchString(output.Stderr), "assert.%s was unexpectedly inlined\n%s", name, output.Stderr)
+
+		noInlinePattern := regexp.MustCompile(`cannot inline .*assert\.` + name + `.*marked go:noinline`)
+		h.Assertf(noInlinePattern.MatchString(output.Stderr), "missing noinline diagnostic for assert.%s\n%s", name, output.Stderr)
+	}
+}

--- a/common/cmdx/run.go
+++ b/common/cmdx/run.go
@@ -9,20 +9,33 @@ import (
 	"github.com/typesanitizer/happygo/common/logx"
 )
 
+// RunOutput contains output captured from a command invocation.
+type RunOutput struct {
+	Stdout string
+	Stderr string
+}
+
 // RunOptions configures BaseRunner.Run behavior.
 type RunOptions struct {
 	CaptureStdout bool
+	CaptureStderr bool
 	TransformEnv  func(envx.Env) envx.Env
 }
 
 // RunOptionsDefault returns default options for BaseRunner.Run.
 func RunOptionsDefault() RunOptions {
-	return RunOptions{CaptureStdout: false, TransformEnv: nil}
+	return RunOptions{CaptureStdout: false, CaptureStderr: false, TransformEnv: nil}
 }
 
 // WithCaptureStdout returns a copy with CaptureStdout set.
 func (o RunOptions) WithCaptureStdout() RunOptions {
 	o.CaptureStdout = true
+	return o
+}
+
+// WithCaptureStderr returns a copy with CaptureStderr set.
+func (o RunOptions) WithCaptureStderr() RunOptions {
+	o.CaptureStderr = true
 	return o
 }
 
@@ -33,10 +46,10 @@ func (o RunOptions) WithCaptureStdout() RunOptions {
 type BaseRunner interface {
 	// Run runs a command.
 	//
-	// The first return value is the captured stdout. There may be stdout
-	// even in the presence of errors. Stdout is only captured if
-	// options.CaptureStdout is true.
-	Run(_ logx.LogCtx, _ Cmd, options RunOptions) (string, error)
+	// The first return value contains captured output from enabled streams.
+	// There may be captured output even in the presence of errors. Stdout and
+	// stderr are only populated when their corresponding capture option is true.
+	Run(_ logx.LogCtx, _ Cmd, options RunOptions) (RunOutput, error)
 }
 
 // Runner executes single commands and sequential command lists.

--- a/common/syscaps/syscaps.go
+++ b/common/syscaps/syscaps.go
@@ -60,7 +60,7 @@ type CmdRunner struct {
 	Env envx.Env
 }
 
-func (runner CmdRunner) Run(ctx logx.LogCtx, cmd cmdx.Cmd, options cmdx.RunOptions) (string, error) {
+func (runner CmdRunner) Run(ctx logx.LogCtx, cmd cmdx.Cmd, options cmdx.RunOptions) (cmdx.RunOutput, error) {
 	dir, hasDir := cmd.Dir().Get()
 	if hasDir {
 		ctx.Debug("running command", "cmd", cmd, "dir", dir.String())
@@ -83,18 +83,26 @@ func (runner CmdRunner) Run(ctx logx.LogCtx, cmd cmdx.Cmd, options cmdx.RunOptio
 		execCmd.Env = runner.Env.Entries()
 	}
 
-	var capturedOutput bytes.Buffer
+	var capturedStdout bytes.Buffer
+	var capturedStderr bytes.Buffer
 	if options.CaptureStdout {
-		execCmd.Stdout = io.MultiWriter(stdout, &capturedOutput)
+		execCmd.Stdout = io.MultiWriter(stdout, &capturedStdout)
 	} else {
 		execCmd.Stdout = stdout
 	}
-	execCmd.Stderr = stderr
-
-	if err := execCmd.Run(); err != nil {
-		return capturedOutput.String(), errorx.Wrapf("+stacks", err, "%s", cmd)
+	if options.CaptureStderr {
+		execCmd.Stderr = io.MultiWriter(stderr, &capturedStderr)
+	} else {
+		execCmd.Stderr = stderr
 	}
-	return capturedOutput.String(), nil
+
+	capturedOutput := func() cmdx.RunOutput {
+		return cmdx.RunOutput{Stdout: capturedStdout.String(), Stderr: capturedStderr.String()}
+	}
+	if err := execCmd.Run(); err != nil {
+		return capturedOutput(), errorx.Wrapf("+stacks", err, "%s", cmd)
+	}
+	return capturedOutput(), nil
 }
 
 func (runner CmdRunner) ExecAll(ctx logx.LogCtx, cmds ...cmdx.Cmd) error {

--- a/misc/cmd/happydo/main.go
+++ b/misc/cmd/happydo/main.go
@@ -37,11 +37,11 @@ type Workspace struct {
 func newWorkspaceFromGit(runner cmdx.Runner) (Workspace, error) {
 	repoRootCmd := cmdx.New("git", "rev-parse", "--show-toplevel")
 	ctx := logx.NewLogCtx(context.Background(), logx.NewLogger(io.Discard, logx.ColorSupport_Disable))
-	out, err := runner.Run(ctx, repoRootCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
+	output, err := runner.Run(ctx, repoRootCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return Workspace{}, errorx.Wrapf("nostack", err, "determine git repository root")
 	}
-	repoRoot := NewAbsPath(strings.TrimSpace(out))
+	repoRoot := NewAbsPath(strings.TrimSpace(output.Stdout))
 	repoFS, err := syscaps.FS(repoRoot)
 	if err != nil {
 		return Workspace{}, errorx.Wrapf("+stacks", err, "open repo filesystem at %s", repoRoot)

--- a/misc/cmd/happydo/sync_branch.go
+++ b/misc/cmd/happydo/sync_branch.go
@@ -114,11 +114,11 @@ func deleteLocalBranchIfPresent(
 	ctx logx.LogCtx, runner cmdx.BaseRunner, worktreeDir AbsPath, branch string,
 ) error {
 	listCmd := cmdx.New("git", "branch", "--list", branch).In(worktreeDir)
-	out, err := runner.Run(ctx, listCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
+	output, err := runner.Run(ctx, listCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(out) == "" {
+	if strings.TrimSpace(output.Stdout) == "" {
 		return nil
 	}
 	deleteCmd := cmdx.New("git", "branch", "-D", branch).In(worktreeDir)
@@ -133,11 +133,11 @@ func findRemoteBranchHeadRef(
 
 	branchRef := "refs/heads/" + branch
 	lsRemoteCmd := cmdx.New("git", "ls-remote", "--heads", "origin", branchRef).In(worktreeDir)
-	out, err := runner.Run(ctx, lsRemoteCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
+	output, err := runner.Run(ctx, lsRemoteCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return None[remoteRef](), err
 	}
-	return parseSingleRemoteRef(branchRef, out)
+	return parseSingleRemoteRef(branchRef, output.Stdout)
 }
 
 func parseSingleRemoteRef(wantRef string, lsRemoteOutput string) (Option[remoteRef], error) {

--- a/misc/cmd/happydo/sync_pr.go
+++ b/misc/cmd/happydo/sync_pr.go
@@ -97,11 +97,11 @@ func runSyncPRProject(
 		return nil
 	}
 	headSHACmd := cmdx.New("git", "rev-parse", "origin/"+syncBranch).In(repoRoot)
-	headSHA, err := runner.Run(ctx, headSHACmd, cmdx.RunOptionsDefault().WithCaptureStdout())
+	headSHAOutput, err := runner.Run(ctx, headSHACmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return err
 	}
-	headSHA = strings.TrimSpace(headSHA)
+	headSHA := strings.TrimSpace(headSHAOutput.Stdout)
 	metadata, err := subtreeMetadataForSyncHead(ctx, runner, repoRoot, project, headSHA)
 	if err != nil {
 		return err
@@ -203,11 +203,11 @@ func subtreeMetadataForSyncHead(
 
 	var emptyMetadata subtreeMetadata
 	parentsCmd := cmdx.New("git", "show", "--no-patch", "--format=%P", headSHA).In(repoRoot)
-	parentsOut, err := runner.Run(ctx, parentsCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
+	parentsOutput, err := runner.Run(ctx, parentsCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return emptyMetadata, err
 	}
-	parentSHAs := strings.Fields(strings.TrimSpace(parentsOut))
+	parentSHAs := strings.Fields(strings.TrimSpace(parentsOutput.Stdout))
 	if len(parentSHAs) != 2 {
 		return emptyMetadata, errorx.Newf("nostack",
 			"expected sync head %q for %q to be a 2-parent merge commit, got %d parent(s)",
@@ -228,13 +228,13 @@ func listOpenPRs(
 		"--state", "open", "--base", base, "--head", head,
 		"--json", "number,url",
 	).In(repoRoot)
-	out, err := runner.Run(ctx, listPRsCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
+	output, err := runner.Run(ctx, listPRsCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return nil, err
 	}
 	var prs []ListOpenPRsData
-	if err := json.Unmarshal([]byte(out), &prs); err != nil {
-		return nil, errorx.Wrapf("+stacks", err, "parse gh pr list output: %s", out)
+	if err := json.Unmarshal([]byte(output.Stdout), &prs); err != nil {
+		return nil, errorx.Wrapf("+stacks", err, "parse gh pr list output: %s", output.Stdout)
 	}
 	return prs, nil
 }
@@ -251,7 +251,7 @@ func ensureLabelExists(
 		"gh", "label", "list",
 		"--search", name, "--json", "name", "--limit", "100",
 	).In(repoRoot)
-	out, err := runner.Run(ctx, listLabelsCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
+	output, err := runner.Run(ctx, listLabelsCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return err
 	}
@@ -259,7 +259,8 @@ func ensureLabelExists(
 		Name string `json:"name"`
 	}
 	// gh label list --search returns empty output (not "[]") when no labels match.
-	if out = strings.TrimSpace(out); out != "" {
+	out := strings.TrimSpace(output.Stdout)
+	if out != "" {
 		if err := json.Unmarshal([]byte(out), &labels); err != nil {
 			return errorx.Wrapf("+stacks", err, "parse gh label list output: %s", out)
 		}

--- a/misc/cmd/happydo/update.go
+++ b/misc/cmd/happydo/update.go
@@ -24,10 +24,10 @@ func (ws Workspace) runUpdate(ctx logx.LogCtx, dir AbsPath, localBranch string, 
 		subtreePullCmd := cmdx.New(
 			"git", "subtree", "pull", "--prefix", project.String(), upstreamURL, upstream.Branch,
 		).In(dir)
-		stdout, err := ws.Runner.Run(ctx, subtreePullCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
+		output, err := ws.Runner.Run(ctx, subtreePullCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 		if err != nil {
-			if stdout != "" {
-				ctx.Info("subtree pull stdout", "output", stdout)
+			if output.Stdout != "" {
+				ctx.Info("subtree pull stdout", "output", output.Stdout)
 			}
 			return err
 		}


### PR DESCRIPTION
This requires some tweaks to the implementation.
Weirdly enough, the compiler doesn't sink heap
allocations into branches, which is a real shame.
