### PR TITLE
feat(timex): Add parsing for POSIX TZ strings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,7 @@ linters:
           files:
             - $all
             - "!**/common/timex/*.go"
+            - "!**/common/timex/**/*_test.go"
             - "!**/common/syscaps/*.go"
           list-mode: lax
           deny:

--- a/common/internal/ranges/closed_range.go
+++ b/common/internal/ranges/closed_range.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package ranges
+
+type ClosedRange[T int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64] struct {
+	Lo T
+	Hi T
+}
+
+func (r ClosedRange[T]) Contains(t T) bool {
+	return r.Lo <= t && t <= r.Hi
+}

--- a/common/parse/error.go
+++ b/common/parse/error.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package parse provides common error types for parsers.
+package parse
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Error reports a parse failure with source/progress information and optional
+// context about what the parser expected at the failure point.
+type Error struct {
+	subject string
+	source  string
+	parsed  string
+
+	context  string
+	expected string
+	reason   string
+}
+
+type ErrorOptions struct {
+	// Parsed is the prefix of Source that was parsed before the error was hit.
+	// It may be empty if the parser failed at the start of Source.
+	Parsed string
+	// Context describes what the parser was trying to parse when it failed. It
+	// may be empty if there is no more specific context.
+	Context string
+	// Expected describes what the parser expected at the failure point. It may be
+	// empty if Reason is used instead.
+	Expected string
+	// Reason describes the failure directly. It may be empty when Expected is set.
+	Reason string
+}
+
+func NewError(subject string, source string, options ErrorOptions) *Error {
+	return &Error{
+		subject:  subject,
+		source:   source,
+		parsed:   options.Parsed,
+		context:  options.Context,
+		expected: options.Expected,
+		reason:   options.Reason,
+	}
+}
+
+func (e *Error) Subject() string {
+	return e.subject
+}
+
+func (e *Error) Source() string {
+	return e.source
+}
+
+func (e *Error) Parsed() string {
+	return e.parsed
+}
+
+func (e *Error) Context() string {
+	return e.context
+}
+
+func (e *Error) Expected() string {
+	return e.expected
+}
+
+func (e *Error) Reason() string {
+	return e.reason
+}
+
+func (e *Error) Error() string {
+	// TODO: Migrate this logic to instead use a structured formatter
+	// so that we get JSON + multiline formatting + coloring for "free".
+	var b strings.Builder
+	fmt.Fprintf(&b, "failed to parse %s %q", e.subject, e.source)
+	if e.reason != "" {
+		fmt.Fprintf(&b, ": %s", e.reason)
+		return b.String()
+	}
+	if e.parsed != "" || e.context != "" || e.expected != "" {
+		fmt.Fprintf(&b, ": hit error after parsing %q", e.parsed)
+	}
+	if e.context != "" {
+		fmt.Fprintf(&b, ": context - trying to parse %s", e.context)
+	}
+	if e.expected != "" {
+		fmt.Fprintf(&b, ", expected - %s, next char - %s", e.expected, e.nextChar())
+	}
+	return b.String()
+}
+
+func (e *Error) nextChar() string {
+	if len(e.parsed) >= len(e.source) {
+		return "EOF"
+	}
+	r, size := utf8.DecodeRuneInString(e.source[len(e.parsed):])
+	if r == utf8.RuneError && size == 1 {
+		return fmt.Sprintf("byte 0x%02x", e.source[len(e.parsed)])
+	}
+	return fmt.Sprintf("%q", r)
+}

--- a/common/parse/error_test.go
+++ b/common/parse/error_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package parse
+
+import (
+	"testing"
+
+	"code.kibou.tools/common/check"
+)
+
+func TestError(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("ExpectedWithContextAndEOF", func(h check.Harness) {
+		h.Parallel()
+		err := NewError("POSIX TZ", "EST5:3", ErrorOptions{
+			Parsed:   "EST5:3",
+			Context:  "standard time offset",
+			Expected: "two minute digits ([0-9]{2})",
+			Reason:   "",
+		})
+		want := `failed to parse POSIX TZ "EST5:3": hit error after parsing "EST5:3": context - trying to parse standard time offset, expected - two minute digits ([0-9]{2}), next char - EOF`
+		check.AssertSame(h, want, err.Error(), "Error()")
+	})
+
+	h.Run("ExpectedWithNextChar", func(h check.Harness) {
+		h.Parallel()
+		err := NewError("POSIX TZ", "EST5,J", ErrorOptions{
+			Parsed:   "EST5",
+			Context:  "",
+			Expected: "end of input",
+			Reason:   "",
+		})
+		want := `failed to parse POSIX TZ "EST5,J": hit error after parsing "EST5", expected - end of input, next char - ','`
+		check.AssertSame(h, want, err.Error(), "Error()")
+	})
+
+	h.Run("Reason", func(h check.Harness) {
+		h.Parallel()
+		err := NewError("POSIX TZ", string([]byte{0xff}), ErrorOptions{
+			Parsed:   "",
+			Context:  "",
+			Expected: "",
+			Reason:   "invalid UTF-8",
+		})
+		want := "failed to parse POSIX TZ \"\\xff\": invalid UTF-8"
+		check.AssertSame(h, want, err.Error(), "Error()")
+	})
+}

