### PR TITLE
feat(common): Add support for timing and cancellation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters:
       # common/core and common/check/prelude are designed for dot-import usage.
       - linters: [staticcheck]
         text: "ST1001"
-        source: 'common/core|common/check/prelude'
+        source: 'common/core|common/check/prelude|common/unit'
       - linters: [forbidigo]
         path: ^common/core/pathx/pathx.go$
         source: 'os\.(MkdirAll|MkdirTemp)'
@@ -71,6 +71,16 @@ linters:
           deny:
             - pkg: "time"
               desc: "use common/time instead"
+        NoStdlibContext:
+          files:
+            - $all
+            - "!**/common/cancel/*.go"
+            - "!**/common/cancel_bridge/*.go"
+            - "!**/cmd/**/main.go"
+          list-mode: lax
+          deny:
+            - pkg: "context"
+              desc: "use common/cancel.Token instead of context.Context; only common/cancel, common/cancel_bridge, and cli main.go files may import context"
         NoDirectSyscaps:
           files:
             - $all
@@ -93,7 +103,7 @@ linters:
     importas:
       no-unaliased: true
       alias:
-        - pkg: code.kibou.tools/common/(core|check/prelude)
+        - pkg: code.kibou.tools/common/(core|check/prelude|unit)
           alias: .
     exhaustruct:
       # NOTE: Even with allow-empty-returns: false, exhaustruct unconditionally
@@ -113,6 +123,8 @@ linters:
           msg: use common/logx instead of fmt.Print*
         - pattern: ^log\.Print(f|ln)?$
           msg: use common/logx instead of log.Print*
+        - pattern: ^time\.AfterFunc$
+          msg: use timex.Scheduler instead of time.AfterFunc
         - pattern: ^print(ln)?$
           msg: do not use builtin print/println
         - pattern: ^testing\.T\.Errorf$

