### PR TITLE
feat(common): Add simple Zero helper for zero values

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters:
       # common/core and common/check/prelude are designed for dot-import usage.
       - linters: [staticcheck]
         text: "ST1001"
-        source: 'common/core|common/check/prelude|common/unit'
+        source: 'common/core|common/check/prelude|common/unit|common/zero'
       - linters: [forbidigo]
         path: ^common/core/pathx/pathx.go$
         source: 'os\.(MkdirAll|MkdirTemp)'
@@ -103,7 +103,7 @@ linters:
     importas:
       no-unaliased: true
       alias:
-        - pkg: code.kibou.tools/common/(core|check/prelude|unit)
+        - pkg: code.kibou.tools/common/(core|check/prelude|unit|zero)
           alias: .
     exhaustruct:
       # NOTE: Even with allow-empty-returns: false, exhaustruct unconditionally

--- a/common/zero/zero.go
+++ b/common/zero/zero.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package zero provides the [Zero] generic zero-value helper.
+//
+// Intended to be dot-imported so callers can write [Zero][T] directly.
+package zero
+
+// Zero returns the zero value of T.
+//
+// The primary use case for this to be used in return statements
+// of the form return Zero[T](), <error> where <error> is some
+// non-heap-allocating type (e.g. a boolean, some integer type)
+// that signals an error.
+//
+// If the type of the second return value is `error`, then exhaustruct
+// correctly allows T{}, <error>. However, exhaustruct does not extend
+// this generality to other error-like return types.
+//
+// Avoid using this except in return statements.
+func Zero[T any]() (t T) { return }


### PR DESCRIPTION
When returning the zero value of a struct in an error case,
exhaustruct (correctly) doesn't flag the absence of
explicit initialization when the return type of the
enclosing function is (T, error).

However, in some cases, we want to avoid heap allocations,
so we return (T, bool) or (T, otherType) instead.

In those cases, exhaustruct incorrectly flags the use of
T{} as missing fields. Add a Zero helper to work around
that limitation.
