### PR TITLE
feat(common): Add ranges.Span for half-open ranges

### DIFF
--- a/common/core/option/bounds_checked.go
+++ b/common/core/option/bounds_checked.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package option
+
+import "code.kibou.tools/common/assert"
+
+// BoundsChecked denotes an optional value of type T,
+// which potentially indicates overflow.
+//
+// Prefer using this over Option to indicate overflow.
+type BoundsChecked[T any] struct {
+	value      T
+	overflowed bool
+}
+
+// InRange is a constructor for a BoundsChecked value,
+// representing the result of a computation which stayed
+// within the bounds of the underlying numeric type.
+//
+// This is the equivalent of option.Some.
+func InRange[T any](t T) BoundsChecked[T] {
+	return BoundsChecked[T]{value: t, overflowed: false}
+}
+
+// Overflowed is a constructor for a BoundsChecked value
+// representing the result of a computation which overflowed
+// the bounds of the underlying numeric type.
+//
+// This is the equivalent of option.None.
+func Overflowed[T any]() BoundsChecked[T] {
+	var zero T
+	return BoundsChecked[T]{value: zero, overflowed: true}
+}
+
+// Get unpacks an InRange value, similar to how Option.Get
+// unpacks a Some value.
+//
+// The first return value should not be consulted if the
+// second return value is false.
+func (b BoundsChecked[T]) Get() (_ T, inRange bool) {
+	return b.value, !b.overflowed
+}
+
+// IsOverflowed checks if the computation overflowed.
+func (b BoundsChecked[T]) IsOverflowed() bool {
+	return b.overflowed
+}
+
+// Unwrap gets the underlying InRange value.
+//
+// Pre-condition: The value must not have Overflowed.
+func (b BoundsChecked[T]) Unwrap() T {
+	if b.overflowed {
+		assert.Precondition(false, "called Unwrap on Overflowed value")
+	}
+	return b.value
+}