--- a/common/assert/internal/codegen/codegen_test.go
+++ b/common/assert/internal/codegen/codegen_test.go
@@ -5,12 +5,12 @@
 package codegen
 
 import (
-	"context"
 	"io"
 	"path/filepath"
 	"regexp"
 	"testing"
 
+	"code.kibou.tools/common/cancel"
 	"code.kibou.tools/common/check"
 	"code.kibou.tools/common/cmdx"
 	"code.kibou.tools/common/logx"
@@ -31,7 +31,7 @@ func TestAssertInliningDiagnostics(t *testing.T) {
 		"-gcflags=code.kibou.tools/common/assert/internal/codegen=-m=2",
 		".",
 	)
-	ctx := logx.NewLogCtx(context.Background(), logx.NewLogger(io.Discard, logx.ColorSupport_Disable))
+	ctx := logx.NewLogCtx(cancel.Never(), logx.NewLogger(io.Discard, logx.ColorSupport_Disable))
 	output, err := syscaps.CmdRunner{Env: syscaps.Env()}.Run(ctx, cmd, cmdx.RunOptionsDefault().WithCaptureStderr())
 	h.NoErrorf(err, "go test -c failed\n%s", output.Stderr)
 

--- a/common/cancel/clock_token.go
+++ b/common/cancel/clock_token.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package cancel
+
+import (
+	"context"
+	stdlib_time "time" //nolint:depguard // cancel is the designated timer wrapper for ClockToken
+
+	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/cancel/deadline"
+	"code.kibou.tools/common/core/option"
+	"code.kibou.tools/common/timex"
+	. "code.kibou.tools/common/unit"
+)
+
+// --- Aliases for external use ---
+
+type Option = CancelOption
+
+// --- Package implementation ---
+
+// ClockToken is a token which will be automatically canceled
+// when the time crosses Deadline().
+//
+// You can think of a ClockToken as a triplet of:
+//
+//  1. A Token which can have children/propagates cancellation
+//     unidirectionally to them.
+//  2. A monotonic clock.
+//  3. A Deadline value, fixed at the time of creation.
+type ClockToken interface {
+	Token
+	timex.MonotonicClock
+
+	// Deadline returns Some(deadline) iff this token has an associated deadline.
+	//
+	// See the methods on [cancel.Deadline] for more information.
+	//
+	// Requirement: Implementations must return equal values across
+	// invocations.
+	Deadline() option.Option[Deadline]
+
+	// NewClockChild returns a ChildClockToken that is automatically
+	// canceled if the receiver is canceled.
+	// Cancellation flow is unidirectional: canceling the child does
+	// not affect the parent.
+	//
+	// The cancellation for the ChildClockToken can be controlled by:
+	//
+	//   1. Calling its [ChildToken.Cancel] method.
+	//   2. By customizing the options passed during construction.
+	NewClockChild(options ...CancelOption) ChildClockToken
+}
+
+type ChildClockToken interface {
+	ClockToken
+	ChildToken
+}
+
+// CancelOption represents a way of cancelling a ClockToken.
+//
+// The zero value of this type is invalid.
+// Use Timeout or Deadline for initialization.
+type CancelOption struct {
+	// Exactly one of timeout or deadline must be Some.
+	timeout  option.Option[timex.Duration]
+	deadline option.Option[timex.Instant]
+}
+
+// OnTimeout create a new CancelOption which indicates
+// cancellation after duration d from the creation of the
+// corresponding ClockToken.
+//
+// Pre-condition: d >= 0.
+func OnTimeout(d timex.Duration) CancelOption {
+	assert.Preconditionf(d >= 0, "duration must be >= 0, but got %v", d)
+	return CancelOption{timeout: option.Some(d), deadline: option.None[timex.Instant]()}
+}
+
+// OnDeadline creates a new CancelOption which indicates expiry
+// when a monotonic clock reaches the instant `i`.
+//
+// Pre-condition: !i.IsZero()
+func OnDeadline(i timex.Instant) CancelOption {
+	assert.Preconditionf(!i.IsZero(), "zero value for Instant indicates likely bug in caller")
+	// TODO: What pre-condition should we set here...? Ideally, Deadline()
+	// should be >= programStart, because it's almost certainly a bug if
+	// you're setting a deadline for a time before the program started.
+	// but that imposes a dependency on global state...
+	return CancelOption{timeout: option.None[timex.Duration](), deadline: option.Some(i)}
+}
+
+// Pre-conditions:
+//  1. parent must be non-nil.
+//  2. scheduler must be non-nil.
+func NewClockToken(parent Token, scheduler timex.Scheduler, opts ...CancelOption) ChildClockToken {
+	assert.Precondition(parent != nil, "parent token must be non-nil")
+	assert.Precondition(scheduler != nil, "scheduler must be non-nil")
+
+	var tightest option.Option[Deadline]
+	if parentClockToken, ok := parent.(ClockToken); ok {
+		if pd, ok := parentClockToken.Deadline().Get(); ok {
+			tightest = option.Some(pd.ReinterpretForChild())
+		}
+	}
+
+	var lazyNow option.Option[timex.Instant]
+	for _, opt := range opts {
+		instant, hasDeadline := opt.deadline.Get()
+		duration, hasTimeout := opt.timeout.Get()
+		if !hasDeadline && !hasTimeout {
+			assert.Precondition(false, "got zero CancelOption value as argument")
+		}
+		if hasDeadline && hasTimeout {
+			assert.Invariantf(false, "provided CancelOption %v, with both deadline and timeout; this should be impossible through the public API", opt)
+		}
+		if hasDeadline {
+			soonest(&tightest, deadline.New(instant, deadline.NewSource(deadline.Source_InitializedWithAbsoluteDeadline, 0)))
+		} else {
+			if lazyNow.IsNone() {
+				lazyNow = option.Some(scheduler.GetInstant())
+			}
+			now := lazyNow.Unwrap()
+			soonest(&tightest, deadline.New(now.Add(duration), deadline.NewSource(deadline.Source_InitializedWithTimeout, 0)))
+		}
+	}
+
+	return newClockTokenImpl(parent, scheduler, tightest, lazyNow)
+}
+
+func soonest(lhs *option.Option[Deadline], rhs Deadline) {
+	if lhsDeadline, ok := lhs.Get(); ok {
+		if !rhs.Instant().IsBefore(lhsDeadline.Instant()) {
+			return
+		}
+		// rhs < lhs
+	}
+	// rhs < lhs || lhs.IsNone()
+	*lhs = option.Some(rhs)
+}
+
+type clockToken struct {
+	// Always non-nil.
+	child ChildToken
+	// Always non-nil.
+	scheduler timex.Scheduler
+	deadline  option.Option[Deadline]
+	// Nil iff no future deadline was scheduled.
+	timer timex.ScheduledFunc
+}
+
+// Pre-conditions:
+// 1. parent is non-nil.
+// 2. scheduler is non-nil.
+func newClockTokenImpl(parent Token, scheduler timex.Scheduler, optDeadline option.Option[Deadline], lazyNow option.Option[timex.Instant]) *clockToken {
+	ct := &clockToken{
+		child:     parent.NewChild(),
+		scheduler: scheduler,
+		deadline:  optDeadline,
+		timer:     nil,
+	}
+	deadline_, ok := optDeadline.Get()
+	if !ok {
+		return ct
+	}
+	now, ok := lazyNow.Get()
+	if !ok {
+		now = scheduler.GetInstant()
+	}
+	delay := deadline_.Instant().Sub(now)
+	if delay <= 0 {
+		ct.child.Cancel(deadline.NewExceededError(deadline_))
+		return ct
+	}
+	ct.timer = scheduler.RunAfter(delay, func() {
+		ct.child.Cancel(deadline.NewExceededError(deadline_))
+	})
+	return ct
+}
+
+var _ Token = (*clockToken)(nil)
+
+func (c *clockToken) KeepGoing() error {
+	return c.child.KeepGoing()
+}
+
+func (c *clockToken) Done() <-chan Unit {
+	return c.child.Done()
+}
+
+func (c *clockToken) NewChild() ChildToken {
+	return c.child.NewChild()
+}
+
+func (c *clockToken) AsStdlibContext() context.Context {
+	return clockTokenContext{c: c}
+}
+
+var _ timex.MonotonicClock = (*clockToken)(nil)
+
+func (c *clockToken) GetInstant() timex.Instant {
+	return c.scheduler.GetInstant()
+}
+
+var _ ClockToken = (*clockToken)(nil)
+
+func (c *clockToken) Deadline() option.Option[Deadline] {
+	return c.deadline
+}
+
+func (c *clockToken) NewClockChild(opts ...CancelOption) ChildClockToken {
+	return NewClockToken(c, c.scheduler, opts...)
+}
+
+var _ ChildToken = (*clockToken)(nil)
+
+func (c *clockToken) Cancel(err error) CancelResult {
+	res := c.child.Cancel(err)
+	if c.timer != nil {
+		c.timer.Stop()
+	}
+	return res
+}
+
+type clockTokenContext struct {
+	// Always non-nil.
+	c *clockToken
+}
+
+var _ context.Context = (*clockTokenContext)(nil)
+
+func (cc clockTokenContext) Deadline() (stdlib_time.Time, bool) {
+	d, ok := cc.c.deadline.Get()
+	if !ok {
+		return stdlib_time.Time{}, false
+	}
+	return d.Instant().AsStdlibTime(), true
+}
+
+func (cc clockTokenContext) Done() <-chan struct{} {
+	return cc.c.Done()
+}
+
+func (cc clockTokenContext) Err() error {
+	return stdlibContextErr(cc.c.KeepGoing())
+}
+
+func (cc clockTokenContext) Value(_ any) any {
+	return nil
+}

--- a/common/cancel/clock_token_test.go
+++ b/common/cancel/clock_token_test.go
@@ -1,0 +1,366 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package cancel_test
+
+import (
+	"slices"
+	"testing"
+	stdlib_time "time" //nolint:depguard // tests need deterministic timex.Instant values
+
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/common/cancel"
+	"code.kibou.tools/common/cancel/deadline"
+	"code.kibou.tools/common/check"
+	"code.kibou.tools/common/check/pbt/flat"
+	"code.kibou.tools/common/core/option"
+	"code.kibou.tools/common/errorx"
+	"code.kibou.tools/common/timex"
+)
+
+func TestClockToken(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("Unit", testClockTokenUnit)
+	h.Run("Properties", testClockTokenProperties)
+}
+
+func testClockTokenUnit(h check.Harness) {
+	h.Parallel()
+
+	h.Run("timeout", func(h check.Harness) {
+		h.Parallel()
+
+		scheduler := newManualScheduler()
+		start := scheduler.GetInstant()
+		timeout := 5 * timex.Second
+		tok := cancel.NewClockToken(cancel.Never(), scheduler, cancel.OnTimeout(timeout))
+
+		d, ok := tok.Deadline().Get()
+		h.Assertf(ok, "token should have a deadline")
+		h.Assertf(d.Instant().Equals(start.Add(timeout)), "deadline instant = %v, want start+5s", d.Instant())
+		h.Assertf(d.Source() == deadline.NewSource(deadline.Source_InitializedWithTimeout, 0), "deadline source = %v", d.Source())
+		h.Assertf(scheduler.PendingCount() == 1, "pending timers = %d, want 1", scheduler.PendingCount())
+		h.Assertf(tok.KeepGoing() == nil, "token should initially be live")
+
+		scheduler.Advance(timeout - timex.Nanosecond)
+		h.Assertf(tok.KeepGoing() == nil, "token should be live before deadline")
+		scheduler.Advance(timex.Nanosecond)
+		h.Assertf(tok.KeepGoing() != nil, "token should be expired after deadline")
+
+		gotErr := errorx.GetRootCauseAs[deadline.ExceededError](tok.KeepGoing()).Unwrap()
+		h.Assertf(gotErr.Deadline().Instant().Compare(d.Instant()) == 0, "exceeded deadline instant = %v, want %v", gotErr.Deadline().Instant(), d.Instant())
+		h.Assertf(scheduler.PendingCount() == 0, "pending timers = %d, want 0", scheduler.PendingCount())
+	})
+
+	h.Run("synchronous cancellation", func(h check.Harness) {
+		h.Parallel()
+
+		scheduler := newManualScheduler()
+		base := scheduler.GetInstant()
+		tok := cancel.NewClockToken(cancel.Never(), scheduler, cancel.OnDeadline(base))
+
+		gotErr := errorx.GetRootCauseAs[deadline.ExceededError](tok.KeepGoing()).Unwrap()
+		h.Assertf(gotErr.Deadline().Instant().Compare(base) == 0, "exceeded deadline instant = %v, want base", gotErr.Deadline().Instant())
+		h.Assertf(scheduler.PendingCount() == 0, "pending timers = %d, want 0", scheduler.PendingCount())
+	})
+
+	h.Run("cancellation cause is sticky", func(h check.Harness) {
+		h.Parallel()
+
+		scheduler := newManualScheduler()
+		tok := cancel.NewClockToken(cancel.Never(), scheduler, cancel.OnTimeout(5*timex.Second))
+		errBoom := errorx.New("nostack", "boom")
+
+		h.Assertf(tok.Cancel(errBoom) == cancel.Result_CanceledByUs, "first cancel should win")
+		h.Assertf(tok.KeepGoing() == errBoom, "KeepGoing() = %v, want errBoom", tok.KeepGoing())
+		h.Assertf(scheduler.PendingCount() == 0, "pending timers = %d, want 0", scheduler.PendingCount())
+
+		scheduler.Advance(5 * timex.Second)
+		h.Assertf(tok.KeepGoing() == errBoom, "deadline expiry should not replace explicit cancellation cause")
+	})
+
+	h.Run("parent deadline propagates", func(h check.Harness) {
+		h.Parallel()
+
+		parentTimeout := 5 * timex.Second
+		childTimeout := 10 * timex.Second
+
+		scheduler := newManualScheduler()
+		parent := cancel.NewClockToken(cancel.Never(), scheduler, cancel.OnTimeout(parentTimeout))
+		child := parent.NewClockChild(cancel.OnTimeout(childTimeout))
+
+		parentDeadline := parent.Deadline().Unwrap()
+		childDeadline := child.Deadline().Unwrap()
+		h.Assertf(parentDeadline.Instant() == childDeadline.Instant(),
+			"child deadline instant = %v, want %v", childDeadline.Instant(), parentDeadline.Instant())
+	})
+}
+
+// A tree of ChildClockToken values.
+//
+// For each token, there is one nominal deadline source:
+// - No deadline
+// - Timeout based deadline (from the token's creation instant)
+// - Absolute deadline
+//
+// Creation times are weakly monotonic along any path down the tree, but sibling
+// subtrees may be created in either order. We first generate that model tree,
+// then drive one scheduler monotonically through all creation/deadline events.
+// As nominal deadlines pass, those tokens should cancel their whole subtrees.
+func testClockTokenProperties(h check.Harness) {
+	h.Parallel()
+
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		scheduler := newManualScheduler()
+		nodeBudget := rapid.IntRange(1, 10).Draw(t, "node_budget")
+		nextIndex := 1
+
+		base := scheduler.GetInstant()
+		rootCreationTime := drawClockTokenCreationTime(t, base)
+		rootOpts, rootOwnDeadline := drawClockTokenDeadline(t, rootCreationTime)
+
+		tree := flat.UnfoldTree(
+			clockTokenTreeNode{
+				creationTime: rootCreationTime,
+				opts:         rootOpts,
+				ownDeadline:  rootOwnDeadline,
+			},
+			func(node clockTokenTreeNode, yieldChild func(clockTokenTreeNode)) clockTokenTreeNode {
+				remaining := nodeBudget - nextIndex
+				if remaining > 0 {
+					childCount := rapid.IntRange(0, min(remaining, 4)).Draw(t, "child_count")
+					for range childCount {
+						nextIndex++
+						childCreationTime := drawClockTokenCreationTime(t, node.creationTime)
+						childOpts, childOwnDeadline := drawClockTokenDeadline(t, childCreationTime)
+						yieldChild(clockTokenTreeNode{
+							creationTime: childCreationTime,
+							opts:         childOpts,
+							ownDeadline:  childOwnDeadline,
+						})
+					}
+				}
+				return node
+			},
+		)
+
+		type clockTokenEventKind uint8
+		const (
+			clockTokenEvent_Create clockTokenEventKind = iota + 1
+			clockTokenEvent_Deadline
+		)
+		type clockTokenEvent struct {
+			at   timex.Instant
+			kind clockTokenEventKind
+			id   flat.TreeID
+		}
+		var events []clockTokenEvent
+		for i := range tree.NodeCount() {
+			id := tree.ID(i)
+			node := tree.Value(id)
+			events = append(events, clockTokenEvent{at: node.creationTime, kind: clockTokenEvent_Create, id: id})
+			if d, ok := node.ownDeadline.Get(); ok {
+				events = append(events, clockTokenEvent{at: d, kind: clockTokenEvent_Deadline, id: id})
+			}
+		}
+		slices.SortFunc(events, func(lhs, rhs clockTokenEvent) int {
+			if cmp := lhs.at.Compare(rhs.at); cmp != 0 {
+				return cmp
+			}
+			if lhs.kind != rhs.kind {
+				return int(lhs.kind) - int(rhs.kind)
+			}
+			return lhs.id.Compare(rhs.id)
+		})
+
+		created := make([]bool, tree.NodeCount())
+		tokens := make([]cancel.ChildClockToken, tree.NodeCount())
+		assertCanceled := func(expectedAll []bool) {
+			expected := make([]bool, tree.NodeCount())
+			got := make([]bool, tree.NodeCount())
+			for j := range got {
+				if !created[j] {
+					continue
+				}
+				node := tree.Value(tree.ID(j))
+				tok := tokens[j]
+				expected[j] = expectedAll[j]
+				got[j] = tok.KeepGoing() != nil
+				h.Assertf(tok.GetInstant().Compare(scheduler.GetInstant()) == 0, "node %d clock should be scheduler clock", j)
+
+				gotDeadline, gotDeadlineOK := tok.Deadline().Get()
+				gotDeadlineAgain, gotDeadlineAgainOK := tok.Deadline().Get()
+				h.Assertf(gotDeadlineOK == gotDeadlineAgainOK, "node %d Deadline presence changed between calls", j)
+				if gotDeadlineOK {
+					h.Assertf(gotDeadline == gotDeadlineAgain, "node %d Deadline value changed between calls", j)
+				}
+				h.Assertf(!node.creationTime.IsAfter(scheduler.GetInstant()), "node %d should not be created in the future", j)
+			}
+			check.AssertSame(h, expected, got, "canceled tokens")
+		}
+
+		createToken := func(id flat.TreeID) {
+			node := tree.Value(id)
+			if id.Index() == 0 {
+				tokens[id.Index()] = cancel.NewClockToken(cancel.Never(), scheduler, node.opts...)
+			} else {
+				parentID := tree.ParentID(id).Unwrap()
+				h.Assertf(created[parentID.Index()], "parent %d should be created before child %d", parentID.Index(), id.Index())
+				tokens[id.Index()] = tokens[parentID.Index()].NewClockChild(node.opts...)
+			}
+			created[id.Index()] = true
+		}
+
+		var expiredIDs []flat.TreeID
+		now := base
+		for eventIndex := 0; eventIndex < len(events); {
+			eventInstant := events[eventIndex].at
+			scheduler.Advance(eventInstant.Sub(now))
+			now = eventInstant
+
+			for eventIndex < len(events) && events[eventIndex].at.Compare(eventInstant) == 0 {
+				event := events[eventIndex]
+				switch event.kind {
+				case clockTokenEvent_Create:
+					createToken(event.id)
+				case clockTokenEvent_Deadline:
+					expiredIDs = append(expiredIDs, event.id)
+				}
+				eventIndex++
+			}
+
+			sortedExpiredIDs := slices.Clone(expiredIDs)
+			slices.SortFunc(sortedExpiredIDs, flat.TreeID.Compare)
+			assertCanceled(tree.MarkSubtrees(sortedExpiredIDs))
+		}
+	})
+}
+
+type clockTokenTreeNode struct {
+	creationTime timex.Instant
+	opts         []cancel.Option
+	// None iff this token has no deadline directly configured on itself.
+	ownDeadline option.Option[timex.Instant]
+}
+
+func drawClockTokenCreationTime(t *rapid.T, earliest timex.Instant) timex.Instant {
+	d := timex.Duration(rapid.IntRange(0, 10).Draw(t, "creation_delay_seconds")) * timex.Second
+	return earliest.Add(d)
+}
+
+func drawClockTokenDeadline(t *rapid.T, creationTime timex.Instant) ([]cancel.Option, option.Option[timex.Instant]) {
+	deadlineKind := rapid.IntRange(0, 2).Draw(t, "deadline_kind")
+	if deadlineKind == 0 {
+		return nil, option.None[timex.Instant]()
+	}
+	d := timex.Duration(rapid.IntRange(0, 10).Draw(t, "deadline_seconds")) * timex.Second
+	at := creationTime.Add(d)
+	if deadlineKind == 1 {
+		return []cancel.Option{cancel.OnTimeout(d)}, option.Some(at)
+	}
+	return []cancel.Option{cancel.OnDeadline(at)}, option.Some(at)
+}
+
+type manualScheduler struct {
+	now    timex.Instant
+	nextID int
+	// Nil iff no functions have been scheduled.
+	timers []*manualScheduledFunc
+}
+
+var _ timex.Scheduler = (*manualScheduler)(nil)
+
+func newManualScheduler() *manualScheduler {
+	return &manualScheduler{
+		now:    timex.NewInstant(stdlib_time.Unix(1_000, 0)),
+		nextID: 0,
+		timers: nil,
+	}
+}
+
+func (s *manualScheduler) GetInstant() timex.Instant {
+	return s.now
+}
+
+func (s *manualScheduler) RunAfter(d timex.Duration, f func()) timex.ScheduledFunc {
+	if d < 0 {
+		panic("negative duration")
+	}
+	if f == nil {
+		panic("nil scheduled function")
+	}
+	s.nextID++
+	timer := &manualScheduledFunc{
+		id:      s.nextID,
+		at:      s.now.Add(d),
+		f:       f,
+		started: false,
+		stopped: false,
+	}
+	s.timers = append(s.timers, timer)
+	return timer
+}
+
+func (s *manualScheduler) Advance(d timex.Duration) {
+	if d < 0 {
+		panic("negative duration")
+	}
+	target := s.now.Add(d)
+	for {
+		timer := s.nextReadyTimer(target)
+		if timer == nil {
+			break
+		}
+		s.now = timer.at
+		timer.started = true
+		timer.f()
+	}
+	s.now = target
+}
+
+func (s *manualScheduler) PendingCount() int {
+	count := 0
+	for _, timer := range s.timers {
+		if !timer.started && !timer.stopped {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *manualScheduler) nextReadyTimer(target timex.Instant) *manualScheduledFunc {
+	var best *manualScheduledFunc
+	for _, timer := range s.timers {
+		if timer.started || timer.stopped || timer.at.IsAfter(target) {
+			continue
+		}
+		if best == nil || timer.at.IsBefore(best.at) || (timer.at.Compare(best.at) == 0 && timer.id < best.id) {
+			best = timer
+		}
+	}
+	return best
+}
+
+type manualScheduledFunc struct {
+	id int
+	at timex.Instant
+	// Always non-nil.
+	f       func()
+	started bool
+	stopped bool
+}
+
+var _ timex.ScheduledFunc = (*manualScheduledFunc)(nil)
+
+func (f *manualScheduledFunc) Stop() timex.StopResult {
+	if f.started || f.stopped {
+		return timex.StopResult_TooLate
+	}
+	f.stopped = true
+	return timex.StopResult_Stopped
+}

--- a/common/cancel/deadline/deadline.go
+++ b/common/cancel/deadline/deadline.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package deadline
+
+import (
+	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/timex"
+)
+
+// --- Aliases for exported use ---
+
+type Source = DeadlineSource
+type SourceKind = DeadlineSourceKind
+type ExceededError = DeadlineExceededError
+
+// --- Package implementation ---
+
+type Deadline struct {
+	instant timex.Instant
+	source  DeadlineSource
+}
+
+func New(instant timex.Instant, source DeadlineSource) Deadline {
+	return Deadline{instant, source}
+}
+
+func (d Deadline) Instant() timex.Instant {
+	return d.instant
+}
+
+func (d Deadline) Source() DeadlineSource {
+	return d.source
+}
+
+type DeadlineExceededError struct {
+	deadline Deadline
+}
+
+func NewExceededError(deadline Deadline) DeadlineExceededError {
+	return DeadlineExceededError{deadline}
+}
+
+func (e DeadlineExceededError) Error() string {
+	return "cancel: deadline exceeded"
+}
+
+func (e DeadlineExceededError) Deadline() Deadline {
+	return e.deadline
+}
+
+// ReinterpretForChild interprets the current Deadline as a potential
+// Deadline for a child token.
+func (d Deadline) ReinterpretForChild() Deadline {
+	var newSource DeadlineSourceKind
+	var newDepth int
+	switch source := d.source; source.kind {
+	case Source_InitializedWithTimeout:
+		newSource = Source_AncestorTimeout
+		newDepth = 1
+	case Source_InitializedWithAbsoluteDeadline:
+		newSource = Source_AncestorAbsoluteDeadline
+		newDepth = 1
+	case Source_AncestorTimeout, Source_AncestorAbsoluteDeadline:
+		newSource = source.kind
+		newDepth = source.ancestorLevel + 1
+	default:
+		assert.PanicUnknownCase[DeadlineSourceKind](source.kind)
+	}
+	return New(d.instant, NewSource(newSource, newDepth))
+}
+
+type DeadlineSourceKind uint8
+
+const (
+	// Source_AncestorTimeout indicates that a particular deadline
+	Source_AncestorTimeout DeadlineSourceKind = iota + 1
+	Source_AncestorAbsoluteDeadline
+	Source_InitializedWithTimeout
+	Source_InitializedWithAbsoluteDeadline
+)
+
+type DeadlineSource struct {
+	kind DeadlineSourceKind
+	// See NewDeadlineSource for invariants
+	ancestorLevel int
+}
+
+// Pre-condition:
+//   - If kind is Source_InitializedWithTimeout
+//     or Source_InitializedWithAbsoluteDeadline,
+//     then ancestorLevel == 0
+//   - If kind is Source_AncestorTimeout
+//     or Source_AncestorAbsoluteDeadline,
+//     then ancestorLevel >= 1
+func NewSource(kind DeadlineSourceKind, ancestorLevel int) DeadlineSource {
+	switch kind {
+	case Source_InitializedWithTimeout, Source_InitializedWithAbsoluteDeadline:
+		assert.Preconditionf(ancestorLevel == 0, "got ancestorLevel=%d for DeadlineSourceKind %v", ancestorLevel, kind)
+	case Source_AncestorTimeout, Source_AncestorAbsoluteDeadline:
+		assert.Preconditionf(ancestorLevel >= 1, "got ancestorLevel=%d for DeadlineSourceKind %v", ancestorLevel, kind)
+	}
+	return DeadlineSource{kind, ancestorLevel}
+}

--- a/common/cancel/never_token.go
+++ b/common/cancel/never_token.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package cancel
+
+import (
+	"context"
+
+	. "code.kibou.tools/common/unit"
+)
+
+var neverTokenSingleton = neverToken{}
+
+// Never returns a Token that is never canceled.
+//
+// Generally a replacement for [context.Background] from the standard library.
+func Never() Token {
+	return &neverTokenSingleton
+}
+
+// neverToken in a more lightweight implementation of Token
+//
+// Since this cannot be canceled, there's no notion of propagating
+// the cancellation to a child, so we don't need to track children,
+// unlike rawToken.
+type neverToken struct{}
+
+var _ Token = (*neverToken)(nil)
+
+func (neverToken) KeepGoing() error {
+	return nil
+}
+
+func (neverToken) Done() <-chan Unit {
+	return nil
+}
+
+func (t neverToken) AsStdlibContext() context.Context {
+	return tokenContext{tok: t}
+}
+
+func (neverToken) NewChild() ChildToken {
+	return newChildToken(nil)
+}

--- a/common/cancel/reexports.go
+++ b/common/cancel/reexports.go
@@ -1,0 +1,9 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package cancel
+
+import "code.kibou.tools/common/cancel/deadline"
+
+type Deadline = deadline.Deadline

--- a/common/cancel/stdlib_context_test.go
+++ b/common/cancel/stdlib_context_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package cancel_test
+
+import (
+	"context"
+	"testing"
+
+	"code.kibou.tools/common/cancel"
+	"code.kibou.tools/common/check"
+	"code.kibou.tools/common/errorx"
+	"code.kibou.tools/common/timex"
+)
+
+func TestAsStdlibContext(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("never token", func(h check.Harness) {
+		h.Parallel()
+
+		tok := cancel.Never()
+		ctx := tok.AsStdlibContext()
+
+		_, ok := ctx.Deadline()
+		h.Assertf(!ok, "Never().AsStdlibContext().Deadline() should report no deadline")
+		h.Assertf(ctx.Done() == nil, "Never().AsStdlibContext().Done() = %v, want nil", ctx.Done())
+		h.Assertf(ctx.Err() == nil, "Never().AsStdlibContext().Err() = %v, want nil", ctx.Err())
+		h.Assertf(ctx.Value("key") == nil, "Never().AsStdlibContext().Value() should always be nil")
+	})
+
+	h.Run("child token", func(h check.Harness) {
+		h.Parallel()
+
+		errBoom := errorx.New("nostack", "boom")
+		tok := cancel.Never().NewChild()
+		ctx := tok.AsStdlibContext()
+
+		_, ok := ctx.Deadline()
+		h.Assertf(!ok, "child context should report no deadline")
+		h.Assertf(ctx.Done() == tok.Done(), "context Done channel should be token Done channel")
+		h.Assertf(ctx.Err() == nil, "live child context Err() = %v, want nil", ctx.Err())
+		h.Assertf(ctx.Value("key") == nil, "child context Value() should always be nil")
+
+		select {
+		case <-ctx.Done():
+			h.Assertf(false, "context Done channel closed before token cancellation")
+		default:
+		}
+
+		tok.Cancel(errBoom)
+		select {
+		case <-ctx.Done():
+		default:
+			h.Assertf(false, "context Done channel did not close after token cancellation")
+		}
+		h.Assertf(errorx.GetRootCauseAsValue(ctx.Err(), context.Canceled), "canceled child context Err() = %v, want %v", ctx.Err(), context.Canceled)
+	})
+
+	h.Run("clock token without deadline", func(h check.Harness) {
+		h.Parallel()
+
+		scheduler := newManualScheduler()
+		tok := cancel.NewClockToken(cancel.Never(), scheduler)
+		ctx := tok.AsStdlibContext()
+
+		_, ok := ctx.Deadline()
+		h.Assertf(!ok, "clock context without cancel options should report no deadline")
+		h.Assertf(ctx.Done() == tok.Done(), "clock context Done channel should be token Done channel")
+		h.Assertf(ctx.Err() == nil, "live clock context Err() = %v, want nil", ctx.Err())
+		h.Assertf(ctx.Value("key") == nil, "clock context Value() should always be nil")
+	})
+
+	h.Run("clock token with deadline", func(h check.Harness) {
+		h.Parallel()
+
+		scheduler := newManualScheduler()
+		start := scheduler.GetInstant()
+		timeout := 5 * timex.Second
+		tok := cancel.NewClockToken(cancel.Never(), scheduler, cancel.OnTimeout(timeout))
+		ctx := tok.AsStdlibContext()
+
+		gotDeadline, ok := ctx.Deadline()
+		h.Assertf(ok, "clock context should report configured deadline")
+		wantDeadline := start.Add(timeout).AsStdlibTime()
+		h.Assertf(gotDeadline.Equal(wantDeadline), "clock context deadline = %v, want %v", gotDeadline, wantDeadline)
+		h.Assertf(ctx.Done() == tok.Done(), "clock context Done channel should be token Done channel")
+		h.Assertf(ctx.Err() == nil, "live clock context Err() = %v, want nil", ctx.Err())
+		h.Assertf(ctx.Value("key") == nil, "clock context Value() should always be nil")
+
+		scheduler.Advance(timeout)
+		select {
+		case <-ctx.Done():
+		default:
+			h.Assertf(false, "clock context Done channel did not close after deadline")
+		}
+		h.Assertf(errorx.GetRootCauseAsValue(ctx.Err(), context.DeadlineExceeded), "expired clock context Err() = %v, want %v", ctx.Err(), context.DeadlineExceeded)
+	})
+}

--- a/common/cancel/token.go
+++ b/common/cancel/token.go
@@ -1,0 +1,398 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package cancel provides cause-aware cancellation tokens.
+package cancel
+
+import (
+	"context"
+	"slices"
+	"sync"
+	stdlib_time "time" //nolint:depguard // cancel is the designated context wrapper
+
+	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/cancel/deadline"
+	"code.kibou.tools/common/collections"
+	"code.kibou.tools/common/errorx"
+	. "code.kibou.tools/common/unit"
+)
+
+// --- Aliases for package-external use ---
+
+type Result = CancelResult
+
+// --- Package implementation ---
+
+// Token is the base cancellation primitive.
+//
+// A token is a simple state machine:
+//
+//		 Alive ─► Canceled
+//	           │      ▲
+//	           └──────┘
+//
+// Once it has been canceled, it stays canceled.
+type Token interface {
+	// KeepGoing returns nil if the Token is still live, or a non-nil error
+	// describing why cancellation occurred.
+	//
+	// Requirement: If the reason for cancellation is the crossing of a deadline,
+	// then the error must be a deadline.ExceededError as its root cause.
+	KeepGoing() error
+
+	// Done returns a channel that is closed when the Token is canceled.
+	//
+	// This is meant to be used in select statements.
+	Done() <-chan Unit
+
+	// NewChild returns a ChildToken that is automatically canceled if the receiver
+	// is canceled. Cancellation flow is unidirectional: canceling the child does
+	// not affect the parent.
+	//
+	// In most cases, you don't really need to use this unless you're implementing
+	// a data type related to unstructured concurrency yourself.
+	//
+	// If you want to cancel subtasks based on a timeout, take a look
+	// at [ClockToken.NewClockChild] instead.
+	NewChild() ChildToken
+
+	// AsStdlibContext() reinterprets this cancellation token as a [context.Context]
+	// value from the standard library.
+	//
+	// This is used for bridging into APIs which only work with [context.Context].
+	// The [context.Context.Value] method will return nil for all keys.
+	AsStdlibContext() context.Context
+}
+
+// CancelResult reports whether a cancellation attempt
+// triggered cancellation, or if the token was already
+// canceled earlier.
+type CancelResult int
+
+const (
+	// Result_CanceledByUs means this Cancel call transitioned the token
+	// from live to canceled and fixed the token's cancellation error.
+	Result_CanceledByUs CancelResult = iota + 1
+
+	// Result_AlreadyCanceled means the token was already canceled by someone else.
+	Result_AlreadyCanceled
+)
+
+// ChildToken is both a cancellation signal and the authority to cancel that signal.
+type ChildToken interface {
+	Token
+
+	// Cancel attempts to cancel the token with err.
+	//
+	// There are two possibilities:
+	//
+	//   1. The token was already canceled.
+	//   2. The token was canceled by this particular Cancel invocation.
+	//
+	// The return value provides that information.
+	//
+	// Pre-condition: err != nil.
+	//
+	// Requirement: Cancel must run synchronously. In particular, the
+	// following must be guaranteed:
+	//
+	//     tok.Cancel(someErr)
+	//     gotErr := tok.KeepGoing()
+	//     assert.Invariant(gotErr != nil, "Cancel is synchronous")
+	Cancel(err error) CancelResult
+}
+
+type tokenContext struct {
+	tok Token
+}
+
+func (c tokenContext) Deadline() (stdlib_time.Time, bool) {
+	return stdlib_time.Time{}, false
+}
+
+func (c tokenContext) Done() <-chan struct{} {
+	return c.tok.Done()
+}
+
+func (c tokenContext) Err() error {
+	return stdlibContextErr(c.tok.KeepGoing())
+}
+
+func (c tokenContext) Value(_ any) any {
+	return nil
+}
+
+func stdlibContextErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errorx.GetRootCauseAs[deadline.ExceededError](err).IsSome() {
+		return context.DeadlineExceeded
+	}
+	return context.Canceled
+}
+
+type rawToken struct {
+	// Cancelable parent.
+	//
+	// Nil when one of the following is true:
+	//   - Created under Never().
+	//   - Parent was already canceled during child construction.
+	//
+	// May remain non-nil after cancellation.
+	// Immutable after construction.
+	parent *rawToken
+
+	// Index in parent.children.
+	//
+	// Valid only when:
+	//   - parent != nil.
+	//   - parent.children[parentIdx] == this token.
+	//
+	// Protected by parent.mu, not this token's mu.
+	// (This implies that a single token's mu can protect
+	// arbitrary many children's parentIdx.)
+	parentIdx int
+
+	// Protects:
+	//   - err.
+	//   - children.
+	//   - parentIdx of each c in children (not our own)
+	//
+	// Does not protect:
+	//   - parent: immutable after construction.
+	//   - done: immutable after construction.
+	mu sync.Mutex
+
+	// Closed when canceled.
+	//
+	// Always non-nil.
+	done chan Unit
+
+	// Direct children registered for cancellation propagation.
+	//
+	// Nil when either:
+	//   - No children are registered.
+	//   - This token is canceled.
+	children []*rawToken
+
+	// Cancellation cause.
+	//
+	// Nil while alive. Non-nil after cancellation. Set once.
+	err error
+}
+
+// newChildToken creates a new rawToken that has the
+// `parent` argument as its parent.
+//
+// parent may be nil. If not, the parent's registerChild
+// method will be called.
+func newChildToken(parent *rawToken) *rawToken {
+	t := &rawToken{
+		parent:    parent,
+		parentIdx: 0,
+		mu:        sync.Mutex{},
+		done:      make(chan Unit),
+		children:  nil,
+		err:       nil,
+	}
+	if parent == nil {
+		return t
+	}
+	if err := parent.registerChild(t); err != nil {
+		t.parent = nil
+		t.Cancel(err)
+	}
+	return t
+}
+
+var _ Token = (*rawToken)(nil)
+
+func (t *rawToken) KeepGoing() error {
+	t.mu.Lock()
+	err := t.err
+	t.mu.Unlock()
+	return err
+}
+
+func (t *rawToken) Done() <-chan Unit {
+	return t.done
+}
+
+func (t *rawToken) AsStdlibContext() context.Context {
+	return tokenContext{tok: t}
+}
+
+func (t *rawToken) NewChild() ChildToken {
+	return newChildToken(t)
+}
+
+func (t *rawToken) Cancel(err error) CancelResult {
+	assert.Precondition(err != nil, "Cancel called with nil error")
+
+	// Use a queue to avoid recursion in cancellation.
+	// Generally, a token tree shouldn't be deep, but avoiding
+	// recursion eliminates the risk of stack overflow.
+	queue := collections.NewDeque[*rawToken]()
+	result := t.cancelSelfAndDetachChildren(err, &queue)
+	switch result {
+	case Result_CanceledByUs:
+		if t.parent != nil {
+			t.parent.unregisterChild(t)
+		}
+		// Use BFS instead of DFS for fairness/more intuitive behavior
+		// for the common case where only t is canceled but none of
+		// its descendants have been (directly) canceled.
+		for {
+			if descendant, ok := queue.TryPopFront().Get(); ok {
+				descendant.cancelSelfAndDetachChildren(err, &queue)
+				continue
+			}
+			break
+		}
+		return result
+	case Result_AlreadyCanceled:
+		// If the receiver was already canceled, then that cancellation logic
+		// will handle cancellation of descendants too, so there's nothing
+		// to do here. Don't double-cancel descendants.
+		return Result_AlreadyCanceled
+	default:
+		return assert.PanicUnknownCase[CancelResult](result)
+	}
+}
+
+// registerChild registers the child token as belonging to the receiver.
+//
+// Returns an error if the receiver has already been canceled.
+//
+// Pre-condition: The child pointer is owning/not accessed concurrently.
+//
+// Post-condition: If there's no error, child.parentIdx is set to the
+// child's position in the receiver's [rawToken.children] slice.
+func (t *rawToken) registerChild(child *rawToken) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.err != nil {
+		return t.err
+	}
+	child.parentIdx = len(t.children)
+	t.children = append(t.children, child)
+	return nil
+}
+
+// unregisterChild unregisters the child token from the receiver's list.
+//
+// This method is meant to be called only during the cancellation of
+// the `child` argument.
+//
+// Pre-condition: The receiver is the parent of the child argument.
+func (t *rawToken) unregisterChild(child *rawToken) {
+	parent := t
+	parent.mu.Lock()
+	defer parent.mu.Unlock()
+	if parent.err != nil {
+		// Our parent was canceled while `child` is being canceled.
+		// Since we have the lock now, it means that cancelSelfAndDetachChildren
+		// must've finished, so parent.children must be nil.
+		// Assert that as a sanity check.
+		assert.Invariant(parent.children == nil, "canceled token has children")
+		// Since parent.children is already nil, the parent's cancellation
+		// logic will handle cleanup of the old slice; there's nothing we
+		// can do here.
+		return
+	}
+	// parent.err == nil => parent is alive right now.
+	//
+	// child.parentIdx is protected by parent.mu (acquired above),
+	// so this read won't race.
+	idx := child.parentIdx
+
+	n := len(parent.children)
+	{
+		// Perform some sanity checks that parentIdx is correct.
+		if idx < 0 || n <= idx {
+			assert.PanicInvariantViolation[any]("child.parentIdx (%d) not in [0, %d); please report this as a bug", idx, n)
+			return
+		}
+		if c := parent.children[idx]; c != child {
+			assert.PanicInvariantViolation[any]("child token (%p) at index differs from child being unregistered (%p); please report this as a bug", c, child)
+			return
+		}
+	}
+	// idx ∈ [0, n) => n >= 1
+	last := n - 1 // n >= 1 => last ∈ [0, n)
+	if idx != last {
+		// Move last child earlier to be able to trim the slice's tail.
+		moved := parent.children[last]
+		parent.children[idx] = moved
+		// parent is alive => ∀ c ∈ parent.children, c.parent == parent
+		if moved.parent != parent {
+			assert.PanicInvariantViolation[any]("child token (%p) has parent (%p), but it's registered as child of token %p",
+				moved, moved.parent, parent)
+			return
+		}
+		// Write to parentIdx is OK, because moved is also a child of parent,
+		// so its parentIdx field is also protected by parent.mu
+		moved.parentIdx = idx
+	}
+	parent.children[last] = nil // eagerly drop reference to child for GC
+	parent.children = parent.children[:last]
+	if last == 0 {
+		// Restore field invariant that parent.children = nil iff there are no registered children
+		parent.children = nil
+		return
+	}
+	// n >= 2 because (last == 0 <=> n == 2) was already handled above.
+	newLen := n - 1 // n >= 2 => newLen >= 1
+
+	// Try to free up space if the slice is being underutilized.
+	// The 25% utilization threshold is chosen arbitrarily.
+	if 4*newLen <= cap(parent.children) {
+		// TODO: We don't have strong guarantees about the capacity
+		// of the buffer returned by slices.Clone. We need a guarantee
+		// here that the utilization percentage will exceed 25%,
+		// or perhaps a stronger guarantee that we won't have to Clone
+		// the slice again on the next removal.
+		parent.children = slices.Clone(parent.children)
+	}
+}
+
+// cancelSelfAndDetachChildren cancels the receiver (if it hasn't
+// already been canceled). If the receiver token has any children,
+// they are pushed to the back of the queue parameter.
+//
+// The detailed cancellation sequence is:
+//
+//  1. Lock t.mu.
+//  2. Set t.err.
+//  3. Close t.done.
+//  4. Detach t.children.
+//  5. Unlock t.mu.
+//  6. Enqueue detached children.
+//
+// Rationale:
+//   - Set err before closing done so waiters can observe the cause.
+//   - Detach children under mu so only one caller owns propagation.
+//   - Enqueue after unlock to avoid growing queue while holding t.mu.
+//
+// Pre-condition: queue != nil.
+func (t *rawToken) cancelSelfAndDetachChildren(err error, queue *collections.Deque[*rawToken]) CancelResult {
+	assert.Precondition(queue != nil, "cancelSelfAndDetachChildren should be able to append to queue")
+	t.mu.Lock()
+	if t.err != nil {
+		t.mu.Unlock()
+		return Result_AlreadyCanceled
+	}
+	t.err = err
+	close(t.done)
+	children := t.children
+	t.children = nil
+	t.mu.Unlock()
+
+	queue.ReserveMore(len(children))
+	for _, child := range children {
+		queue.PushBack(child)
+	}
+	return Result_CanceledByUs
+}

