### PR TITLE
docs(errorx): Make package docs more informative

### DIFF
--- a/common/errorx/errorx.go
+++ b/common/errorx/errorx.go
@@ -4,6 +4,12 @@
 
 // Package errorx wraps cockroachdb/errors for consistent error handling.
 // All error creation in first-party code should go through this package.
+//
+// Common substitutes:
+//
+// - Stdlib errors.Is -> errorx.GetRootCauseAsValue
+// - Stdlib errors.As -> errorx.GetRootCauseAs or FindInChainAs
+// - Stdlib errors.Join -> errorx.Join
 package errorx
 
 import (


### PR DESCRIPTION
For commonly used functions in "errors", mention
the corresponding alternatives in errorx.