### PR TITLE
refactor(logx): Reduce dependency on charmlog.Logger

### DIFF
--- a/common/logx/cmd_loggers.go
+++ b/common/logx/cmd_loggers.go
@@ -10,22 +10,21 @@ import (
 	"io"
 )
 
-// CmdLoggers returns line-oriented writers for command stdout and stderr streams.
-func (ctx LogCtx) CmdLoggers(command fmt.Stringer) (io.Writer, io.Writer) {
-	cmdLogger := ctx.With("cmd", command)
+type TraceLogger interface {
+	Trace(msg string, keyvals ...any)
+	GetLevel() Level
+}
 
-	stdout := io.Discard
-	if ctx.IsDebugEnabled() {
-		stdoutLogger := cmdLogger.With("stream", "stdout")
-		stdout = newLineLogger(func(msg []byte) {
-			stdoutLogger.Debug(string(msg))
-		})
+func CmdLoggers(logger TraceLogger, command fmt.Stringer) (io.Writer, io.Writer) {
+	if logger.GetLevel() > Level_Trace {
+		return io.Discard, io.Discard
 	}
-	stderrLogger := cmdLogger.With("stream", "stderr")
-	stderr := io.Writer(newLineLogger(func(msg []byte) {
-		stderrLogger.Info(string(msg))
-	}))
-
+	stdout := newLineLogger(func(msg []byte) {
+		logger.Trace(string(msg), "cmd", command, "stream", "stdout")
+	})
+	stderr := newLineLogger(func(msg []byte) {
+		logger.Trace(string(msg), "cmd", command, "stream", "stderr")
+	})
 	return stdout, stderr
 }
 

--- a/common/logx/log_ctx.go
+++ b/common/logx/log_ctx.go
@@ -14,16 +14,16 @@ import (
 type LogCtx struct {
 	context.Context
 	// Always non-nil.
-	*Logger
+	Logger
 }
 
 // NewLogCtx constructs a LogCtx from context and logger.
-func NewLogCtx(ctx context.Context, logger *Logger) LogCtx {
+func NewLogCtx(ctx context.Context, logger Logger) LogCtx {
 	assert.Precondition(logger != nil, "logger must be non-nil")
 	return LogCtx{Context: ctx, Logger: logger}
 }
 
 // IsDebugEnabled reports whether debug-level logs are enabled.
 func (ctx LogCtx) IsDebugEnabled() bool {
-	return ctx.GetLevel() <= DebugLevel
+	return ctx.GetLevel() <= Level_Debug
 }

--- a/common/logx/logx.go
+++ b/common/logx/logx.go
@@ -16,17 +16,34 @@ import (
 	"golang.org/x/term"
 )
 
-// Logger is a structured logger.
-type Logger = charmlog.Logger
+// Level is a logging severity.
+type Level = charmlog.Level
 
 // Re-exported log levels so callers don't need to import charmbracelet/log.
 const (
-	DebugLevel = charmlog.DebugLevel
-	InfoLevel  = charmlog.InfoLevel
-	WarnLevel  = charmlog.WarnLevel
-	ErrorLevel = charmlog.ErrorLevel
-	FatalLevel = charmlog.FatalLevel
+	// Level_Trace is below Level_Debug and is used for very high-volume output
+	// such as captured subprocess stdout/stderr.
+	Level_Trace Level = -8
+	Level_Debug       = charmlog.DebugLevel
+	Level_Info        = charmlog.InfoLevel
+	Level_Warn        = charmlog.WarnLevel
+	Level_Error       = charmlog.ErrorLevel
+	Level_Fatal       = charmlog.FatalLevel
 )
+
+// Logger is an interface to represent
+//
+// TODO: This should be refactored to use zap-style concrete types
+// for the keyvals instead of ...any.
+type Logger interface {
+	GetLevel() Level
+	With(keyvals ...any) Logger
+	Error(msg string, keyvals ...any)
+	Warn(msg string, keyvals ...any)
+	Info(msg string, keyvals ...any)
+	Debug(msg string, keyvals ...any)
+	Trace(msg string, keyvals ...any)
+}
 
 // ColorSupport controls whether the logger emits ANSI colors.
 type ColorSupport int
@@ -38,7 +55,7 @@ const (
 )
 
 // NewLogger creates a configured logger writing to w.
-func NewLogger(w io.Writer, cs ColorSupport) *Logger {
+func NewLogger(w io.Writer, cs ColorSupport) Logger {
 	color := false
 	switch cs {
 	case ColorSupport_Enable:
@@ -84,5 +101,26 @@ func NewLogger(w io.Writer, cs ColorSupport) *Logger {
 		logger.SetColorProfile(termenv.Ascii)
 	}
 
-	return logger
+	return &consoleLogger{inner: logger}
+}
+
+type consoleLogger struct {
+	inner *charmlog.Logger
+}
+
+func (l *consoleLogger) GetLevel() Level { return l.inner.GetLevel() }
+
+func (l *consoleLogger) With(keyvals ...any) Logger {
+	return &consoleLogger{inner: l.inner.With(keyvals...)}
+}
+
+func (l *consoleLogger) Error(msg string, keyvals ...any) { l.inner.Error(msg, keyvals...) }
+func (l *consoleLogger) Warn(msg string, keyvals ...any)  { l.inner.Warn(msg, keyvals...) }
+func (l *consoleLogger) Info(msg string, keyvals ...any)  { l.inner.Info(msg, keyvals...) }
+func (l *consoleLogger) Debug(msg string, keyvals ...any) { l.inner.Debug(msg, keyvals...) }
+
+func (l *consoleLogger) Trace(msg string, keyvals ...any) {
+	if l.inner.GetLevel() <= Level_Trace {
+		l.inner.Debug(msg, keyvals...)
+	}
 }

--- a/common/syscaps/syscaps.go
+++ b/common/syscaps/syscaps.go
@@ -68,7 +68,7 @@ func (runner CmdRunner) Run(ctx logx.LogCtx, cmd cmdx.Cmd, options cmdx.RunOptio
 		ctx.Debug("running command", "cmd", cmd)
 	}
 
-	stdout, stderr := ctx.CmdLoggers(cmd)
+	stdout, stderr := logx.CmdLoggers(ctx, cmd)
 	defer logx.FlushLogWriter(stdout)
 	defer logx.FlushLogWriter(stderr)
 

--- a/misc/cmd/happydo/list.go
+++ b/misc/cmd/happydo/list.go
@@ -55,7 +55,7 @@ type ListOptions struct {
 }
 
 // List writes folder names matching the options, one per line.
-func (w Workspace) List(logger *logx.Logger, out io.Writer, opts ListOptions) error {
+func (w Workspace) List(logger logx.Logger, out io.Writer, opts ListOptions) error {
 	switch opts.Type {
 	case ListType_GoModules:
 		return w.listGoModules(logger, out, opts.Provenance)
@@ -64,7 +64,7 @@ func (w Workspace) List(logger *logx.Logger, out io.Writer, opts ListOptions) er
 	}
 }
 
-func (w Workspace) listGoModules(logger *logx.Logger, out io.Writer, provenance ListProvenance) error {
+func (w Workspace) listGoModules(logger logx.Logger, out io.Writer, provenance ListProvenance) error {
 	folders, err := w.goModules(logger, provenance)
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func (w Workspace) listGoModules(logger *logx.Logger, out io.Writer, provenance 
 	return nil
 }
 
-func (w Workspace) goModules(logger *logx.Logger, provenance ListProvenance) ([]fsx.Name, error) {
+func (w Workspace) goModules(logger logx.Logger, provenance ListProvenance) ([]fsx.Name, error) {
 	rootRel := pathx.Dot()
 	var folders []fsx.Name
 	for entryRes := range w.FS.ReadDir(rootRel) {

--- a/misc/cmd/happydo/main.go
+++ b/misc/cmd/happydo/main.go
@@ -162,7 +162,7 @@ func main() {
 	}
 
 	if err := app.Run(context.Background(), os.Args); err != nil {
-		logger.Error(err)
+		logger.Error(err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
1. Make Logger an interface, reducing coupling.
2. Use our naming conventions TypeName_CaseName for cases.
3. Make cmdx depend on individual levels it cares about,
   instead of taking a full Logger