--- a/common/cancel/token_interleaving_test.go
+++ b/common/cancel/token_interleaving_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package cancel
+
+import (
+	"testing"
+
+	"code.kibou.tools/common/check"
+	"code.kibou.tools/common/errorx"
+)
+
+func TestConcurrentChildAndParentCancelInterleaving(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("whitebox", func(h check.Harness) {
+		h.Parallel()
+
+		errBoom := errorx.New("nostack", "boom")
+		parent := newChildToken(nil)
+		child := parent.NewChild().(*rawToken)
+
+		h.Assertf(parent.Cancel(errBoom) == Result_CanceledByUs, "parent cancellation should win")
+		h.Assertf(parent.KeepGoing() == errBoom, "parent KeepGoing() = %v, want errBoom", parent.KeepGoing())
+		h.Assertf(child.KeepGoing() == errBoom, "child should have been canceled by parent")
+		h.Assertf(parent.children == nil, "canceled parent should have detached children")
+
+		// This state can occur when a child cancellation reaches unregisterChild after
+		// parent cancellation has already detached the child list. Call the helper
+		// directly to cover that deterministic branch without relying on scheduler
+		// races.
+		parent.unregisterChild(child)
+	})
+
+	h.Run("blackbox", func(h check.Harness) {
+		h.Parallel()
+
+		for attempt := range 10 {
+			parent := Never().NewChild()
+			child := parent.NewChild()
+			for range 1_000 {
+				child.NewChild()
+			}
+
+			errChild := errorx.Newf("nostack", "child cancel attempt %d", attempt)
+			errParent := errorx.Newf("nostack", "parent cancel attempt %d", attempt)
+			childCancelReturned := make(chan struct{})
+			go func() {
+				defer close(childCancelReturned)
+				child.Cancel(errChild)
+			}()
+
+			// child.Done is closed before child unregisters itself from parent.
+			// The grandchildren above make it more likely that parent.Cancel runs
+			// during that window and exercises unregisterChild's parent-already-canceled
+			// path. The test's correctness does not rely on winning that race; coverage
+			// can be used to check whether the interleaving was observed in a run.
+			<-child.Done()
+			parent.Cancel(errParent)
+			<-childCancelReturned
+
+			h.Assertf(parent.KeepGoing() != nil, "attempt %d: parent should be canceled", attempt)
+			h.Assertf(child.KeepGoing() != nil, "attempt %d: child should be canceled", attempt)
+		}
+	})
+}