--- a/common/timex/Comparison.djot
+++ b/common/timex/Comparison.djot
@@ -1,0 +1,12 @@
+# Comparison with `time` in the Go standard library
+
+## Open upstream issues fixed in timex
+
+- [#50863][golang-go-issue-50863]: `TZ` environment variable doesn't support
+  complex formats like `TZ="EST5EDT,M3.2.0/2,M11.1.0/2"`.
+  When such a format is used, code silently falls back to UTC.
+
+  - Upstream status: Issue opened in Jan 2022, marked as backlog.
+  - `timex`: All structured POSIX.1-2024 TZ-string forms parse correctly.
+
+[golang-go-issue-50863]: https://github.com/golang/go/issues/50863

--- a/common/timex/internal/posix_tz/base_types.go
+++ b/common/timex/internal/posix_tz/base_types.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package timex_base defines small bounded time/calendar value types.
+package posix_tz
+
+import (
+	. "code.kibou.tools/common/zero"
+	"code.kibou.tools/common/assert"
+)
+
+// DayOfYear is a zero-based day-of-year in the POSIX rule format,
+// potentially allowing for leap years.
+//
+// The underlying value is in the range [0, 365], with Jan 1 ~ 0,
+// and Dec 31 ~ 364 for non-leap years, and 365 for leap years.
+type DayOfYear struct{ value int16 }
+
+func NewDayOfYear(value int16) (DayOfYear, bool) {
+	if value < 0 || value > 365 {
+		return Zero[DayOfYear](), false
+	}
+	return DayOfYear{value: value}, true
+}
+
+func MustDayOfYear(value int16) DayOfYear {
+	day, ok := NewDayOfYear(value)
+	if !ok {
+		assert.Preconditionf(false, "day-of-year %d out of range", value)
+	}
+	return day
+}
+
+func (day DayOfYear) Int16() int16 { return day.value }
+func (day DayOfYear) Int() int     { return int(day.value) }
+
+// JulianDay is a one-based POSIX Julian day that does not count leap days.
+//
+// See code://docs/external/posix_tz.md#rule-date-format
+type JulianDay struct{ value int16 }
+
+func NewJulianDay(value int16) (JulianDay, bool) {
+	if value < 1 || value > 365 {
+		return Zero[JulianDay](), false
+	}
+	return JulianDay{value: value}, true
+}
+
+func MustJulianDay(value int16) JulianDay {
+	day, ok := NewJulianDay(value)
+	if !ok {
+		assert.Preconditionf(false, "Julian day %d out of range", value)
+	}
+	return day
+}
+
+func (day JulianDay) Int16() int16 { return day.value }
+func (day JulianDay) Int() int     { return int(day.value) }
+
+const firstJulianDayAfterFeb29 = 60
+
+// zeroBasedDayOfYear returns a value in the range [0, 365].
+func (day JulianDay) zeroBasedDayOfYear(year int) int {
+	yearDay := day.Int() - 1
+	if isLeapYear(year) && day.Int() >= firstJulianDayAfterFeb29 {
+		yearDay++
+	}
+	return yearDay
+}
+
+// Zero-based weekday value, with 0 = Sunday.
+type Weekday struct{ value uint8 }
+
+func NewWeekday(value uint8) (Weekday, bool) {
+	if value > 6 {
+		return Zero[Weekday](), false
+	}
+	return Weekday{value: value}, true
+}
+
+func MustWeekday(value uint8) Weekday {
+	weekday, ok := NewWeekday(value)
+	if !ok {
+		assert.Preconditionf(false, "weekday %d out of range", value)
+	}
+	return weekday
+}
+
+// Uint8 returns the weekday value in the range [0, 6].
+func (weekday Weekday) Uint8() uint8 { return weekday.value }
+
+// Int returns the weekday value in the range [0, 6].
+func (weekday Weekday) Int() int { return int(weekday.value) }
+
+type Week struct {
+	// value ∈ [1, 5]
+	value uint8
+}
+
+func NewWeek(value uint8) (Week, bool) {
+	if value < 1 || value > 5 {
+		return Zero[Week](), false
+	}
+	return Week{value: value}, true
+}
+
+func MustWeek(value uint8) Week {
+	week, ok := NewWeek(value)
+	if !ok {
+		assert.Preconditionf(false, "week %d out of range", value)
+	}
+	return week
+}
+
+// Uint8 returns a value in the range [1, 5]
+func (week Week) Uint8() uint8 { return week.value }
+
+// Int returns a value in the range [1, 5]
+func (week Week) Int() int { return int(week.value) }
+
+type Month struct {
+	// value ∈ [1, 12]
+	value uint8
+}
+
+func NewMonth(value uint8) (Month, bool) {
+	if value < 1 || value > 12 {
+		return Zero[Month](), false
+	}
+	return Month{value: value}, true
+}
+
+func MustMonth(value uint8) Month {
+	month, ok := NewMonth(value)
+	if !ok {
+		assert.Preconditionf(false, "month %d out of range", value)
+	}
+	return month
+}
+
+// Uint8 returns the month value in the range [1, 12].
+func (month Month) Uint8() uint8 { return month.value }
+
+// Int returns the month value in the range [1, 12].
+func (month Month) Int() int { return int(month.value) }
+
+type WeekMonth uint8
+
+func NewWeekMonth(month Month, week Week) WeekMonth {
+	// month.Uint8() ∈ [1, 12] and week.Uint8() ∈ [1, 5]
+	// so this conversion is lossless.
+	return WeekMonth(month.Uint8()<<4 | week.Uint8())
+}
+
+func (wm WeekMonth) Month() Month {
+	month, ok := NewMonth(uint8(wm) >> 4)
+	if !ok {
+		assert.Invariantf(false, "WeekMonth has invalid month bits: %d", uint8(wm)>>4)
+	}
+	return month
+}
+
+func (wm WeekMonth) Week() Week {
+	week, ok := NewWeek(uint8(wm) & 0x0f)
+	if !ok {
+		assert.Invariantf(false, "WeekMonth has invalid week bits: %d", uint8(wm)&0x0f)
+	}
+	return week
+}

--- a/common/timex/internal/posix_tz/calendar.go
+++ b/common/timex/internal/posix_tz/calendar.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package posix_tz
+
+// Computes the 0-based weekday value (with 0 ~ Sunday),
+// based on the Proleptic Gregorian calendar, with 0001-01-01
+// being considered a Monday.
+func computeWeekday(year int, month int, day int) int {
+	// Days before Jan 1 of `year` is 365·y + ⌊y/4⌋ − ⌊y/100⌋ + ⌊y/400⌋
+	// where y = year − 1.
+	y := year - 1
+	// Since 365 ≡ 1 (mod 7), 365·y ≡ y (mod 7), reduce the (y mod 7)
+	// up front to avoid overflow.
+	base := modFloor(y, 7)
+	// The remaining leap-day terms sum to (1/4 − 1/100 + 1/400)·y ≈ 0.2425·y,
+	// well within int range.
+	leapYearAdjustment := divFloor(y, 4) - divFloor(y, 100) + divFloor(y, 400)
+	currentYearAdjustment := dayOfYear(year, month, day)
+	return modFloor(base+leapYearAdjustment+currentYearAdjustment, 7)
+}
+
+// dayOfYear returns the 1-based day in the year, with the value
+// being in [1, 365] during non-leap years, and in [1, 366] in leap years.
+func dayOfYear(year int, month int, day int) int {
+	day += daysBeforeMonth(month)
+	if month > 2 && isLeapYear(year) {
+		day++
+	}
+	return day
+}
+
+// Pre-condition: month ∈ [1, 12]
+func daysInMonth(year int, month int) int {
+	switch month {
+	case 2:
+		if isLeapYear(year) {
+			return 29
+		}
+		return 28
+	case 4, 6, 9, 11:
+		return 30
+	default:
+		return 31
+	}
+}
+
+func isLeapYear(year int) bool {
+	return year%4 == 0 && (year%100 != 0 || year%400 == 0)
+}
+
+// Pre-condition: month ∈ [1, 12]
+func daysBeforeMonth(month int) int {
+	return [12]int{0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334}[month-1]
+}
+
+// nthWeekdayOfMonth returns the day-of-month of the n-th `weekday` in
+// (year, month), per POSIX Mm.w.d semantics: n=5 means "last occurrence",
+// i.e., the 5th if it exists, otherwise the 4th.
+//
+// Per code://docs/external/posix_tz.md#rule-date-format, weekdays are
+// computed based on the Proleptic Gregorian calendar.
+func nthWeekdayOfMonth(year int, month Month, weekday Weekday, n Week) int {
+	m := month.Int()
+	firstOfMonthWeekday := computeWeekday(year, m, 1)
+	// For 'weekday' (e.g. Friday), compute the first day in the month
+	// for which the day is that weekday. => firstHit ∈ [1, 7]
+	// E.g. if first day is Tuesday, then Fri - Tue = 3, so 4th of the
+	// month will be the first Friday.
+	firstHit := 1 + modFloor(weekday.Int()-firstOfMonthWeekday, 7)
+	// n = 1 => firstHit is correct, if n >= 2, we have to advance by 7.
+	day := firstHit + (n.Int()-1)*7
+	if day > daysInMonth(year, m) {
+		// n ∈ [1, 5], but it's possible for a month to not have (say)
+		// a 5th Friday, so in that case, n = 5 means "last", so go back
+		// by 1 week.
+		day -= 7
+	}
+	return day
+}
+
+// divFloor returns floor(x/y) (i.e. rounding towards -∞),
+// unlike Go's / operator, which rounds toward 0.
+//
+// Pre-condition: y > 0.
+func divFloor(x int, y int) int {
+	q := x / y
+	// If x < 0 && x % y != 0, (e.g. x = -9, y = 4),
+	// we need to subtract 1 (adjust -2 -> -3).
+	if x%y < 0 {
+		q--
+	}
+	return q
+}
+
+// modFloor returns x mod y in the range [0, y)
+// (i.e. textbook Euclidean mod) unlike Go's % operator,\
+// which keeps the sign of x.
+//
+// Pre-condition: y > 0.
+func modFloor(x int, y int) int {
+	r := x % y
+	if r < 0 {
+		r += y
+	}
+	return r
+}

--- a/common/timex/internal/posix_tz/calendar_test.go
+++ b/common/timex/internal/posix_tz/calendar_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package posix_tz
+
+import (
+	"math"
+	"math/big"
+	"testing"
+	stdlib_time "time"
+
+	"code.kibou.tools/common/check"
+	"pgregory.net/rapid"
+)
+
+func TestCalendarMatchesStdlib(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		year := rapid.IntRange(-9999, 9999).Draw(t, "year")
+		month := rapid.IntRange(1, 12).Draw(t, "month")
+		day := rapid.IntRange(1, stdlibDaysInMonth(year, month)).Draw(t, "day")
+
+		date := stdlib_time.Date(year, stdlib_time.Month(month), day, 0, 0, 0, 0, stdlib_time.UTC)
+		check.AssertSame(h, int(date.Weekday()), computeWeekday(year, month, day), "weekday")
+		check.AssertSame(h, date.YearDay(), dayOfYear(year, month, day), "day of year")
+		check.AssertSame(h, stdlibDaysInMonth(year, month), daysInMonth(year, month), "days in month")
+	})
+}
+
+func stdlibDaysInMonth(year int, month int) int {
+	return stdlib_time.Date(year, stdlib_time.Month(month)+1, 0, 0, 0, 0, 0, stdlib_time.UTC).Day()
+}
+
+// Verifies weekday against an arbitrary-precision reference
+// across the full int range, to catch any overflow in the production code.
+// stdlib_time.Date's internal int64-nanosecond representation can't cover the
+// extremes, so a big.Int reference is needed here.
+func TestWeekdayAtExtremeYears(t *testing.T) {
+	if math.MaxInt < math.MaxInt64 {
+		t.Skip("requires 64-bit int")
+	}
+	h := check.New(t)
+	h.Parallel()
+
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		year := rapid.Int64().Draw(t, "year")
+		if year == math.MinInt64 {
+			// year-1 wraps in the production code; not a meaningful input.
+			t.Skip("MinInt64")
+		}
+		month := rapid.IntRange(1, 12).Draw(t, "month")
+		day := rapid.IntRange(1, daysInMonth(int(year), month)).Draw(t, "day")
+
+		check.AssertSame(h,
+			bigIntWeekday(int(year), month, day),
+			computeWeekday(int(year), month, day),
+			"weekday")
+	})
+}
+
+// bigIntWeekday is a math/big reference for weekday.
+// Any disagreement indicates an int overflow in the production implementation.
+func bigIntWeekday(year int, month int, day int) int {
+	// Compute y = year - 1 in big.Int so the reference stays exact even for
+	// inputs at the int boundary.
+	y := new(big.Int).SetInt64(int64(year))
+	y.Sub(y, big.NewInt(1))
+
+	sum := new(big.Int).Mul(y, big.NewInt(365))
+	// big.Int.Div / Mod implement Euclidean division (floor for positive y).
+	sum.Add(sum, new(big.Int).Div(y, big.NewInt(4)))
+	sum.Sub(sum, new(big.Int).Div(y, big.NewInt(100)))
+	sum.Add(sum, new(big.Int).Div(y, big.NewInt(400)))
+	sum.Add(sum, big.NewInt(int64(dayOfYear(year, month, day))))
+	return int(new(big.Int).Mod(sum, big.NewInt(7)).Int64())
+}