--- a/common/core/option/option.go
+++ b/common/core/option/option.go
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
-// Package option provides a generic optional value type.
+// Package option provides some generic optional value types
+// which are commonly needed by a variety of applications.
 package option
 
 import (

--- a/common/ranges/ranges.go
+++ b/common/ranges/ranges.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package ranges
+
+import (
+	"cmp"
+
+	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/core/option"
+)
+
+type Numeric interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// Span represents a half-open interval [start, end).
+//
+// The Span may be empty if start == end.
+type Span[T Numeric] struct {
+	start T
+	end   T
+}
+
+// NewSpan constructs a new Span from a start and end value.
+//
+// Pre-condition: end >= start.
+func NewSpan[T Numeric](start, end T) Span[T] {
+	if end < start {
+		assert.Preconditionf(false, "end %v before start %v", end, start)
+	}
+	return Span[T]{start: start, end: end}
+}
+
+func (s Span[T]) Start() T      { return s.start }
+func (s Span[T]) End() T        { return s.end }
+func (s Span[T]) IsEmpty() bool { return s.start == s.end }
+
+// Length attempts to compute the length of this span using the
+// span's numeric type.
+//
+// Post-condition: If the return value is [option.InRange], it will be
+// non-negative.
+func (s Span[T]) Length() option.BoundsChecked[T] {
+	length := s.end - s.start
+	// By construction, s.start <= s.end. Suppose we have N bits.
+	//
+	// For unsigned integer types, s.end - s.start ∈ [0, 2^N - 1];
+	// there's no possibility of overflow.
+	//
+	// For signed integer types, s.end - s.start ∈ [0, 2^N - 1].
+	// If s.end - s.start ∈ [0, 2^(N-1) - 1], then length >= 0.
+	// Else s.end - s.start ∈ [2^(N-1), 2^N - 1].
+	//   - Wrapping on overflow is equivalent to subtracting
+	//     2^N. So length ∈ [-2^(N-1), -1].
+	//
+	// Hence, length < 0 is sufficient to detect overflow.
+	if length < 0 {
+		return option.Overflowed[T]()
+	}
+	return option.InRange(length)
+}
+
+// CompareStrict defines a total lexicographic order across ranges.
+func (s Span[T]) CompareStrict(other Span[T]) int {
+	if c := cmp.Compare(s.start, other.start); c != 0 {
+		return c
+	}
+	return cmp.Compare(s.end, other.end)
+}
+
+// Overlaps computes the relationship between the receiver and the argument span.
+func (s Span[T]) Overlaps(other Span[T]) Relation {
+	switch {
+	case s.start == other.start && s.end == other.end:
+		return Relation_Equal
+	case s.end <= other.start:
+		return Relation_BeforeStart
+	case s.start >= other.end:
+		return Relation_AfterEnd
+	case s.start <= other.start && s.end >= other.end:
+		return Relation_Covers
+	case s.start >= other.start && s.end <= other.end:
+		return Relation_IsCoveredBy
+	case s.start < other.start:
+		return Relation_OverlapsStart
+	default:
+		return Relation_OverlapsEnd
+	}
+}
+
+// Relation describes the relationship between two ranges.
+type Relation uint8
+
+const (
+	Relation_BeforeStart Relation = iota + 1
+	Relation_OverlapsStart
+	Relation_IsCoveredBy
+	Relation_Equal
+	Relation_Covers
+	Relation_OverlapsEnd
+	Relation_AfterEnd
+)
+
+func (r Relation) Inverse() Relation {
+	switch r {
+	case Relation_BeforeStart:
+		return Relation_AfterEnd
+	case Relation_AfterEnd:
+		return Relation_BeforeStart
+	case Relation_Covers:
+		return Relation_IsCoveredBy
+	case Relation_IsCoveredBy:
+		return Relation_Covers
+	case Relation_OverlapsStart:
+		return Relation_OverlapsEnd
+	case Relation_OverlapsEnd:
+		return Relation_OverlapsStart
+	case Relation_Equal:
+		return Relation_Equal
+	default:
+		return assert.PanicUnknownCase[Relation](r)
+	}
+}
+
+func (r Relation) String() string {
+	switch r {
+	case Relation_BeforeStart:
+		return "before-start"
+	case Relation_OverlapsStart:
+		return "overlaps-start"
+	case Relation_IsCoveredBy:
+		return "is-covered-by"
+	case Relation_Equal:
+		return "equal"
+	case Relation_Covers:
+		return "covers"
+	case Relation_OverlapsEnd:
+		return "overlaps-end"
+	case Relation_AfterEnd:
+		return "after-end"
+	default:
+		return assert.PanicUnknownCase[string](r)
+	}
+}

--- a/common/ranges/ranges_test.go
+++ b/common/ranges/ranges_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package ranges_test
+
+import (
+	"math"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/check"
+	"code.kibou.tools/common/ranges"
+)
+
+func TestSpan(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("NewSpan", testNewSpan)
+	h.Run("Length", testLength)
+	h.Run("CompareStrict", testCompareStrict)
+	h.Run("Overlaps", func(h check.Harness) {
+		h.Run("unit", testOverlapsUnit)
+		h.Run("property", testOverlapsProperty)
+	})
+}
+
+func testNewSpan(h check.Harness) {
+	h.Parallel()
+	h.AssertPanicsWith(
+		assert.AssertionError{Fmt: "precondition violation: end %v before start %v", Args: []any{0, 5}},
+		func() { _ = ranges.NewSpan(5, 0) },
+	)
+}
+
+func testLength(h check.Harness) {
+	h.Parallel()
+
+	s := ranges.NewSpan(3, 10)
+	check.AssertSame(h, 7, s.Length().Unwrap(), "in-range Length")
+
+	empty := ranges.NewSpan(5, 5)
+	check.AssertSame(h, 0, empty.Length().Unwrap(), "empty Length")
+	check.AssertSame(h, true, empty.IsEmpty(), "IsEmpty")
+
+	overflowed := ranges.NewSpan[int8](-128, 127)
+	check.AssertSame(h, true, overflowed.Length().IsOverflowed(), "int8 overflow detected")
+
+	for start := math.MinInt8; start <= math.MaxInt8; start++ {
+		for end := start; end <= math.MaxInt8; end++ {
+			length, ok := ranges.NewSpan(int8(start), int8(end)).Length().Get()
+			if !ok { // overflowed
+				continue
+			}
+			h.Assertf(length >= 0,
+				"NewSpan(%d, %d).Length() = %d, want non-negative or Overflowed",
+				start, end, length)
+		}
+	}
+}
+
+func testCompareStrict(h check.Harness) {
+	h.Parallel()
+
+	span := func(start, end int) ranges.Span[int] { return ranges.NewSpan(start, end) }
+
+	type TestCase struct {
+		Name string
+		LHS  ranges.Span[int]
+		RHS  ranges.Span[int]
+		Want int
+	}
+	cases := []TestCase{
+		{"equal", span(3, 7), span(3, 7), 0},
+		{"smaller start", span(2, 7), span(3, 7), -1},
+		{"larger start", span(4, 7), span(3, 7), 1},
+		{"equal start, smaller end", span(3, 5), span(3, 7), -1},
+		{"equal start, larger end", span(3, 9), span(3, 7), 1},
+	}
+	for _, tc := range cases {
+		check.AssertSame(h, tc.Want, tc.LHS.CompareStrict(tc.RHS), tc.Name)
+	}
+
+	spans := []ranges.Span[int]{span(5, 10), span(3, 7), span(3, 9), span(3, 3), span(0, 0)}
+	want := []ranges.Span[int]{span(0, 0), span(3, 3), span(3, 7), span(3, 9), span(5, 10)}
+	slices.SortFunc(spans, func(a, b ranges.Span[int]) int { return a.CompareStrict(b) })
+	check.AssertSame(h, want, spans, "sorted spans", cmp.AllowUnexported(ranges.Span[int]{}))
+}
+
+func testOverlapsUnit(h check.Harness) {
+	h.Parallel()
+
+	span := func(start, end int) ranges.Span[int] { return ranges.NewSpan(start, end) }
+
+	type TestCase struct {
+		Name string
+		LHS  ranges.Span[int]
+		RHS  ranges.Span[int]
+		Want ranges.Relation
+	}
+	cases := []TestCase{
+		{"Equal", span(5, 15), span(5, 15), ranges.Relation_Equal},
+		{"BeforeStart", span(0, 5), span(10, 15), ranges.Relation_BeforeStart},
+		{"AfterEnd", span(20, 25), span(10, 15), ranges.Relation_AfterEnd},
+		{"Covers", span(0, 20), span(5, 15), ranges.Relation_Covers},
+		{"IsCoveredBy", span(7, 11), span(5, 15), ranges.Relation_IsCoveredBy},
+		{"OverlapsStart", span(0, 8), span(5, 15), ranges.Relation_OverlapsStart},
+		{"OverlapsEnd", span(10, 20), span(5, 15), ranges.Relation_OverlapsEnd},
+	}
+	for _, tc := range cases {
+		check.AssertSame(h, tc.Want, tc.LHS.Overlaps(tc.RHS), tc.Name)
+	}
+}
+
+func testOverlapsProperty(h check.Harness) {
+	h.Parallel()
+
+	h.Run("int8", func(h check.Harness) {
+		genSpan := rapid.Custom(func(t *rapid.T) ranges.Span[int8] {
+			start := rapid.Int8().Draw(t, "start")
+			end := rapid.Int8Range(start, math.MaxInt8).Draw(t, "end")
+			return ranges.NewSpan(start, end)
+		})
+		runOverlapsProperties(h, genSpan)
+	})
+
+	h.Run("uint8", func(h check.Harness) {
+		genSpan := rapid.Custom(func(t *rapid.T) ranges.Span[uint8] {
+			start := rapid.Uint8().Draw(t, "start")
+			end := rapid.Uint8Range(start, math.MaxUint8).Draw(t, "end")
+			return ranges.NewSpan(start, end)
+		})
+		runOverlapsProperties(h, genSpan)
+	})
+}
+
+func runOverlapsProperties[T ranges.Numeric](h check.Harness, genSpan *rapid.Generator[ranges.Span[T]]) {
+	h.Run("reflexivity", func(h check.Harness) {
+		rapid.Check(h.T(), func(t *rapid.T) {
+			s := genSpan.Draw(t, "s")
+			if got := s.Overlaps(s); got != ranges.Relation_Equal {
+				t.Fatalf("R(s, s) = %v, want Equal (s = %+v)", got, s)
+			}
+		})
+	})
+
+	h.Run("duality", func(h check.Harness) {
+		rapid.Check(h.T(), func(t *rapid.T) {
+			a := genSpan.Draw(t, "a")
+			b := genSpan.Draw(t, "b")
+			rAB := a.Overlaps(b)
+			rBA := b.Overlaps(a)
+			if want := rAB.Inverse(); rBA != want {
+				t.Fatalf("R(a, b) = %v but R(b, a) = %v; want %v", rAB, rBA, want)
+			}
+		})
+	})
+
+	h.Run("transitivity", func(h check.Harness) {
+		rapid.Check(h.T(), func(t *rapid.T) {
+			s1 := genSpan.Draw(t, "s1")
+			s2 := genSpan.Draw(t, "s2")
+			s3 := genSpan.Draw(t, "s3")
+			r12 := s1.Overlaps(s2)
+			r23 := s2.Overlaps(s3)
+			want, ok := transitiveRelation(r12, r23)
+			if !ok {
+				return
+			}
+			if got := s1.Overlaps(s3); got != want {
+				t.Fatalf("R(s1,s2)=%v R(s2,s3)=%v R(s1,s3)=%v, want %v", r12, r23, got, want)
+			}
+		})
+	})
+}
+
+// transitiveRelation attempts to determine based on r12 and r23,
+// if there's a unique possible value for r13.
+func transitiveRelation(r12, r23 ranges.Relation) (ranges.Relation, bool) {
+	switch r12 {
+	case ranges.Relation_Equal:
+		return r23, true
+	case ranges.Relation_BeforeStart,
+		ranges.Relation_AfterEnd,
+		ranges.Relation_Covers,
+		ranges.Relation_IsCoveredBy:
+		if r23 == r12 || r23 == ranges.Relation_Equal {
+			return r12, true
+		}
+		return 0, false
+	case ranges.Relation_OverlapsStart, ranges.Relation_OverlapsEnd:
+		if r23 == ranges.Relation_Equal {
+			return r12, true
+		}
+		return 0, false
+	default:
+		return assert.PanicUnknownCase[ranges.Relation](r12), false
+	}
+}


### PR DESCRIPTION
These are generally useful for all the basic numeric types.
However, for simplicity, we restrict the types to integer
types only for now.