--- a/common/cancel/token_test.go
+++ b/common/cancel/token_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package cancel_test
+
+import (
+	"slices"
+	"sync"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/common/cancel"
+	"code.kibou.tools/common/check"
+	"code.kibou.tools/common/check/pbt/flat"
+	"code.kibou.tools/common/errorx"
+)
+
+func TestChildTokenCancel(t *testing.T) {
+	h := check.New(t)
+
+	errBoom := errorx.New("nostack", "boom")
+	tok := cancel.Never().NewChild()
+	h.Assertf(tok.KeepGoing() == nil, "new child should be live")
+	h.Assertf(tok.Cancel(errBoom) == cancel.Result_CanceledByUs, "first cancel should win")
+	h.Assertf(tok.KeepGoing() == errBoom, "KeepGoing() = %v, want errBoom", tok.KeepGoing())
+	h.Assertf(tok.Cancel(errorx.New("nostack", "second boom")) == cancel.Result_AlreadyCanceled,
+		"second cancel should lose")
+	h.Assertf(tok.KeepGoing() == errBoom, "second cancel should not replace cause")
+}
+
+func TestTokenTreeCancellation(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	rapid.Check(h.T(), func(t *rapid.T) {
+		basic := check.NewBasic(t)
+		nodeBudget := rapid.IntRange(1, 10).Draw(t, "node_budget")
+		nextIndex := 1
+
+		type ChildToken = cancel.ChildToken
+
+		tree := flat.UnfoldTree(cancel.Never().NewChild(), func(tok ChildToken, yieldChild func(ChildToken)) ChildToken {
+			remaining := nodeBudget - nextIndex
+			if remaining > 0 {
+				childCount := rapid.IntRange(0, min(remaining, 4)).Draw(t, "child_count")
+				for range childCount {
+					nextIndex++
+					yieldChild(tok.NewChild())
+				}
+			}
+			return tok
+		})
+
+		allIDs := make([]flat.TreeID, tree.NodeCount())
+		for i := range allIDs {
+			allIDs[i] = tree.ID(i)
+		}
+		cancelIDs := rapid.SliceOfN(rapid.SampledFrom(allIDs), 0, tree.NodeCount()).Draw(t, "cancel_ids")
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var expected []bool
+		go func() {
+			defer wg.Done()
+			sortedCancelIDs := slices.Clone(cancelIDs)
+			slices.SortFunc(sortedCancelIDs, flat.TreeID.Compare)
+			expected = tree.MarkSubtrees(sortedCancelIDs)
+		}()
+
+		for _, id := range cancelIDs {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				tree.Value(id).Cancel(errorx.Newf("nostack", "cancel token %d", id.Index()))
+			}()
+		}
+		wg.Wait()
+
+		got := make([]bool, tree.NodeCount())
+		for i := range got {
+			id := tree.ID(i)
+			got[i] = tree.Value(id).KeepGoing() != nil
+		}
+		check.AssertSame(basic, expected, got, "canceled tokens")
+	})
+}
+
+func TestCancel_NoStackOverflow(t *testing.T) {
+	h := check.New(t)
+
+	errBoom := errorx.New("nostack", "boom")
+	root := cancel.Never().NewChild()
+	var leaf cancel.Token = root
+	for range 100_000 {
+		leaf = leaf.NewChild()
+	}
+	root.Cancel(errBoom)
+	<-leaf.Done()
+	h.Assertf(leaf.KeepGoing() == errBoom, "leaf KeepGoing() = %v, want errBoom", leaf.KeepGoing())
+}