--- a/common/timex/internal/posix_tz/errors.go
+++ b/common/timex/internal/posix_tz/errors.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package posix_tz
+
+import (
+	"code.kibou.tools/common/assert"
+	parseerr "code.kibou.tools/common/parse"
+)
+
+// ParseErrorKind identifies why POSIX TZ parsing failed.
+type ParseErrorKind uint8
+
+const (
+	ParseErrorKind_Empty ParseErrorKind = iota + 1
+	ParseErrorKind_InvalidUTF8
+	ParseErrorKind_SpecViolation
+	ParseErrorKind_TrailingData
+)
+
+type want uint8
+
+const (
+	want_None want = iota
+	want_NameAtLeast3Bytes
+	want_NameClosingQuote
+	want_HourDigits
+	want_HourInRange
+	want_TwoMinuteDigits
+	want_MinuteInRange
+	want_TwoSecondDigits
+	want_SecondInRange
+	want_DSTRule
+	want_CommaBeforeRule
+	want_RuleSeparator
+	want_JulianDay
+	want_DayOfYear
+	want_Month
+	want_Week
+	want_Weekday
+)
+
+type parseCtx uint8
+
+const (
+	parseCtx_StandardName parseCtx = iota + 1
+	parseCtx_StandardOffset
+	parseCtx_DSTName
+	parseCtx_DSTOffset
+	parseCtx_DSTRule
+	parseCtx_RuleStartDateTime
+	parseCtx_RuleEndDateTime
+)
+
+type specViolation struct {
+	expected want
+	context  parseCtx
+}
+
+// ParseError reports a failed POSIX TZ parse.
+type ParseError struct {
+	kind ParseErrorKind
+	// Always non-nil.
+	diagnostic *parseerr.Error
+}
+
+func newParseError(kind ParseErrorKind, source string, parsed string) *ParseError {
+	options := parseerr.ErrorOptions{Parsed: parsed, Context: "", Expected: "", Reason: ""}
+	switch kind {
+	case ParseErrorKind_Empty:
+		options.Expected = "non-empty input"
+	case ParseErrorKind_InvalidUTF8:
+		options.Reason = "invalid UTF-8"
+	case ParseErrorKind_SpecViolation:
+		assert.PanicUnknownCase[any](kind)
+	case ParseErrorKind_TrailingData:
+		options.Expected = "end of input"
+	default:
+		assert.PanicUnknownCase[any](kind)
+	}
+	return &ParseError{kind: kind, diagnostic: parseerr.NewError("POSIX TZ", source, options)}
+}
+
+func newSpecViolationParseError(violation specViolation, source string, parsed string) *ParseError {
+	options := parseerr.ErrorOptions{
+		Parsed:   parsed,
+		Context:  violation.context.reason(),
+		Expected: violation.expected.expected(violation.context),
+		Reason:   "",
+	}
+	return &ParseError{kind: ParseErrorKind_SpecViolation, diagnostic: parseerr.NewError("POSIX TZ", source, options)}
+}
+
+func (e *ParseError) Kind() ParseErrorKind { return e.kind }
+func (e *ParseError) Source() string       { return e.diagnostic.Source() }
+func (e *ParseError) Parsed() string       { return e.diagnostic.Parsed() }
+
+func (e *ParseError) Error() string { return e.diagnostic.Error() }
+
+func (e *ParseError) Unwrap() error { return e.diagnostic }
+
+func (e want) expected(context parseCtx) string {
+	switch e {
+	case want_None:
+		return assert.PanicUnknownCase[string](e)
+	case want_NameAtLeast3Bytes:
+		return "time abbreviation with at least 3 bytes"
+	case want_NameClosingQuote:
+		return "closing '>' for quoted time abbreviation"
+	case want_HourDigits:
+		return "hour digits ([0-9]+)"
+	case want_HourInRange:
+		if context == parseCtx_StandardOffset || context == parseCtx_DSTOffset {
+			return "hour in range [-24,24]"
+		}
+		return "hour in range [-167,167]"
+	case want_TwoMinuteDigits:
+		return "two minute digits ([0-9]{2})"
+	case want_MinuteInRange:
+		return "minute in range [0,59]"
+	case want_TwoSecondDigits:
+		return "two second digits ([0-9]{2})"
+	case want_SecondInRange:
+		return "second in range [0,59]"
+	case want_DSTRule:
+		return "daylight saving time transition rule"
+	case want_CommaBeforeRule:
+		return "comma before transition rule"
+	case want_RuleSeparator:
+		return "rule date/time separator"
+	case want_JulianDay:
+		return "Julian day in range [1,365]"
+	case want_DayOfYear:
+		return "day-of-year in range [0,365]"
+	case want_Month:
+		return "transition-rule month in range [1,12]"
+	case want_Week:
+		return "transition-rule week in range [1,5]"
+	case want_Weekday:
+		return "transition-rule weekday in range [0,6]"
+	default:
+		return assert.PanicUnknownCase[string](e)
+	}
+}
+
+func (c parseCtx) reason() string {
+	switch c {
+	case parseCtx_StandardName:
+		return "standard time abbreviation"
+	case parseCtx_StandardOffset:
+		return "standard time offset"
+	case parseCtx_DSTName:
+		return "daylight saving time abbreviation"
+	case parseCtx_DSTOffset:
+		return "daylight saving time offset"
+	case parseCtx_DSTRule:
+		return "daylight saving time rule"
+	case parseCtx_RuleStartDateTime:
+		return "daylight saving time rule start date/time"
+	case parseCtx_RuleEndDateTime:
+		return "daylight saving time rule end date/time"
+	default:
+		return assert.PanicUnknownCase[string](c)
+	}
+}