--- a/common/cancel_bridge/cancel_bridge.go
+++ b/common/cancel_bridge/cancel_bridge.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package cancel_bridge is used for hiding a cancel.Token
+// inside a [context.Context].
+//
+// Generally, this is needed when using third-party APIs involving
+// callbacks, where one registers callbacks of type func(context.Context, SomeArgs) error
+// and primary API is invoked with func(context.Context, OtherArgs) error.
+package cancel_bridge
+
+import (
+	"context" //nolint:depguard // cancel_bridge is the designated context-interop wrapper
+
+	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/cancel"
+)
+
+type tokenKey struct{}
+
+// Pre-condition: tok is non-nil.
+func Inject(ctx context.Context, tok cancel.Token) context.Context {
+	assert.Precondition(tok != nil, "tok argument must be non-nil")
+	return context.WithValue(ctx, tokenKey{}, tok)
+}
+
+// Pre-condition: The argument ctx's construction should've used [cancel_bridge.Inject].
+func Extract(ctx context.Context) cancel.Token {
+	tok, ok := ctx.Value(tokenKey{}).(cancel.Token)
+	assert.Preconditionf(ok, "no cancel.Token present on context; cancel_bridge.Inject was not called")
+	return tok
+}

--- a/common/check/pbt/flat/tree.go
+++ b/common/check/pbt/flat/tree.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package flat provides flat data structures.
+package flat
+
+import (
+	"math"
+
+	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/core/option"
+)
+
+const rootParentIndex int32 = -1
+
+// TreeID identifies a node in a [Tree].
+type TreeID struct {
+	index int32
+}
+
+// Index returns the stable breadth-first index for this tree node.
+func (id TreeID) Index() int {
+	return int(id.index)
+}
+
+func (id TreeID) Compare(other TreeID) int {
+	return int(id.index) - int(other.index)
+}
+
+// Tree is a rooted tree stored in breadth-first order.
+type Tree[T any] struct {
+	// Always non-nil. Contains at least one node.
+	nodes []node[T]
+}
+
+type node[T any] struct {
+	value T
+	// rootParentIndex iff this is the root.
+	parentIndex int32
+	// Immediate children are stored in nodes[childStart:childEnd].
+	childStart int32
+	childEnd   int32
+}
+
+// UnfoldTree constructs a rooted tree from a root seed.
+//
+// For each seed, f returns the corresponding node value and may call yieldChild
+// zero or more times to append child seeds. Nodes are stored in breadth-first
+// order, and a node's immediate children are stored contiguously.
+//
+// The yieldChild callback must only be called during the invocation of f that
+// received it. Calling it after f returns is a pre-condition violation.
+//
+// Pre-conditions:
+//  1. f is non-nil.
+//  2. f eventually stops yielding child seeds.
+//  3. the total number of yielded nodes is <= math.MaxInt32.
+func UnfoldTree[Seed, T any](root Seed, f func(seed Seed, yieldChild func(Seed)) T) Tree[T] {
+	assert.Precondition(f != nil, "unfold function must be non-nil")
+
+	var zero T
+	nodes := []node[T]{{
+		value:       zero,
+		parentIndex: rootParentIndex,
+		childStart:  0,
+		childEnd:    0,
+	}}
+	seeds := []Seed{root}
+	for index := 0; index < len(nodes); index++ {
+		childStart := len(nodes)
+		active := true
+		value := f(seeds[index], func(child Seed) {
+			assert.Precondition(active, "yieldChild called after unfold callback returned")
+			assert.Precondition(len(nodes) < math.MaxInt32, "tree cannot contain more than math.MaxInt32 nodes")
+			nodes = append(nodes, node[T]{
+				value:       zero,
+				parentIndex: int32(index),
+				childStart:  0,
+				childEnd:    0,
+			})
+			seeds = append(seeds, child)
+		})
+		active = false
+		nodes[index].value = value
+		nodes[index].childStart = int32(childStart)
+		nodes[index].childEnd = int32(len(nodes))
+	}
+	return Tree[T]{nodes: nodes}
+}
+
+func (t Tree[T]) NodeCount() int {
+	return len(t.nodes)
+}
+
+// ID returns the [TreeID] with index.
+//
+// Pre-condition: index is in [0, NodeCount()).
+func (t Tree[T]) ID(index int) TreeID {
+	t.checkIndex(index, "node index")
+	return TreeID{index: int32(index)}
+}
+
+// Value returns the value stored at id.
+//
+// Pre-condition: id belongs to this tree.
+func (t Tree[T]) Value(id TreeID) T {
+	t.checkID(id, "node ID")
+	return t.nodes[id.index].value
+}
+
+// ParentID returns the parent ID for id, or None for the root.
+//
+// Pre-condition: id belongs to this tree.
+func (t Tree[T]) ParentID(id TreeID) option.Option[TreeID] {
+	t.checkID(id, "node ID")
+	parentIndex := t.nodes[id.index].parentIndex
+	if parentIndex == rootParentIndex {
+		return option.None[TreeID]()
+	}
+	return option.Some(TreeID{index: parentIndex})
+}
+
+// ChildIDs returns the immediate children of id.
+//
+// Pre-condition: id belongs to this tree.
+func (t Tree[T]) ChildIDs(id TreeID) []TreeID {
+	t.checkID(id, "node ID")
+	node := t.nodes[id.index]
+	children := make([]TreeID, 0, node.childEnd-node.childStart)
+	for childIndex := node.childStart; childIndex < node.childEnd; childIndex++ {
+		children = append(children, TreeID{index: childIndex})
+	}
+	return children
+}
+
+// MarkSubtrees returns a bool slice of length NodeCount marking every node in
+// the subtree of any ID in sortedIDs.
+//
+// Pre-conditions:
+//  1. every ID in sortedIDs belongs to this tree.
+//  2. sortedIDs is sorted by [TreeID.Compare].
+func (t Tree[T]) MarkSubtrees(sortedIDs []TreeID) []bool {
+	marked := make([]bool, t.NodeCount())
+	for _, id := range sortedIDs {
+		t.markSubtree(id, marked)
+	}
+	return marked
+}
+
+func (t Tree[T]) markSubtree(root TreeID, marked []bool) {
+	t.checkID(root, "node ID")
+	if marked[root.Index()] {
+		return
+	}
+	marked[root.Index()] = true
+	for _, childID := range t.ChildIDs(root) {
+		t.markSubtree(childID, marked)
+	}
+}
+
+func (t Tree[T]) checkID(id TreeID, what string) {
+	t.checkIndex(id.Index(), what)
+}
+
+func (t Tree[T]) checkIndex(index int, what string) {
+	assert.Preconditionf(0 <= index && index < t.NodeCount(), "%s %d out of range [0, %d)", what, index, t.NodeCount())
+}