--- a/common/timex/internal/posix_tz/format.go
+++ b/common/timex/internal/posix_tz/format.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package posix_tz
+
+import (
+	"strconv"
+	"strings"
+
+	"code.kibou.tools/common/assert"
+)
+
+// Format returns the canonical POSIX TZ string for tz.
+//
+// Parse(tz.Format()).Get() is guaranteed to return a TimeZone equal to tz.
+// The canonical form:
+//   - quotes a name only when it contains characters outside [A-Za-z];
+//   - omits the explicit DST offset when it equals StdOffset + 1h, matching
+//     the POSIX default;
+//   - omits the "/time" suffix on a rule when it equals 02:00, the default.
+func (tz TimeZone) Format() string {
+	var b strings.Builder
+	writeName(&b, tz.StdName)
+	// Per code://docs/external/posix_tz.md#offset-format, the on-wire offset
+	// is the value added to local time to arrive at UTC — the opposite of
+	// "seconds east of UTC", hence the negation.
+	writeOffset(&b, -tz.StdOffset)
+	if !tz.HasDST {
+		return b.String()
+	}
+	writeName(&b, tz.dstName)
+	if tz.dstOffset != tz.StdOffset+secondsPerHour {
+		writeOffset(&b, -tz.dstOffset)
+	}
+	b.WriteByte(',')
+	writeRuleDateTime(&b, tz.rule.Start)
+	b.WriteByte(',')
+	writeRuleDateTime(&b, tz.rule.End)
+	return b.String()
+}
+
+func writeName(b *strings.Builder, name string) {
+	if nameNeedsQuoting(name) {
+		b.WriteByte('<')
+		b.WriteString(name)
+		b.WriteByte('>')
+		return
+	}
+	b.WriteString(name)
+}
+
+func nameNeedsQuoting(name string) bool {
+	for i := 0; i < len(name); i++ {
+		if !isUnquotedPOSIXAbbreviationByte(name[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// writeOffset writes a signed `[-+]?h[h[h]][:mm[:ss]]` value.
+//
+// The hour component is printed without leading zeros; minutes and seconds
+// are zero-padded to two digits and elided when both are zero.
+func writeOffset(b *strings.Builder, offset int32) {
+	if offset < 0 {
+		b.WriteByte('-')
+		offset = -offset
+	}
+	h := offset / secondsPerHour
+	rem := offset % secondsPerHour
+	m := rem / secondsPerMinute
+	s := rem % secondsPerMinute
+	b.WriteString(strconv.FormatInt(int64(h), 10))
+	if m == 0 && s == 0 {
+		return
+	}
+	b.WriteByte(':')
+	writeTwoDigit(b, m)
+	if s == 0 {
+		return
+	}
+	b.WriteByte(':')
+	writeTwoDigit(b, s)
+}
+
+func writeTwoDigit(b *strings.Builder, n int32) {
+	b.WriteByte(byte('0' + n/10))
+	b.WriteByte(byte('0' + n%10))
+}
+
+func writeRuleDateTime(b *strings.Builder, dt RuleDateTime) {
+	switch dt.Kind() {
+	case RuleDateTimeKind_Julian:
+		b.WriteByte('J')
+		b.WriteString(strconv.FormatInt(int64(dt.JulianDay().Int()), 10))
+	case RuleDateTimeKind_DayOfYear:
+		b.WriteString(strconv.FormatInt(int64(dt.DayOfYear().Int()), 10))
+	case RuleDateTimeKind_MonthWeekDay:
+		b.WriteByte('M')
+		b.WriteString(strconv.FormatInt(int64(dt.Month().Int()), 10))
+		b.WriteByte('.')
+		b.WriteString(strconv.FormatInt(int64(dt.Week().Int()), 10))
+		b.WriteByte('.')
+		b.WriteString(strconv.FormatInt(int64(dt.Weekday().Int()), 10))
+	default:
+		assert.PanicUnknownCase[any](dt.Kind())
+	}
+	if dt.Second() != 2*secondsPerHour {
+		b.WriteByte('/')
+		writeOffset(b, dt.Second())
+	}
+}

--- a/common/timex/internal/posix_tz/parse.go
+++ b/common/timex/internal/posix_tz/parse.go
@@ -1,0 +1,403 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package posix_tz
+
+import (
+	"unicode/utf8"
+
+	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/core/result"
+	"code.kibou.tools/common/internal/ranges"
+	. "code.kibou.tools/common/zero"
+)
+
+// Parse parses the input string based on the rules specified
+// in POSIX.1-2024 Ch. 8.
+//
+// For docs, see code://docs/external/posix_tz.md
+func Parse(source string) result.Result[TimeZone] {
+	p := parser{s: source, i: 0}
+	if p.done() {
+		return p.err(ParseErrorKind_Empty)
+	}
+	if !utf8.ValidString(source) {
+		return p.err(ParseErrorKind_InvalidUTF8)
+	}
+
+	stdName, err := p.name()
+	if err != want_None {
+		return p.specErr(err, parseCtx_StandardName)
+	}
+	stdRawOffset, err := p.utcOffset()
+	if err != want_None {
+		return p.specErr(err, parseCtx_StandardOffset)
+	}
+	// Per code://docs/external/posix_tz.md#offset-format, the offset
+	// is "the value added to the local time to arrive at [UTC]",
+	// which is the opposite of the usual convention, so we need
+	// an extra - sign.
+	stdOffset := -stdRawOffset
+
+	var (
+		hasDST    bool
+		dstName   string
+		dstOffset int32
+		rule      Rule
+	)
+	if !p.done() {
+		hasDST = true
+		dstName, err = p.name()
+		if err != want_None {
+			return p.specErr(err, parseCtx_DSTName)
+		}
+		if p.done() || p.peek() == ',' {
+			// Per code://docs/external/posix_tz.md#daylight-saving-time-default-offset
+			// If the offset is not specified, it should default to +1 hour.
+			dstOffset = stdOffset + int32(secondsPerHour)
+		} else {
+			dstRawOffset, err := p.utcOffset()
+			if err != want_None {
+				return p.specErr(err, parseCtx_DSTOffset)
+			}
+			// Extra - sign for same reason as stdRawOffset earlier.
+			dstOffset = -dstRawOffset
+		}
+		if p.done() {
+			return p.specErr(want_DSTRule, parseCtx_DSTRule)
+		}
+		if !p.tryConsume(',') {
+			return p.specErr(want_CommaBeforeRule, parseCtx_DSTRule)
+		}
+		parsedRule, err, context := p.rule()
+		if err != want_None {
+			return p.specErr(err, context)
+		}
+		if !p.done() {
+			return p.err(ParseErrorKind_TrailingData)
+		}
+		rule = parsedRule
+	}
+
+	return result.Success(TimeZone{
+		StdName:   stdName,
+		StdOffset: stdOffset,
+		HasDST:    hasDST,
+		dstName:   dstName,
+		dstOffset: dstOffset,
+		rule:      rule,
+	})
+}
+
+type parser struct {
+	s string
+	i int
+}
+
+func (p *parser) done() bool { return p.i == len(p.s) }
+func (p *parser) peek() byte { return p.s[p.i] }
+func (p *parser) err(kind ParseErrorKind) result.Result[TimeZone] {
+	return result.Failure[TimeZone](newParseError(kind, p.s, p.s[:p.i]))
+}
+
+func (p *parser) specErr(err want, context parseCtx) result.Result[TimeZone] {
+	return result.Failure[TimeZone](newSpecViolationParseError(specViolation{err, context}, p.s, p.s[:p.i]))
+}
+
+// tryConsume returns true if the next byte matches b,
+// after consuming it. If there is no next byte, or if it
+// doesn't match b, it returns false without consuming anything.
+func (p *parser) tryConsume(b byte) bool {
+	if p.done() || p.peek() != b {
+		return false
+	}
+	p.i++
+	return true
+}
+
+func (p *parser) consumeWhile(subset charSubset) string {
+	start := p.i
+	switch subset {
+	case charSubset_UnquotedAbbreviation:
+		for !p.done() && isUnquotedPOSIXAbbreviationByte(p.peek()) {
+			p.i++
+		}
+	case charSubset_QuotedAbbreviation:
+		for !p.done() && isQuotedPOSIXAbbreviationByte(p.peek()) {
+			p.i++
+		}
+	default:
+		assert.PanicUnknownCase[any](subset)
+	}
+	return p.s[start:p.i]
+}
+
+// Parses the name based on code://docs/external/posix_tz.md#name-format
+func (p *parser) name() (string, want) {
+	if p.tryConsume('<') {
+		name := p.consumeWhile(charSubset_QuotedAbbreviation)
+		if len(name) < 3 {
+			return "", want_NameAtLeast3Bytes
+		}
+		if !p.tryConsume('>') {
+			return "", want_NameClosingQuote
+		}
+		return name, want_None
+	}
+	name := p.consumeWhile(charSubset_UnquotedAbbreviation)
+	if len(name) < 3 {
+		return "", want_NameAtLeast3Bytes
+	}
+	return name, want_None
+}
+
+// Post-condition: if err == want_None, the returned value is in
+// [-24 * 60 * 60, 24 * 60 * 60].
+func (p *parser) utcOffset() (int32, want) {
+	// POSIX std/dst offset fields accept an optional sign and hours
+	// whose absolute value is in the range 0 through 24.
+	return p.signedHMS(-24, 24, 2)
+}
+
+// Post-condition: if err == want_None, the returned value is in
+// [- (7 * 24 * 60 * 60) + 1, (7 * 24 * 60 * 60) - 1], i.e.
+// [-604799,604799]
+func (p *parser) transitionTime() (int32, want) {
+	// IANA TZif v3+ extends rule transition times to the range
+	// -167:59:59 through 167:59:59.
+	//
+	// So the hour value itself is in [-167, +167].
+	return p.signedHMS(-167, 167, 3)
+}
+
+// signedHMS parses a string of the form:
+//
+// [+|-]hhh[:mm[:ss]]
+//
+// where the :mm and :ss suffixes are optional.
+//
+// mm and ss values must both be exactly 2 digits
+// in the range [00, 59].
+func (p *parser) signedHMS(minHour int32, maxHour int32, maxHourDigits uint8) (int32, want) {
+	// Tracking the sign separately from the hour magnitude preserves a
+	// leading '-' even when all the digit fields are zero (e.g., "-0:00:01"
+	// for −1 second).
+	sign, hour, ok := p.parseInt32(int32Prefix_MayHaveSign, maxHourDigits)
+	if !ok {
+		return 0, want_HourDigits
+	}
+	if sign*hour < minHour || sign*hour > maxHour {
+		return 0, want_HourInRange
+	}
+	offset := hour * secondsPerHour
+	if p.tryConsume(':') {
+		minuteStart := p.i
+		_, minute, ok := p.parseInt32(int32Prefix_NoSign, 2)
+		if !ok || p.i-minuteStart != 2 {
+			return 0, want_TwoMinuteDigits
+		}
+		if minute > 59 {
+			return 0, want_MinuteInRange
+		}
+		offset += minute * secondsPerMinute
+		if p.tryConsume(':') {
+			secondStart := p.i
+			_, second, ok := p.parseInt32(int32Prefix_NoSign, 2)
+			if !ok || p.i-secondStart != 2 {
+				return 0, want_TwoSecondDigits
+			}
+			if second > 59 {
+				return 0, want_SecondInRange
+			}
+			offset += second
+		}
+	}
+	return sign * offset, want_None
+}
+
+func (p *parser) rule() (Rule, want, parseCtx) {
+	start, err := p.ruleDateTime()
+	if err != want_None {
+		return Zero[Rule](), err, parseCtx_RuleStartDateTime
+	}
+	if !p.tryConsume(',') {
+		return Zero[Rule](), want_RuleSeparator, parseCtx_RuleEndDateTime
+	}
+	end, err := p.ruleDateTime()
+	if err != want_None {
+		return Zero[Rule](), err, parseCtx_RuleEndDateTime
+	}
+	return Rule{Start: start, End: end}, want_None, 0
+}
+
+func (p *parser) ruleDateTime() (RuleDateTime, want) {
+	var (
+		kind      RuleDateTimeKind
+		dayBits   uint16
+		weekMonth WeekMonth
+	)
+	switch {
+	case p.tryConsume('J'):
+		_, day, ok := p.parseInt32(int32Prefix_NoSign, 3)
+		if !ok {
+			return Zero[RuleDateTime](), want_JulianDay
+		}
+		// maxDigits = 3 => day ∈ [0, 999] => int32->int16 narrowing is OK
+		julianDay, ok := NewJulianDay(int16(day))
+		if !ok {
+			return Zero[RuleDateTime](), want_JulianDay
+		}
+		kind = RuleDateTimeKind_Julian
+		dayBits = uint16(julianDay.Int16()) // OK as value is in [1, 365]
+	case p.tryConsume('M'):
+		month, ok := p.month()
+		if !ok {
+			return Zero[RuleDateTime](), want_Month
+		}
+		if !p.tryConsume('.') {
+			return Zero[RuleDateTime](), want_RuleSeparator
+		}
+		week, ok := p.week()
+		if !ok {
+			return Zero[RuleDateTime](), want_Week
+		}
+		if !p.tryConsume('.') {
+			return Zero[RuleDateTime](), want_RuleSeparator
+		}
+		weekday, ok := p.weekday()
+		if !ok {
+			return Zero[RuleDateTime](), want_Weekday
+		}
+		kind = RuleDateTimeKind_MonthWeekDay
+		weekMonth = NewWeekMonth(month, week)
+		dayBits = uint16(weekday.Uint8())
+	default:
+		_, day, ok := p.parseInt32(int32Prefix_NoSign, 3)
+		if !ok {
+			return Zero[RuleDateTime](), want_DayOfYear
+		}
+		// maxDigits = 3 => day ∈ [0, 999] => int32->int16 narrowing is OK
+		dayOfYear, ok := NewDayOfYear(int16(day))
+		if !ok {
+			return Zero[RuleDateTime](), want_DayOfYear
+		}
+		kind = RuleDateTimeKind_DayOfYear
+		dayBits = uint16(dayOfYear.Int16())
+	}
+	second := int32(2 * secondsPerHour)
+	if p.tryConsume('/') {
+		s, err := p.transitionTime()
+		if err != want_None {
+			return Zero[RuleDateTime](), err
+		}
+		// transitionTime ∈ [-604799,604799], so it can't fit into
+		// 16 bits. So let's use 32 bits for simplicity.
+		second = s
+	}
+	return RuleDateTime{
+		kind:      kind,
+		day:       dayBits,
+		second:    second,
+		weekMonth: weekMonth,
+	}, want_None
+}
+
+type charSubset uint8
+
+const (
+	charSubset_UnquotedAbbreviation charSubset = iota + 1
+	charSubset_QuotedAbbreviation
+)
+
+func isUnquotedPOSIXAbbreviationByte(b byte) bool {
+	// Per code://docs/external/posix_tz.md#unquoted-form,
+	// only alphabetic characters are allowed.
+	return 'A' <= b && b <= 'Z' || 'a' <= b && b <= 'z'
+}
+
+func isQuotedPOSIXAbbreviationByte(b byte) bool {
+	// Per code://docs/external/posix_tz.md#quoted-form,
+	// alphanumeric characters and '+' and '-' are allowed.
+	return 'A' <= b && b <= 'Z' || 'a' <= b && b <= 'z' || '0' <= b && b <= '9' || b == '+' || b == '-'
+}
+
+func (p *parser) month() (Month, bool) {
+	_, month, ok := p.parseInt32(int32Prefix_NoSign, 2)
+	if !ok {
+		return Zero[Month](), false
+	}
+	// maxDigits = 2 => month ∈ [0, 99] => int32->uint8 narrowing is OK
+	return NewMonth(uint8(month))
+}
+
+func (p *parser) week() (Week, bool) {
+	_, week, ok := p.parseInt32(int32Prefix_NoSign, 1)
+	if !ok {
+		return Zero[Week](), false
+	}
+	// maxDigits = 1 => week ∈ [0, 9] => int32->uint8 narrowing is OK
+	return NewWeek(uint8(week))
+}
+
+func (p *parser) weekday() (Weekday, bool) {
+	_, weekday, ok := p.parseInt32(int32Prefix_NoSign, 1)
+	if !ok {
+		return Zero[Weekday](), false
+	}
+	// maxDigits = 1 => weekday ∈ [0, 9] => int32->uint8 narrowing is OK
+	return NewWeekday(uint8(weekday))
+}
+
+type int32Prefix uint8
+
+const (
+	int32Prefix_MayHaveSign int32Prefix = iota + 1
+	int32Prefix_NoSign
+)
+
+// maxSafeInt32Digits is one less than the number of decimal digits in MaxInt32.
+// This guarantees n*10+digit cannot overflow int32 for any allowed input.
+const maxSafeInt32Digits = 9
+
+// parseInt32 parses a decimal int32 with at most maxDigits digits, returning
+// the sign and the (non-negative) magnitude separately so callers can
+// distinguish a parsed "-0" from "+0".
+//
+// When prefix is int32Prefix_NoSign, sign is always +1.
+//
+// Pre-condition: maxDigits ∈ (0, maxSafeInt32Digits].
+func (p *parser) parseInt32(prefix int32Prefix, maxDigits uint8) (sign int32, value int32, ok bool) {
+	if maxDigits == 0 {
+		assert.Preconditionf(false, "maxDigits must be positive, got %d", maxDigits)
+	}
+	if maxDigits > maxSafeInt32Digits {
+		assert.Preconditionf(false, "maxDigits %d may overflow int32", maxDigits)
+	}
+	asciiNum := ranges.ClosedRange[byte]{Lo: '0', Hi: '9'}
+
+	sign = 1
+	switch prefix {
+	case int32Prefix_MayHaveSign:
+		if p.tryConsume('-') {
+			sign = -1
+		} else {
+			p.tryConsume('+')
+		}
+	case int32Prefix_NoSign:
+		break
+	default:
+		return assert.PanicUnknownCase[int32](prefix), 0, false
+	}
+	if p.done() || !asciiNum.Contains(p.peek()) {
+		return 0, 0, false
+	}
+	n := int32(0)
+	digits := uint8(0)
+	for !p.done() && digits < maxDigits && asciiNum.Contains(p.peek()) {
+		n = n*10 + int32(p.peek()-'0')
+		p.i++
+		digits++
+	}
+	return sign, n, true
+}

--- a/common/timex/internal/posix_tz/posix_tz.go
+++ b/common/timex/internal/posix_tz/posix_tz.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package posix_tz
+
+import (
+	"code.kibou.tools/common/assert"
+)
+
+// The quoted abbreviation form and extended transition-time ranges are also
+// documented by the IANA time-zone database theory file:
+// https://data.iana.org/time-zones/tzdb/theory.html
+const (
+	secondsPerMinute = 60
+	secondsPerHour   = 60 * secondsPerMinute
+	secondsPerDay    = 24 * secondsPerHour
+)
+
+// TimeZone is the parsed representation of a POSIX TZ
+// string, as specified by POSIX.1-2024, Base Definitions, Ch. 8
+// (Environment Variables), in the TZ entry:
+// https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html
+type TimeZone struct {
+	StdName string
+	HasDST  bool
+
+	// Seconds east of UTC.
+	StdOffset int32
+
+	rule      Rule
+	dstName   string
+	dstOffset int32 // Seconds east of UTC.
+}
+
+// DstName returns the DST abbreviation.
+//
+// Pre-condition: tz.HasDST must be true.
+func (tz TimeZone) DstName() string {
+	if !tz.HasDST {
+		assert.Precondition(false, "DST name is only available when HasDST is true")
+	}
+	return tz.dstName
+}
+
+// DstOffset returns the DST offset in seconds east of UTC.
+//
+// Pre-condition: tz.HasDST must be true.
+func (tz TimeZone) DstOffset() int32 {
+	if !tz.HasDST {
+		assert.Precondition(false, "DST offset is only available when HasDST is true")
+	}
+	return tz.dstOffset
+}
+
+// Rule returns the DST transition rule.
+//
+// Pre-condition: tz.HasDST must be true.
+func (tz TimeZone) Rule() Rule {
+	if !tz.HasDST {
+		assert.Precondition(false, "DST rule is only available when HasDST is true")
+	}
+	return tz.rule
+}
+
+// Rule is a POSIX DST transition rule of the form:
+//
+// date[/time],date[/time]
+type Rule struct {
+	Start RuleDateTime
+	End   RuleDateTime
+}
+
+// RuleDateTimeKind describes the format of the date retrieved
+// from a rule.
+//
+// See code://docs/external/posix_tz.md#rule-date-format
+type RuleDateTimeKind uint8
+
+const (
+	// RuleDateTimeKind_Julian indicates the date is of the form
+	// 1 <= n <= 365, with leap days being disallowed.
+	RuleDateTimeKind_Julian RuleDateTimeKind = iota + 1
+	RuleDateTimeKind_DayOfYear
+	RuleDateTimeKind_MonthWeekDay
+)
+
+// RuleDateTime is one date[/time] component in a POSIX DST transition rule.
+type RuleDateTime struct {
+	// second is in the range [-604799,604799].
+	second    int32
+	day       uint16 // Julian day, day-of-year or weekday, depending on kind.
+	kind      RuleDateTimeKind
+	weekMonth WeekMonth
+}
+
+// Second returns the rule part's transition time as a signed second offset from midnight.
+func (dt RuleDateTime) Second() int32 {
+	return dt.second
+}
+
+// Kind returns the rule part variant.
+func (dt RuleDateTime) Kind() RuleDateTimeKind {
+	return dt.kind
+}
+
+// JulianDay returns the one-based Julian day for a Julian rule part.
+//
+// Pre-condition: dt.Kind() must be RuleDateTimeKind_Julian.
+func (dt RuleDateTime) JulianDay() JulianDay {
+	if dt.kind != RuleDateTimeKind_Julian {
+		assert.Precondition(false, "Julian day is only available for Julian rule parts")
+	}
+	return MustJulianDay(int16(dt.day))
+}
+
+// DayOfYear returns the zero-based day-of-year for a day-of-year rule part.
+//
+// Pre-condition: dt.Kind() must be RuleDateTimeKind_DayOfYear.
+func (dt RuleDateTime) DayOfYear() DayOfYear {
+	if dt.kind != RuleDateTimeKind_DayOfYear {
+		assert.Precondition(false, "day-of-year is only available for day-of-year rule parts")
+	}
+	return MustDayOfYear(int16(dt.day))
+}
+
+// Weekday returns the weekday for a month-week-day rule part.
+//
+// Pre-condition: dt.Kind() must be RuleDateTimeKind_MonthWeekDay.
+func (dt RuleDateTime) Weekday() Weekday {
+	if dt.kind != RuleDateTimeKind_MonthWeekDay {
+		assert.Precondition(false, "weekday is only available for month-week-day rule parts")
+	}
+	return MustWeekday(uint8(dt.day))
+}
+
+// Week returns the week number for a month-week-day rule part.
+//
+// Pre-condition: dt.Kind() must be RuleDateTimeKind_MonthWeekDay.
+func (dt RuleDateTime) Week() Week {
+	if dt.kind != RuleDateTimeKind_MonthWeekDay {
+		assert.Precondition(false, "week is only available for month-week-day rule parts")
+	}
+	return dt.weekMonth.Week()
+}
+
+// Month returns the month for a month-week-day rule part.
+//
+// Pre-condition: dt.Kind() must be RuleDateTimeKind_MonthWeekDay.
+func (dt RuleDateTime) Month() Month {
+	if dt.kind != RuleDateTimeKind_MonthWeekDay {
+		assert.Precondition(false, "month is only available for month-week-day rule parts")
+	}
+	return dt.weekMonth.Month()
+}
+
+// SecondInYear returns the moment this rule fires, expressed as a signed
+// offset in seconds from midnight at the start of Jan 1 of `year` in
+// local wall time (no UTC offset applied).
+//
+// The result can be negative or exceed the year length because POSIX
+// permits transition times outside [0, 24h) — e.g., "/-1" means 23:00 the
+// previous day, "/26" means 02:00 the next.
+//
+// TODO: I dislike the shape of this API, because it makes it difficult
+// for the caller to understand what to do. Let's try to improve upon
+// it in a later pass.
+func (dt RuleDateTime) SecondInYear(year int) int {
+	switch dt.Kind() {
+	case RuleDateTimeKind_Julian:
+		return dt.JulianDay().zeroBasedDayOfYear(year)*secondsPerDay + int(dt.Second())
+	case RuleDateTimeKind_DayOfYear:
+		return dt.DayOfYear().Int()*secondsPerDay + int(dt.Second())
+	case RuleDateTimeKind_MonthWeekDay:
+		month := dt.Month()
+		day := nthWeekdayOfMonth(year, month, dt.Weekday(), dt.Week())
+		return (dayOfYear(year, month.Int(), day)-1)*secondsPerDay + int(dt.Second())
+	default:
+		return assert.PanicUnknownCase[int](dt.Kind())
+	}
+}

--- a/common/timex/internal/posix_tz/posix_tz_test.go
+++ b/common/timex/internal/posix_tz/posix_tz_test.go
@@ -1,0 +1,488 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package posix_tz
+
+import (
+	"strings"
+	"testing"
+	"unsafe"
+
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/common/check"
+	"code.kibou.tools/common/errorx"
+	parseerr "code.kibou.tools/common/parse"
+	. "code.kibou.tools/common/zero"
+)
+
+func TestParse(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("Unit", func(h check.Harness) {
+		h.Parallel()
+		h.Run("Valid", testParseValid)
+		h.Run("Invalid", testParseInvalid)
+	})
+
+	h.Run("Property", func(h check.Harness) {
+		h.Parallel()
+		h.Run("NoPanic", testParseNoPanic)
+		h.Run("ErrorIsParseError", testParseErrorShape)
+		h.Run("FormatRoundTrip", testParseFormatRoundTrip)
+		h.Run("ParseRoundTrip", testParseParseRoundTrip)
+	})
+}
+
+func testParseValid(h check.Harness) {
+	h.Parallel()
+
+	h.Run("StandardOnly", func(h check.Harness) {
+		h.Parallel()
+		got := mustParsePOSIXTimeZone(h, "UTC0")
+		assertPOSIX(h, got, wantPOSIX{
+			StdName:   "UTC",
+			StdOffset: 0,
+			DstName:   "",
+			DstOffset: 0,
+			HasDST:    false,
+			Rule:      Zero[Rule](),
+		})
+	})
+
+	h.Run("DSTRules", func(h check.Harness) {
+		h.Parallel()
+		got := mustParsePOSIXTimeZone(h, "EST5EDT,M3.2.0,M11.1.0")
+		assertPOSIX(h, got, wantPOSIX{
+			StdName:   "EST",
+			StdOffset: -5 * secondsPerHour,
+			DstName:   "EDT",
+			DstOffset: -4 * secondsPerHour,
+			HasDST:    true,
+			Rule:      Rule{Start: wantMonthWeekDayRuleDateTime(3, 2, 0, 2*secondsPerHour), End: wantMonthWeekDayRuleDateTime(11, 1, 0, 2*secondsPerHour)},
+		})
+	})
+
+	h.Run("QuotedNamesAndExplicitOffsets", func(h check.Harness) {
+		h.Parallel()
+		got := mustParsePOSIXTimeZone(h, "<-03>3<+05>-5,J60/1:02:03,365/-1")
+		assertPOSIX(h, got, wantPOSIX{
+			StdName:   "-03",
+			StdOffset: -3 * secondsPerHour,
+			DstName:   "+05",
+			DstOffset: 5 * secondsPerHour,
+			HasDST:    true,
+			Rule:      Rule{Start: wantJulianRuleDateTime(60, secondsPerHour+2*secondsPerMinute+3), End: wantDayOfYearRuleDateTime(365, -secondsPerHour)},
+		})
+	})
+
+	h.Run("ExplicitDSTOffset", func(h check.Harness) {
+		h.Parallel()
+		got := mustParsePOSIXTimeZone(h, "AEST-10AEDT-11,M10.1.0,M4.1.0/3")
+		check.AssertSame(h, true, got.HasDST, "has DST")
+		check.AssertSame(h, "AEDT", got.DstName(), "dst name")
+		check.AssertSame(h, int32(11*secondsPerHour), got.DstOffset(), "dst offset")
+		assertRuleDateTime(h, "Start", wantMonthWeekDayRuleDateTime(10, 1, 0, 2*secondsPerHour), got.Rule().Start)
+		assertRuleDateTime(h, "End", wantMonthWeekDayRuleDateTime(4, 1, 0, 3*secondsPerHour), got.Rule().End)
+	})
+
+	h.Run("GoIssueRegressions", testParseGoIssueRegressions)
+}
+
+// testParseGoIssueRegressions exercises POSIX TZ strings drawn from real
+// IANA tzdata footers and from inputs that have historically tripped up
+// golang/go's time package. Each case is anchored to a closed (or
+// closed-by-rejection) golang/go issue so that future parser changes can
+// be audited against parity with the stdlib's stated behavior.
+func testParseGoIssueRegressions(h check.Harness) {
+	h.Parallel()
+
+	// golang/go#5361: Atlantic/South_Georgia used a quoted negative
+	// abbreviation with no DST. The historical IANA footer for that zone
+	// is "<-02>2", which Go's tzset accepts but earlier versions
+	// mishandled. The parser must produce a UTC-2 zone with no DST.
+	h.Run("Issue5361_QuotedNegativeNoDST", func(h check.Harness) {
+		h.Parallel()
+		got := mustParsePOSIXTimeZone(h, "<-02>2")
+		assertPOSIX(h, got, wantPOSIX{
+			StdName:   "-02",
+			StdOffset: -2 * secondsPerHour,
+			HasDST:    false,
+			Rule:      Zero[Rule](),
+		})
+	})
+
+	// golang/go#3604: Southern-hemisphere zones encode DST that starts in
+	// the back half of the year and ends in the front half — the END rule
+	// is earlier in the calendar than the START rule. Australia's footer
+	// "AEST-10AEDT,M10.1.0,M4.1.0/3" exercises this; the parser must keep
+	// the rule order exactly as given without "normalizing" it.
+	h.Run("Issue3604_SouthernHemisphereRuleOrder", func(h check.Harness) {
+		h.Parallel()
+		got := mustParsePOSIXTimeZone(h, "AEST-10AEDT,M10.1.0,M4.1.0/3")
+		assertPOSIX(h, got, wantPOSIX{
+			StdName:   "AEST",
+			StdOffset: 10 * secondsPerHour,
+			DstName:   "AEDT",
+			DstOffset: 11 * secondsPerHour, // default DST offset = std + 1h
+			HasDST:    true,
+			Rule: Rule{
+				Start: wantMonthWeekDayRuleDateTime(10, 1, 0, 2*secondsPerHour),
+				End:   wantMonthWeekDayRuleDateTime(4, 1, 0, 3*secondsPerHour),
+			},
+		})
+	})
+
+	// golang/go#8134: TZif v3 extended the transition-time range from
+	// [0, 24h) to [-167h, 167h] so that footers can encode transitions
+	// that fall on the previous or next civil day. Real-world example:
+	// Chile uses "<-04>4<-03>,M9.1.6/24,M4.1.6/22", where "/24" means
+	// 24:00:00 (midnight at the end of the day). The parser must accept
+	// the value verbatim and preserve the sign and magnitude.
+	h.Run("Issue8134_TransitionTimeAtOrPast24h", func(h check.Harness) {
+		h.Parallel()
+		got := mustParsePOSIXTimeZone(h, "<-04>4<-03>,M9.1.6/24,M4.1.6/22")
+		assertPOSIX(h, got, wantPOSIX{
+			StdName:   "-04",
+			StdOffset: -4 * secondsPerHour,
+			DstName:   "-03",
+			DstOffset: -3 * secondsPerHour,
+			HasDST:    true,
+			Rule: Rule{
+				Start: wantMonthWeekDayRuleDateTime(9, 1, 6, 24*secondsPerHour),
+				End:   wantMonthWeekDayRuleDateTime(4, 1, 6, 22*secondsPerHour),
+			},
+		})
+	})
+
+	// Sibling of Issue8134: the negative end of the extended range.
+	// IANA documents "/-1" (the previous day at 23:00) as legal; the
+	// existing QuotedNamesAndExplicitOffsets case covers this for a
+	// day-of-year rule, but we also need the Mm.w.d form because that's
+	// what real-world footers use.
+	h.Run("Issue8134_NegativeTransitionTime", func(h check.Harness) {
+		h.Parallel()
+		got := mustParsePOSIXTimeZone(h, "STD5DST,M3.2.0/-1,M11.1.0/2")
+		check.AssertSame(h, true, got.HasDST, "has DST")
+		assertRuleDateTime(h, "Start", wantMonthWeekDayRuleDateTime(3, 2, 0, -secondsPerHour), got.Rule().Start)
+	})
+
+	// golang/go#3385: Pre-1970 DST history is encoded only in the static
+	// transition table, never in the POSIX footer (the footer captures
+	// the rule applicable *after* the last static transition). The
+	// parser has no opinion on history; it just needs to round-trip the
+	// modern Mm.w.d form without dropping fields. Sanity check using a
+	// minimal Europe-style footer.
+	h.Run("Issue3385_LastSundayRule", func(h check.Harness) {
+		h.Parallel()
+		got := mustParsePOSIXTimeZone(h, "CET-1CEST,M3.5.0,M10.5.0/3")
+		assertPOSIX(h, got, wantPOSIX{
+			StdName:   "CET",
+			StdOffset: 1 * secondsPerHour,
+			DstName:   "CEST",
+			DstOffset: 2 * secondsPerHour,
+			HasDST:    true,
+			Rule: Rule{
+				Start: wantMonthWeekDayRuleDateTime(3, 5, 0, 2*secondsPerHour),
+				End:   wantMonthWeekDayRuleDateTime(10, 5, 0, 3*secondsPerHour),
+			},
+		})
+	})
+}
+
+func testParseInvalid(h check.Harness) {
+	h.Parallel()
+
+	for _, tt := range []struct {
+		input             string
+		wantKind          ParseErrorKind
+		wantParsed        string
+		wantErrorContains string
+	}{
+		{input: "", wantKind: ParseErrorKind_Empty, wantParsed: "", wantErrorContains: "expected - non-empty input"},
+		{input: "ES5", wantKind: ParseErrorKind_SpecViolation, wantParsed: "ES", wantErrorContains: "context - trying to parse standard time abbreviation, expected - time abbreviation with at least 3 bytes"},
+		{input: "EST", wantKind: ParseErrorKind_SpecViolation, wantParsed: "EST", wantErrorContains: "context - trying to parse standard time offset, expected - hour digits ([0-9]+)"},
+		{input: "EST5EDT", wantKind: ParseErrorKind_SpecViolation, wantParsed: "EST5EDT", wantErrorContains: "context - trying to parse daylight saving time rule, expected - daylight saving time transition rule"},
+		{input: "EST5EDT,M13.1.0,M11.1.0", wantKind: ParseErrorKind_SpecViolation, wantParsed: "EST5EDT,M13", wantErrorContains: "context - trying to parse daylight saving time rule start date/time, expected - transition-rule month in range [1,12]"},
+		{input: "EST5EDT,M3.2.7,M11.1.0", wantKind: ParseErrorKind_SpecViolation, wantParsed: "EST5EDT,M3.2.7", wantErrorContains: "context - trying to parse daylight saving time rule start date/time, expected - transition-rule weekday in range [0,6]"},
+		{input: "EST5EDT,M3.2.0", wantKind: ParseErrorKind_SpecViolation, wantParsed: "EST5EDT,M3.2.0", wantErrorContains: "context - trying to parse daylight saving time rule end date/time, expected - rule date/time separator"},
+		{input: "EST25", wantKind: ParseErrorKind_SpecViolation, wantParsed: "EST25", wantErrorContains: "context - trying to parse standard time offset, expected - hour in range [-24,24]"},
+		{input: "EST5EDT,M3.2.0/168,M11.1.0", wantKind: ParseErrorKind_SpecViolation, wantParsed: "EST5EDT,M3.2.0/168", wantErrorContains: "context - trying to parse daylight saving time rule start date/time, expected - hour in range [-167,167]"},
+		{input: "EST5EDT,M3.2.0/2:60,M11.1.0", wantKind: ParseErrorKind_SpecViolation, wantParsed: "EST5EDT,M3.2.0/2:60", wantErrorContains: "context - trying to parse daylight saving time rule start date/time, expected - minute in range [0,59]"},
+		{input: string([]byte{'E', 'S', 'T', 0xff, '5'}), wantKind: ParseErrorKind_InvalidUTF8, wantParsed: "", wantErrorContains: "invalid UTF-8"},
+	} {
+		h.Run(tt.input, func(h check.Harness) {
+			h.Parallel()
+			_, err := Parse(tt.input).Get()
+			parseErr, ok := err.(*ParseError)
+			h.Assertf(ok, "error = %T %[1]v, want *ParseError", err)
+			check.AssertSame(h, tt.wantKind, parseErr.Kind(), "Kind")
+			check.AssertSame(h, tt.input, parseErr.Source(), "Source")
+			check.AssertSame(h, tt.wantParsed, parseErr.Parsed(), "Parsed")
+			h.Assertf(strings.Contains(parseErr.Error(), tt.wantErrorContains), "Error() = %q, want substring %q", parseErr.Error(), tt.wantErrorContains)
+		})
+	}
+}
+
+// Parse must never panic on arbitrary input. rapid treats panics as property
+// failures, so this also covers calls that succeed and calls that error.
+func testParseNoPanic(h check.Harness) {
+	h.Parallel()
+	rapid.Check(h.T(), func(t *rapid.T) {
+		input := arbitraryParseInput().Draw(t, "input")
+		Parse(input)
+	})
+}
+
+// On failure, Parse must return a *ParseError with consistent invariants:
+// Source equals the input, Parsed is a prefix of the input, and Error() is
+// non-empty so that the error message can be surfaced to users.
+func testParseErrorShape(h check.Harness) {
+	h.Parallel()
+	rapid.Check(h.T(), func(t *rapid.T) {
+		hh := check.NewBasic(t)
+		input := arbitraryParseInput().Draw(t, "input")
+		_, err := Parse(input).Get()
+		if err == nil {
+			return
+		}
+		parseErr, ok := err.(*ParseError)
+		hh.Assertf(ok, "error = %T %[1]v, want *ParseError", err)
+		diagnostic := errorx.GetRootCauseAs[*parseerr.Error](err).Unwrap()
+		check.AssertSame(hh, input, parseErr.Source(), "Source")
+		check.AssertSame(hh, input, diagnostic.Source(), "diagnostic Source")
+		hh.Assertf(strings.HasPrefix(input, parseErr.Parsed()), "Parsed %q is not a prefix of Source %q", parseErr.Parsed(), input)
+		hh.Assertf(parseErr.Error() != "", "Error() returned empty string")
+	})
+}
+
+// Format → Parse must round-trip: any TimeZone we can construct must format
+// to a string that parses back to an equal TimeZone.
+func testParseFormatRoundTrip(h check.Harness) {
+	h.Parallel()
+	rapid.Check(h.T(), func(t *rapid.T) {
+		hh := check.NewBasic(t)
+		tz := arbitraryTimeZone().Draw(t, "tz")
+		formatted := tz.Format()
+		got, err := Parse(formatted).Get()
+		hh.Assertf(err == nil, "Parse(%q) failed: %v", formatted, err)
+		assertTimeZoneEqual(hh, tz, got, formatted)
+	})
+}
+
+// Parse → Format → Parse must be idempotent: for any input that parses, the
+// canonical formatted form must re-parse to an equal TimeZone. This catches
+// Format/Parse asymmetries on input shapes (leading zeros, explicit '+',
+// negative sub-hour offsets) that Format never emits itself.
+func testParseParseRoundTrip(h check.Harness) {
+	h.Parallel()
+	rapid.Check(h.T(), func(t *rapid.T) {
+		hh := check.NewBasic(t)
+		input := arbitraryParseInput().Draw(t, "input")
+		tz1, err := Parse(input).Get()
+		if err != nil {
+			return
+		}
+		formatted := tz1.Format()
+		tz2, err := Parse(formatted).Get()
+		hh.Assertf(err == nil, "Parse(%q) failed after Format(%v): %v", formatted, tz1, err)
+		assertTimeZoneEqual(hh, tz1, tz2, formatted)
+	})
+}
+
+func TestRuleLayout(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	size := unsafe.Sizeof(Zero[RuleDateTime]())
+	h.Assertf(size <= 8, "RuleDateTime size = %d bytes, want at most 8", size)
+}
+
+func TestSecondInYear(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("JulianSkipsLeapDay", func(h check.Harness) {
+		h.Parallel()
+		dt := wantJulianRuleDateTime(60, 0)
+		check.AssertSame(h, 59*secondsPerDay, dt.SecondInYear(2023), "common year")
+		check.AssertSame(h, 60*secondsPerDay, dt.SecondInYear(2024), "leap year")
+	})
+
+	h.Run("DayOfYearIncludesLeapDay", func(h check.Harness) {
+		h.Parallel()
+		dt := wantDayOfYearRuleDateTime(60, 0)
+		check.AssertSame(h, 60*secondsPerDay, dt.SecondInYear(2023), "common year")
+		check.AssertSame(h, 60*secondsPerDay, dt.SecondInYear(2024), "leap year")
+	})
+
+	h.Run("FifthWeekMeansLastWeekdayInMonth", func(h check.Harness) {
+		h.Parallel()
+		dt := wantMonthWeekDayRuleDateTime(2, 5, 0, 0)
+		check.AssertSame(h, 55*secondsPerDay, dt.SecondInYear(2024), "last Sunday in February 2024")
+	})
+}
+
+// arbitraryParseInput mixes structured "almost-valid" inputs with arbitrary
+// byte strings, so the property tests cover both error paths near the grammar
+// and pathological inputs.
+func arbitraryParseInput() *rapid.Generator[string] {
+	return rapid.OneOf(
+		rapid.StringN(0, 32, -1),
+		rapid.Custom(func(t *rapid.T) string {
+			return arbitraryTimeZone().Draw(t, "tz").Format()
+		}),
+		rapid.Custom(func(t *rapid.T) string {
+			// Mutate a valid string by truncating or appending garbage.
+			s := arbitraryTimeZone().Draw(t, "tz").Format()
+			cut := rapid.IntRange(0, len(s)).Draw(t, "cut")
+			tail := rapid.StringN(0, 8, -1).Draw(t, "tail")
+			return s[:cut] + tail
+		}),
+	)
+}
+
+func arbitraryTimeZone() *rapid.Generator[TimeZone] {
+	return rapid.Custom(func(t *rapid.T) TimeZone {
+		stdName := arbitraryName().Draw(t, "stdName")
+		stdOffset := arbitraryOffset().Draw(t, "stdOffset")
+		hasDST := rapid.Bool().Draw(t, "hasDST")
+		var dstName string
+		var dstOffset int32
+		var rule Rule
+		if hasDST {
+			dstName = arbitraryName().Draw(t, "dstName")
+			dstOffset = arbitraryOffset().Draw(t, "dstOffset")
+			rule = Rule{
+				Start: arbitraryRuleDateTime().Draw(t, "start"),
+				End:   arbitraryRuleDateTime().Draw(t, "end"),
+			}
+		}
+		return TimeZone{
+			StdName:   stdName,
+			StdOffset: stdOffset,
+			HasDST:    hasDST,
+			dstName:   dstName,
+			dstOffset: dstOffset,
+			rule:      rule,
+		}
+	})
+}
+
+func arbitraryName() *rapid.Generator[string] {
+	alpha := rapid.StringMatching(`[A-Za-z]{3,6}`)
+	alnum := rapid.StringMatching(`[A-Za-z0-9+\-]{3,6}`)
+	return rapid.OneOf(alpha, alnum)
+}
+
+func arbitraryOffset() *rapid.Generator[int32] {
+	return rapid.Int32Range(-24*secondsPerHour, 24*secondsPerHour)
+}
+
+func arbitraryRuleDateTime() *rapid.Generator[RuleDateTime] {
+	transitionSec := rapid.Int32Range(-167*secondsPerHour-59*secondsPerMinute-59, 167*secondsPerHour+59*secondsPerMinute+59)
+	return rapid.Custom(func(t *rapid.T) RuleDateTime {
+		second := transitionSec.Draw(t, "second")
+		switch rapid.IntRange(0, 2).Draw(t, "kind") {
+		case 0:
+			day := rapid.Int16Range(1, 365).Draw(t, "julianDay")
+			return wantJulianRuleDateTime(day, second)
+		case 1:
+			day := rapid.Int16Range(0, 365).Draw(t, "dayOfYear")
+			return wantDayOfYearRuleDateTime(day, second)
+		default:
+			month := rapid.Uint8Range(1, 12).Draw(t, "month")
+			week := rapid.Uint8Range(1, 5).Draw(t, "week")
+			weekday := rapid.Uint8Range(0, 6).Draw(t, "weekday")
+			return wantMonthWeekDayRuleDateTime(month, week, weekday, second)
+		}
+	})
+}
+
+func assertTimeZoneEqual(h check.BasicHarness, want TimeZone, got TimeZone, label string) {
+	check.AssertSame(h, want.StdName, got.StdName, label+" std name")
+	check.AssertSame(h, want.StdOffset, got.StdOffset, label+" std offset")
+	check.AssertSame(h, want.HasDST, got.HasDST, label+" has DST")
+	if !want.HasDST {
+		return
+	}
+	check.AssertSame(h, want.dstName, got.dstName, label+" dst name")
+	check.AssertSame(h, want.dstOffset, got.dstOffset, label+" dst offset")
+	assertRuleDateTime(h, label+" start", want.rule.Start, got.rule.Start)
+	assertRuleDateTime(h, label+" end", want.rule.End, got.rule.End)
+}
+
+type wantPOSIX struct {
+	StdName   string
+	StdOffset int32
+	DstName   string
+	DstOffset int32
+	HasDST    bool
+	Rule      Rule
+}
+
+func mustParsePOSIXTimeZone(h check.Harness, input string) TimeZone {
+	h.T().Helper()
+	got, err := Parse(input).Get()
+	h.Assertf(err == nil, "Parse(%q) failed: %v", input, err)
+	return got
+}
+
+func assertPOSIX(h check.Harness, got TimeZone, want wantPOSIX) {
+	h.T().Helper()
+	check.AssertSame(h, want.StdName, got.StdName, "std name")
+	check.AssertSame(h, want.StdOffset, got.StdOffset, "std offset")
+	check.AssertSame(h, want.HasDST, got.HasDST, "has DST")
+	if want.HasDST {
+		check.AssertSame(h, want.DstName, got.DstName(), "dst name")
+		check.AssertSame(h, want.DstOffset, got.DstOffset(), "dst offset")
+		assertRuleDateTime(h, "Start", want.Rule.Start, got.Rule().Start)
+		assertRuleDateTime(h, "End", want.Rule.End, got.Rule().End)
+	}
+}
+
+func assertRuleDateTime(h check.BasicHarness, label string, want RuleDateTime, got RuleDateTime) {
+	check.AssertSame(h, want.Kind(), got.Kind(), label+" kind")
+	check.AssertSame(h, want.Second(), got.Second(), label+" second")
+	switch want.Kind() {
+	case RuleDateTimeKind_Julian:
+		check.AssertSame(h, want.JulianDay().Int16(), got.JulianDay().Int16(), label+" Julian day")
+	case RuleDateTimeKind_DayOfYear:
+		check.AssertSame(h, want.DayOfYear().Int16(), got.DayOfYear().Int16(), label+" day-of-year")
+	case RuleDateTimeKind_MonthWeekDay:
+		check.AssertSame(h, want.Month().Uint8(), got.Month().Uint8(), label+" month")
+		check.AssertSame(h, want.Week().Uint8(), got.Week().Uint8(), label+" week")
+		check.AssertSame(h, want.Weekday().Uint8(), got.Weekday().Uint8(), label+" weekday")
+	default:
+		h.Assertf(false, "unknown rule date/time kind: %v", want.Kind())
+	}
+}
+
+func wantJulianRuleDateTime(day int16, second int32) RuleDateTime {
+	return RuleDateTime{
+		kind:      RuleDateTimeKind_Julian,
+		day:       uint16(MustJulianDay(day).Int16()),
+		second:    second,
+		weekMonth: 0,
+	}
+}
+
+func wantDayOfYearRuleDateTime(day int16, second int32) RuleDateTime {
+	return RuleDateTime{
+		kind:      RuleDateTimeKind_DayOfYear,
+		day:       uint16(MustDayOfYear(day).Int16()),
+		second:    second,
+		weekMonth: 0,
+	}
+}
+
+func wantMonthWeekDayRuleDateTime(month uint8, week uint8, weekday uint8, second int32) RuleDateTime {
+	return RuleDateTime{
+		kind:      RuleDateTimeKind_MonthWeekDay,
+		weekMonth: NewWeekMonth(MustMonth(month), MustWeek(week)),
+		day:       uint16(MustWeekday(weekday).Uint8()),
+		second:    second,
+	}
+}

--- a/docs/external/posix_tz.md
+++ b/docs/external/posix_tz.md
@@ -1,0 +1,203 @@
+# POSIX Timezone format
+
+POSIX supports the `TZ` environment variable to represent
+"timezone information." -- search for "timezone information"
+in the [POSIX Issue 8 Ch. 8 Environment Variables][posix8-ch8-env-vars].
+
+The spec's HTML unfortunately doesn't allow making permalinks
+to different subsections, so I've copied the key points and
+my interpretations here, for references from the code.
+
+Basically, the `TZ` env var can be one of 3 forms.
+
+## Implementation-defined form
+
+```
+:characters
+```
+
+> If TZ is of the first format (that is, if the first character is a <colon>),
+> the characters following the <colon> are handled in an implementation-defined manner.
+
+## Rule-based form
+
+```
+stdoffset[dst[offset][,start[/time],end[/time]]]
+                     ^-------------------------^
+                               rule
+
+Examples:
+TODO(add examples here)
+```
+
+### Name format
+
+- `std` and `dst` (if present) have length `l ∈ [3, TZNAME_MAX]`.
+  Based on local testing, the values in practice are:
+  - `getconf TZNAME_MAX` returns 255 on macOS 15.7.4
+  - `getconf TZNAME_MAX` returns undefined/unset on Debian 13
+  - `getconf TZNAME_MAX` returns 6 on Alpine 3.23
+
+These have two forms, quoted and unquoted.
+
+#### Quoted form
+
+For quoted, the spec says:
+
+> In the quoted form, the first character shall be the <less-than-sign> ('<') character
+> and the last character shall be the <greater-than-sign> ('>') character. All characters
+> between these quoting characters shall be alphanumeric characters from the portable
+> character set in the current locale, the <plus-sign> ('+') character, or the
+> <hyphen-minus> ('-') character. The std and dst fields in this case shall not include
+> the quoting characters and the quoting characters do not contribute to the three byte
+> minimum length and {TZNAME_MAX} maximum length.
+
+The wording is potentially a bit confusing: the "alphanumeric characters from the portable
+character set in the current locale" does not imply that the set of allowed characters is
+locale-dependent.
+
+Per [POSIX Issue 8 Ch. 6 Character Set][posix8-ch6-char-set]:
+
+> Each supported locale shall include the portable character set, which is the set of symbolic names for characters in Portable Character Set
+> (table of characters)
+
+The full portable character set is essentially a subset of the code point
+range `[U+0000 (NUL), U+007E (~)]`. Since only alphanumeric characters
+matter here, it's just a fancy way of saying `[A-Za-z0-9]`.
+
+The "tricky" thing is encoding. A codepoint may be encoded as UTF-8, [EBCDIC][wikipedia-ebcdic]
+or something else. In theory, there's nothing stopping you from providing
+env vars with whatever encoding you want.
+
+In practice, we only care about Linux and macOS (amongst POSIX-y environments),
+where existing processes generally expect ASCII/UTF-8 encoding for env vars.
+
+#### Unquoted form
+
+> In the unquoted form, all characters in these fields shall be
+> alphabetic characters from the portable character set in the current locale.
+
+Similar to the previous subsection, this means `[A-Za-z]`.
+
+### Offset format
+
+> offset - Indicates the value added to the local time to arrive at Coordinated Universal Time.
+> The offset has the form:
+> 
+> hh[:mm[:ss]]
+> 
+> The minutes (mm) and seconds (ss) are optional. The hour (hh) shall be required and may be a single digit.
+> [..]
+> One or more digits may be used; the value is always interpreted as a decimal number.
+> The hour shall be between zero and 24, and the minutes (and seconds)—if present—between zero and 59.
+> The result of using values outside of this range is unspecified.
+> If preceded by a '-', the timezone shall be east of the Prime Meridian;
+> otherwise, it shall be west (which may be indicated by an optional preceding '+').
+
+The convention is the opposite to that of common parlance.
+E.g. Indian Standard Time (IST) is UTC+05:30, but since the description
+says "added to the local time to arrive at (UTC)", IST would be written
+as -5:30 or -05:30 here.
+
+#### Daylight Saving Time default offset
+
+> If no offset follows dst, Daylight Saving Time is assumed to be one hour ahead of standard time.
+
+This needs special care.
+
+### Rule format
+
+> Indicates when to change from standard time to Daylight Saving Time,
+> and when to change back. The rule has the form:
+> 
+> date\[/time\],date\[/time\]
+>
+> where the first date describes when the change
+> from standard time to Daylight Saving Time
+> occurs and the second date describes when it ends;
+> \[..\]
+> Each time field describes when, in current local time,
+> the change to the other time is made.
+
+#### Rule date order
+
+> if the second date is specified as earlier in the year than the first,
+> then the year begins and ends in Daylight Saving Time.
+
+#### Rule date format
+
+> The format of date is one of the following:
+>
+> - Jn: The Julian day n (1 <= n <= 365). Leap days shall not be counted.
+>   That is, in all years—including leap years—February 28 is day 59 and
+>   March 1 is day 60. It is impossible to refer explicitly to the
+>   occasional February 29.
+> - n: The zero-based Julian day (0 <= n <= 365).
+>   Leap days shall be counted, and it is possible to refer to February 29.
+> - Mm.n.d: The d'th day (0 <= d <= 6) of week n of month m of the year
+>   (1 <= n <= 5, 1 <= m <= 12, where week 5 means
+>   "the last d day in month m" which may occur in either the fourth or the fifth week).
+>   Week 1 is the first week in which the d'th day occurs. Day zero is Sunday.
+
+While the POSIX docs don't mention the calendar, the [IANA docs][iana-tzdb-theory] state:
+
+> In POSIX, time display in a process is controlled by the environment variable TZ,
+> which can have two forms:
+>
+> - A proleptic TZ value like CET-1CEST,M3.5.0,M10.5.0/3 \[..\].
+> - A geographical TZ value like Europe/Berlin \[..\]
+
+This clarifies that the TZ value should be interpreted based on the proleptic Gregorian calendar. 
+
+#### Rule time format
+
+> The time has the same format as offset except that
+> the hour can range from zero to 167.
+> If preceded by a '-', the time shall count backwards before midnight.
+> For example, "47:30" stands for 23:30 the next day,
+> and "-3:30" stands for 20:30 the previous day.
+> The default, if time is not given, shall be 02:00:00.
+
+## IANA timezone
+
+> A format specifying a geographical timezone or a special timezone.
+
+## Overview
+
+> the value of TZ is in one of the three formats (spaces inserted for clarity):
+>
+> :characters
+>
+> or:
+>
+> std offset dst offset, rule
+>
+> or:
+>
+> A format specifying a geographical timezone or a special timezone.
+
+This 
+
+## References
+
+- The Open Group, "[POSIX.1-2024, Issue 8, Chapter 8: Environment
+  Variables][posix8-ch8-env-vars]."
+  ([archived][posix8-ch8-env-vars-a], 2026-05-01)
+
+- The Open Group, "[POSIX.1-2024, Issue 8, Chapter 6: Character
+  Set][posix8-ch6-char-set]."
+  ([archived][posix8-ch6-char-set-a], 2025-11-18)
+
+- IANA, "[Theory and pragmatics of the tz code and data][iana-tzdb-theory]."
+  ([archived][iana-tzdb-theory-a], 2025-08-22)
+
+- Wikipedia, "[EBCDIC][wikipedia-ebcdic]."
+  (accessed 2026-05-16)
+
+[wikipedia-ebcdic]: <https://en.wikipedia.org/wiki/EBCDIC>
+[posix8-ch6-char-set]: <https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/basedefs/V1_chap06.html>
+[posix8-ch6-char-set-a]: <https://web.archive.org/web/20251118165826/https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/basedefs/V1_chap06.html>
+[posix8-ch8-env-vars]: <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html>
+[posix8-ch8-env-vars-a]: <https://web.archive.org/web/20260501232928/https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html>
+[iana-tzdb-theory]: <https://data.iana.org/time-zones/tzdb/theory.html>
+[iana-tzdb-theory-a]: <https://web.archive.org/web/20250822080506/https://data.iana.org/time-zones/tzdb/theory.html>

--- a/docs/external/tzdb.md
+++ b/docs/external/tzdb.md
@@ -1,0 +1,22 @@
+# Timezone database
+
+The [Theory and pragmatics of the tz code and data][iana-tzdb-theory]
+in the IANA docs provide a bunch of information
+about how the timezone database is structured.
+
+This doc captures the key information that we rely on
+in the code, for easier cross-referencing of particular points.
+
+## Choice of calendar
+
+> The tz database models time using the proleptic Gregorian calendar
+> with days containing 24 equal-length hours numbered 00 through 23,
+> except when clock transitions occur.
+
+## References
+
+- IANA, "[Theory and pragmatics of the tz code and data][iana-tzdb-theory]."
+  ([archived][iana-tzdb-theory-a], 2025-08-22)
+
+[iana-tzdb-theory]: <https://data.iana.org/time-zones/tzdb/theory.html>
+[iana-tzdb-theory-a]: <https://web.archive.org/web/20250822080506/https://data.iana.org/time-zones/tzdb/theory.html>


### PR DESCRIPTION
POSIX supports a somewhat complex specification for conveying
information related to daylight savings time. One of them is
the TZ environment variable, which can have a variety of forms.
The same string format can also appear in TZif data
(format used by the timezone database).

This patch adds support for parsing POSIX TZ strings along
with accompanying spec documentation for easier cross-referencing.

The code in this patch is not used immediately, it will be used
in future PRs, once we have the full timezone machinery wired up,
so our logging logic will only invoke our timezone-related logic,
sidestepping the risk of accidentally relying on global state
in the Go stdlib, which silently caches Location values for the
duration of the program.