--- a/common/cmdx/run.go
+++ b/common/cmdx/run.go
@@ -5,6 +5,7 @@
 package cmdx
 
 import (
+	"code.kibou.tools/common/cancel"
 	"code.kibou.tools/common/envx"
 	"code.kibou.tools/common/logx"
 )
@@ -39,6 +40,13 @@ func (o RunOptions) WithCaptureStderr() RunOptions {
 	return o
 }
 
+type RunCtx interface {
+	cancel.Token
+	Debug(msg string, keyvals ...any)
+	Trace(msg string, keyvals ...any)
+	GetLevel() logx.Level
+}
+
 // BaseRunner executes a single command.
 //
 // Run is intended for non-streaming use cases. If we later need streaming
@@ -46,10 +54,13 @@ func (o RunOptions) WithCaptureStderr() RunOptions {
 type BaseRunner interface {
 	// Run runs a command.
 	//
-	// The first return value contains captured output from enabled streams.
-	// There may be captured output even in the presence of errors. Stdout and
-	// stderr are only populated when their corresponding capture option is true.
-	Run(_ logx.LogCtx, _ Cmd, options RunOptions) (RunOutput, error)
+	// The return value contains captured stdout and/or stderr,
+	// based on options.
+	//
+	// CAUTION: If options.CaptureStdout is true, there may be
+	// the returned RunOutput.Stdout may be non-empty even if
+	// err != nil.
+	Run(_ RunCtx, _ Cmd, options RunOptions) (RunOutput, error)
 }
 
 // Runner executes single commands and sequential command lists.
@@ -57,10 +68,10 @@ type Runner interface {
 	BaseRunner
 	// ExecAll runs cmds sequentially with default options, stopping at
 	// the first error.
-	ExecAll(_ logx.LogCtx, cmds ...Cmd) error
+	ExecAll(_ RunCtx, cmds ...Cmd) error
 }
 
-func BaseRunnerExecAll(runner BaseRunner, ctx logx.LogCtx, cmds ...Cmd) error {
+func BaseRunnerExecAll(runner BaseRunner, ctx RunCtx, cmds ...Cmd) error {
 	for _, cmd := range cmds {
 		if _, err := runner.Run(ctx, cmd, RunOptionsDefault()); err != nil {
 			return err

--- a/common/collections/deque.go
+++ b/common/collections/deque.go
@@ -9,6 +9,7 @@ import (
 	"math"
 
 	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/core/option"
 )
 
 // Deque is a double-ended queue implemented as a growable
@@ -112,6 +113,13 @@ func (b *Deque[T]) PushBack(value T) {
 	idx := b.nextBackIndex()
 	b.values[idx] = value
 	b.len++
+}
+
+func (b *Deque[T]) TryPopFront() option.Option[T] {
+	if b.len == 0 {
+		return option.None[T]()
+	}
+	return option.Some(b.PopFront())
 }
 
 // PopFront removes and returns the front element.

--- a/common/go.mod
+++ b/common/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/muesli/termenv v0.16.0
 	golang.org/x/term v0.40.0
+	pgregory.net/rapid v1.2.0
 )
 
 require (
@@ -230,7 +231,6 @@ require (
 	honnef.co/go/tools v0.6.1 // indirect
 	mvdan.cc/gofumpt v0.9.2 // indirect
 	mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 // indirect
-	pgregory.net/rapid v1.2.0 // indirect
 )
 
 // NOTE(id: workspace-tool-directives): In workspace mode, go tool resolves

--- a/common/logx/log_ctx.go
+++ b/common/logx/log_ctx.go
@@ -5,22 +5,21 @@
 package logx
 
 import (
-	"context"
-
 	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/cancel"
 )
 
-// LogCtx carries a logger and context together.
+// LogCtx carries a logger and cancellation token together.
 type LogCtx struct {
-	context.Context
+	cancel.Token
 	// Always non-nil.
 	Logger
 }
 
-// NewLogCtx constructs a LogCtx from context and logger.
-func NewLogCtx(ctx context.Context, logger Logger) LogCtx {
+// NewLogCtx constructs a LogCtx from a token and logger.
+func NewLogCtx(tok cancel.Token, logger Logger) LogCtx {
 	assert.Precondition(logger != nil, "logger must be non-nil")
-	return LogCtx{Context: ctx, Logger: logger}
+	return LogCtx{Token: tok, Logger: logger}
 }
 
 // IsDebugEnabled reports whether debug-level logs are enabled.

--- a/common/syscaps/syscaps.go
+++ b/common/syscaps/syscaps.go
@@ -60,7 +60,7 @@ type CmdRunner struct {
 	Env envx.Env
 }
 
-func (runner CmdRunner) Run(ctx logx.LogCtx, cmd cmdx.Cmd, options cmdx.RunOptions) (cmdx.RunOutput, error) {
+func (runner CmdRunner) Run(ctx cmdx.RunCtx, cmd cmdx.Cmd, options cmdx.RunOptions) (cmdx.RunOutput, error) {
 	dir, hasDir := cmd.Dir().Get()
 	if hasDir {
 		ctx.Debug("running command", "cmd", cmd, "dir", dir.String())
@@ -73,7 +73,7 @@ func (runner CmdRunner) Run(ctx logx.LogCtx, cmd cmdx.Cmd, options cmdx.RunOptio
 	defer logx.FlushLogWriter(stderr)
 
 	argv := cmd.Argv()
-	execCmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	execCmd := exec.CommandContext(ctx.AsStdlibContext(), argv[0], argv[1:]...)
 	if hasDir {
 		execCmd.Dir = dir.String()
 	}
@@ -105,7 +105,7 @@ func (runner CmdRunner) Run(ctx logx.LogCtx, cmd cmdx.Cmd, options cmdx.RunOptio
 	return capturedOutput(), nil
 }
 
-func (runner CmdRunner) ExecAll(ctx logx.LogCtx, cmds ...cmdx.Cmd) error {
+func (runner CmdRunner) ExecAll(ctx cmdx.RunCtx, cmds ...cmdx.Cmd) error {
 	return cmdx.BaseRunnerExecAll(runner, ctx, cmds...)
 }
 
@@ -113,8 +113,37 @@ func TimestampClock() timex.TimestampClock {
 	return systemClock{}
 }
 
+func MonotonicClock() timex.MonotonicClock {
+	return systemClock{}
+}
+
+func Scheduler() timex.Scheduler {
+	return systemClock{}
+}
+
 type systemClock struct{}
+
+type systemScheduledFunc struct {
+	// Always non-nil.
+	timer *stdlib_time.Timer
+}
 
 func (s systemClock) GetTimestamp() timex.Timestamp {
 	return timex.NewTimestamp(stdlib_time.Now().UTC())
+}
+
+func (s systemClock) GetInstant() timex.Instant {
+	return timex.NewInstant(stdlib_time.Now())
+}
+
+func (s systemClock) RunAfter(d timex.Duration, f func()) timex.ScheduledFunc {
+	assert.Precondition(f != nil, "scheduled function must be non-nil")
+	return systemScheduledFunc{timer: stdlib_time.AfterFunc(d, f)} //nolint:forbidigo // syscaps is the ambient scheduler boundary
+}
+
+func (s systemScheduledFunc) Stop() timex.StopResult {
+	if s.timer.Stop() {
+		return timex.StopResult_Stopped
+	}
+	return timex.StopResult_TooLate
 }

--- a/common/timex/clocks.go
+++ b/common/timex/clocks.go
@@ -7,3 +7,15 @@ package timex
 type TimestampClock interface {
 	GetTimestamp() Timestamp
 }
+
+type MonotonicClock interface {
+	// GetInstant reads the value for 'now' from this monotonic
+	// clock.
+	//
+	// Requirements: The value returned must be weakly monotonic
+	// increasing. In other words, if a happens-before relationship
+	// is established between two events A and B according to the
+	// Go memory model, then the corresponding instants IA and IB
+	// must satisfy IA <= IB.
+	GetInstant() Instant
+}

--- a/common/timex/instant.go
+++ b/common/timex/instant.go
@@ -37,6 +37,10 @@ func (i Instant) IsBefore(other Instant) bool { return i.value.Before(other.valu
 
 func (i Instant) IsAfter(other Instant) bool { return i.value.After(other.value) }
 
+func (i Instant) Equals(other Instant) bool {
+	return i.value.Equal(other.value)
+}
+
 func (i Instant) Compare(other Instant) int {
 	return i.value.Compare(other.value)
 }

--- a/common/timex/scheduler.go
+++ b/common/timex/scheduler.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package timex
+
+// Scheduler represents a way of scheduling some work at some given
+// point of time in the future.
+//
+// This interface does not make any guarantees of parallelism.
+type Scheduler interface {
+	MonotonicClock
+
+	// RunAfter schedules f to run after d according to this
+	// scheduler's clock.
+	//
+	// Production schedulers typically run f in its own goroutine.
+	// Test schedulers may instead queue f for deterministic execution.
+	//
+	// If d is sufficiently small, the scheduler may perform the work
+	// immediately, instead of queuing it for later.
+	//
+	// d == 0 is allowed as a hint to the scheduler to run f
+	// immediately. The scheduler may choose to ignore this hint.
+	//
+	// Pre-conditions:
+	// - d >= 0
+	// - f is non-nil
+	// - IMPORTANT: f must not panic. If it does, there are no guarantees
+	//   about how the panic will be propagated.
+	RunAfter(d Duration, f func()) ScheduledFunc
+}
+
+// ScheduledFunc is a handle for a function scheduled through [Scheduler].
+type ScheduledFunc interface {
+	// Stop prevents the scheduled function from running if it has not started.
+	//
+	// Stop does not wait for the function if it has already started.
+	Stop() StopResult
+}
+
+type StopResult uint8
+
+const (
+	// StopResult_Stopped means Stop prevented the scheduled function from
+	// starting. The function will not be called because of this schedule.
+	StopResult_Stopped StopResult = iota + 1
+
+	// StopResult_TooLate means Stop did not prevent the scheduled function from
+	// starting. The function may be running, may have already completed, or the
+	// schedule may have already been stopped by an earlier Stop call.
+	StopResult_TooLate
+)

--- a/common/unit/unit.go
+++ b/common/unit/unit.go
@@ -1,0 +1,9 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package unit provides the canonical zero-size value type.
+package unit
+
+// Unit is a zero-size type for channels and generic APIs whose values carry no information.
+type Unit = struct{}

--- a/docs/style-guides/go.md
+++ b/docs/style-guides/go.md
@@ -43,6 +43,10 @@ of the corresponding type.
 2. If there are interaction tests across methods of a single type,
    prefer having one `TestTypeName` with subtests.
 
+3. For large test groups with many subtests, factor related subtest groups
+   into helpers that accept `check.Harness`; see `TestWalk` in
+   `common/fsx/fsx_walk/walk_test.go` for the preferred organization style.
+
 ## Comments
 
 ### Field-level comments

--- a/misc/cmd/kido/main.go
+++ b/misc/cmd/kido/main.go
@@ -5,7 +5,7 @@
 package main
 
 import (
-	"context"
+	"context" //nolint:depguard // kido's main is the cli boundary; only place allowed to bridge context.Context to cancel.Token
 	"io"
 	"os"
 	"strings"
@@ -13,6 +13,8 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"code.kibou.tools/common/cancel"
+	"code.kibou.tools/common/cancel_bridge"
 	"code.kibou.tools/common/cmdx"
 	"code.kibou.tools/common/collections"
 	. "code.kibou.tools/common/core"
@@ -36,7 +38,7 @@ type Workspace struct {
 
 func newWorkspaceFromGit(runner cmdx.Runner) (Workspace, error) {
 	repoRootCmd := cmdx.New("git", "rev-parse", "--show-toplevel")
-	ctx := logx.NewLogCtx(context.Background(), logx.NewLogger(io.Discard, logx.ColorSupport_Disable))
+	ctx := logx.NewLogCtx(cancel.Never(), logx.NewLogger(io.Discard, logx.ColorSupport_Disable))
 	output, err := runner.Run(ctx, repoRootCmd, cmdx.RunOptionsDefault().WithCaptureStdout())
 	if err != nil {
 		return Workspace{}, errorx.Wrapf("nostack", err, "determine git repository root")
@@ -76,13 +78,13 @@ func main() {
 						return errorx.Wrapf("nostack", err, "in argument for --project")
 					}
 
-					ctx, cancel := withTimeout(ctx, 5*timex.Minute, cmd.Name)
+					tok, cancel := withTimeout(cancel_bridge.Extract(ctx), 5*timex.Minute, cmd.Name)
 					defer cancel()
 					ws, projects, err := resolveProjects(getWorkspace, projectArg)
 					if err != nil {
 						return err
 					}
-					logCtx := logx.NewLogCtx(ctx, logger)
+					logCtx := logx.NewLogCtx(tok, logger)
 					return ws.runSyncBranch(logCtx, projects, RunSyncBranchOptions{
 						Base:    NewOption(cmd.String("base"), cmd.IsSet("base")),
 						Push:    cmd.Bool("push"),
@@ -104,13 +106,13 @@ func main() {
 						return errorx.Wrapf("nostack", err, "in argument for --project")
 					}
 
-					ctx, cancel := withTimeout(ctx, 5*timex.Minute, cmd.Name)
+					tok, cancel := withTimeout(cancel_bridge.Extract(ctx), 5*timex.Minute, cmd.Name)
 					defer cancel()
 					ws, projects, err := resolveProjects(getWorkspace, projectArg)
 					if err != nil {
 						return err
 					}
-					logCtx := logx.NewLogCtx(ctx, logger)
+					logCtx := logx.NewLogCtx(tok, logger)
 					clock := syscaps.TimestampClock()
 					return ws.runSyncPR(logCtx, clock, projects, RunSyncPROptions{
 						Base: NewOption(cmd.String("base"), cmd.IsSet("base")),
@@ -161,7 +163,9 @@ func main() {
 		},
 	}
 
-	if err := app.Run(context.Background(), os.Args); err != nil {
+	rootTok := cancel.Never()
+	rootCtx := cancel_bridge.Inject(context.Background(), rootTok)
+	if err := app.Run(rootCtx, os.Args); err != nil {
 		logger.Error(err.Error())
 		os.Exit(1)
 	}
@@ -183,9 +187,9 @@ func resolveProjects(getWorkspace func() (Workspace, error), project fsx.Name) (
 	return ws, []fsx.Name{project}, nil
 }
 
-func withTimeout(ctx context.Context, duration timex.Duration, cmdName string) (context.Context, context.CancelFunc) {
-	return context.WithTimeoutCause(
-		ctx, duration,
-		errorx.Newf("nostack", "%s exceeded time limit of %s", cmdName, duration),
-	)
+func withTimeout(parent cancel.Token, duration timex.Duration, cmdName string) (cancel.ChildClockToken, func()) {
+	tok := cancel.NewClockToken(parent, syscaps.Scheduler(), cancel.OnTimeout(duration))
+	return tok, func() {
+		tok.Cancel(errorx.Newf("nostack", "%s completed", cmdName))
+	}
 }

--- a/misc/internal/licenses/licenses_test.go
+++ b/misc/internal/licenses/licenses_test.go
@@ -6,7 +6,6 @@ package licenses
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"iter"
 	"runtime"
@@ -17,6 +16,7 @@ import (
 
 	"golang.org/x/sync/semaphore"
 
+	"code.kibou.tools/common/cancel"
 	"code.kibou.tools/common/check"
 	. "code.kibou.tools/common/check/prelude"
 	. "code.kibou.tools/common/core"
@@ -104,7 +104,7 @@ func visitFirstPartyGoFiles[T any](
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			h.NoErrorf(sem.Acquire(context.Background(), 1), "acquire license check semaphore")
+			h.NoErrorf(sem.Acquire(cancel.Never().AsStdlibContext(), 1), "acquire license check semaphore")
 			defer sem.Release(1)
 			resultCh <- visit(rel)
 		}()


### PR DESCRIPTION
The main addition is the common/cancel package which
supports different kinds of cancellation tokens.

There are two main axes:

 - Is the cancellation capability (write-like) exposed,
   or whether only the "check cancellation" capability
   (read-like) is exposed.
   - When a child token is created, this capability is
     exposed (similar to stdlib context.Context).
     However, normal token propagation will drop this
     capability.
 - Is there some support for timing-based cancellation
   or not (i.e. a scheduling capability for a timer to
   to fire after a given time).
   - Scheduling in particular can benefit from dedicated
     support from the runtime, instead of just building
     it on top of some kind other primitive like Spawn
     (which would require busy polling) or even Spawn
     + Sleep (which would prevent eager freeing of
     resources).

The code is updated to use these cancellation tokens,
and we ban the use of context.Context outside the
implementation.
