### PR TITLE
feat(common): Add collections.BitVec type

### DIFF
--- a/common/collections/bit_vec.go
+++ b/common/collections/bit_vec.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package collections
+
+import (
+	"math/bits"
+
+	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/core/option"
+)
+
+// BitVec is a compact fixed-length vector of bits.
+//
+// The implementation is currently focused on simplicity,
+// with just a simple backing uint64 array.
+type BitVec struct {
+	// Bit i is stored in blocks[i >> 6] at bit position i & 63.
+	//
+	//   Indexes:  63 ...  2  1  0 | 127 ... 66 65 64 | ...
+	//   blocks:  [      blocks[0] ] [      blocks[1] ] ...
+	//
+	// Within each uint64, lower BitVec indexes use less-significant bits.
+	blocks []uint64
+	len    int
+}
+
+// NewBitVec returns a BitVec with n bits, all initially unset.
+//
+// Pre-condition: n must be non-negative.
+func NewBitVec(n int) BitVec {
+	if n < 0 {
+		assert.Preconditionf(false, "BitVec length must be >= 0, but got: %d", n)
+	}
+	return BitVec{blocks: make([]uint64, blocksForBits(n)), len: n}
+}
+
+// Len returns the number of bits in b.
+func (b *BitVec) Len() int { return b.len }
+
+// Get returns whether bit i is set.
+//
+// Pre-condition: i ∈ [0, b.Len()).
+func (b *BitVec) Get(i int) bool {
+	b.checkIndex(i)
+	return b.blocks[blockIndex(i)]&bitMask(i) != 0
+}
+
+// Set sets bit i.
+//
+// Pre-condition: i ∈ [0, b.Len()).
+func (b *BitVec) Set(i int) {
+	b.checkIndex(i)
+	b.blocks[blockIndex(i)] |= bitMask(i)
+}
+
+// Clear clears bit i.
+//
+// Pre-condition: i ∈ [0, b.Len()).
+func (b *BitVec) Clear(i int) {
+	b.checkIndex(i)
+	b.blocks[blockIndex(i)] &^= bitMask(i)
+}
+
+// FindAtOrBefore returns the greatest set bit j such that j <= i, if any.
+//
+// Pre-condition: i ∈ [0, b.Len()).
+//
+// Post-condition: If the return value is Some(j), then j ∈ [0, b.Len()).
+func (b *BitVec) FindAtOrBefore(i int) option.Option[int] {
+	b.checkIndex(i)
+	startBlock := blockIndex(i)
+	for oi := startBlock; 0 <= oi; oi-- {
+		blockBits := b.blocks[oi]
+		if oi == startBlock { // TODO: Does unrolling once help?
+			blockBits &= lowBitsMask(uint8(i&63) + 1)
+		}
+		if blockBits != 0 {
+			idx := oi*64 + 63 - bits.LeadingZeros64(blockBits)
+			return option.Some(idx)
+		}
+	}
+	return option.None[int]()
+}
+
+// FindAtOrAfter returns the least set bit j such that i <= j, if any.
+//
+// Pre-condition: i ∈ [0, b.Len()).
+//
+// Post-condition: If the return value is Some(j), then j ∈ [0, b.Len()).
+func (b *BitVec) FindAtOrAfter(i int) option.Option[int] {
+	b.checkIndex(i)
+	startBlock := blockIndex(i)
+	for oi := startBlock; oi < len(b.blocks); oi++ {
+		blockBits := b.blocks[oi]
+		if oi == startBlock { // TODO: Does unrolling once help?
+			blockBits &^= lowBitsMask(uint8(i & 63))
+		}
+		if blockBits != 0 {
+			idx := oi*64 + bits.TrailingZeros64(blockBits)
+			if b.len <= idx {
+				assert.Invariantf(false, "unused bit %d is set in BitVec of length %d", idx, b.len)
+			}
+			return option.Some(idx)
+		}
+	}
+	return option.None[int]()
+}
+
+// checkIndex asserts that i ∈ [0, b.Len()).
+func (b *BitVec) checkIndex(i int) {
+	if i < 0 || b.len <= i {
+		assert.Preconditionf(false, "bit index %d out of range [0, %d)", i, b.len)
+	}
+}
+
+// blocksForBits returns the number of blocks needed for
+// storing n bits.
+func blocksForBits(n int) int {
+	blocks := n >> 6
+	if n&63 != 0 {
+		blocks++
+	}
+	return blocks
+}
+
+// blockIndex returns the index in the block slice that
+// needs to be accessed for getting the data for bit i.
+//
+// Pre-condition: i >= 0
+func blockIndex(i int) int {
+	return i >> 6
+}
+
+// bitMask returns a mask for getting the bit corresponding
+// to the bit i from the block in a BitVec.
+//
+// Pre-condition: i >= 0
+func bitMask(i int) uint64 {
+	return uint64(1) << uint(i&63)
+}
+
+// lowBitsMask returns a word whose lowest n bits are set and whose remaining
+// bits are unset. For example, lowBitsMask(3) == 0b111.
+//
+// Pre-condition: n ∈ [0, 64].
+func lowBitsMask(n uint8) uint64 {
+	// If n == 64, the shift will lead to 0, so -1 will still
+	// give the correct behavior.
+	return (uint64(1) << n) - 1
+}

--- a/common/collections/bit_vec_test.go
+++ b/common/collections/bit_vec_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package collections_test
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/common/check"
+	"code.kibou.tools/common/collections"
+	"code.kibou.tools/common/core/option"
+)
+
+func TestBitVec(t *testing.T) {
+	h := check.New(t)
+	h.Run("unit", func(h check.Harness) {
+		b := collections.NewBitVec(130)
+		model := NewBitVecModel(130)
+		assertBitVecState(h, &b, &model, "new")
+
+		for _, i := range []int{0, 1, 63, 64, 65, 129} {
+			applyBitVecOp(&b, &model, bitVecOp_Set, i)
+		}
+		for _, i := range []int{0, 64, 129} {
+			applyBitVecOp(&b, &model, bitVecOp_Clear, i)
+		}
+		assertBitVecState(h, &b, &model, "after ops")
+	})
+	h.Run("property", func(h check.Harness) {
+		rapid.Check(h.T(), func(t *rapid.T) {
+			h := check.NewBasic(t)
+			n := rapid.IntRange(0, 300).Draw(t, "len")
+			bitVec := collections.NewBitVec(n)
+			model := NewBitVecModel(n)
+			assertBitVecState(h, &bitVec, &model, "rapid new")
+
+			if n == 0 {
+				return
+			}
+			ops := rapid.SliceOfN(rapid.Int(), 0, 300).Draw(t, "ops")
+			for _, value := range ops {
+				i := int(uint(value) % uint(n))
+				op := bitVecOp(uint(value>>1) % 2)
+				applyBitVecOp(&bitVec, &model, op, i)
+			}
+			assertBitVecState(h, &bitVec, &model, "rapid after ops")
+
+			queries := rapid.SliceOfN(rapid.IntRange(0, n-1), 0, 300).Draw(t, "find queries")
+			for _, i := range queries {
+				assertBitVecFinds(h, &bitVec, &model, i, "rapid query")
+			}
+		})
+	})
+}
+
+type bitVecOp uint8
+
+const (
+	bitVecOp_Set bitVecOp = iota
+	bitVecOp_Clear
+)
+
+type BitVecModel struct {
+	bits []bool
+}
+
+func NewBitVecModel(n int) BitVecModel {
+	return BitVecModel{bits: make([]bool, n)}
+}
+
+func (m *BitVecModel) Len() int { return len(m.bits) }
+
+func (m *BitVecModel) Get(i int) bool { return m.bits[i] }
+
+func (m *BitVecModel) Set(i int) { m.bits[i] = true }
+
+func (m *BitVecModel) Clear(i int) { m.bits[i] = false }
+
+func (m *BitVecModel) FindAtOrBefore(i int) option.Option[int] {
+	for i := i; 0 <= i; i-- {
+		if m.bits[i] {
+			return option.Some(i)
+		}
+	}
+	return option.None[int]()
+}
+
+func (m *BitVecModel) FindAtOrAfter(i int) option.Option[int] {
+	for i := i; i < len(m.bits); i++ {
+		if m.bits[i] {
+			return option.Some(i)
+		}
+	}
+	return option.None[int]()
+}
+
+func assertBitVecState(h check.BasicHarness, bitVec *collections.BitVec, model *BitVecModel, what string) {
+	check.AssertSame(h, model.Len(), bitVec.Len(), what+" len")
+	for i := 0; i < model.Len(); i++ {
+		check.AssertSame(h, model.Get(i), bitVec.Get(i), what+" bit")
+	}
+	for i := 0; i < model.Len(); i++ {
+		assertBitVecFinds(h, bitVec, model, i, what)
+	}
+}
+
+func assertBitVecFinds(h check.BasicHarness, bitVec *collections.BitVec, model *BitVecModel, i int, what string) {
+	want := model.FindAtOrBefore(i)
+	got := bitVec.FindAtOrBefore(i)
+	check.AssertSame(h, 0, option.Compare(want, got), what+" find at or before")
+
+	want = model.FindAtOrAfter(i)
+	got = bitVec.FindAtOrAfter(i)
+	check.AssertSame(h, 0, option.Compare(want, got), what+" find at or after")
+}
+
+func applyBitVecOp(bitVec *collections.BitVec, model *BitVecModel, op bitVecOp, i int) {
+	switch op {
+	case bitVecOp_Set:
+		bitVec.Set(i)
+		model.Set(i)
+	case bitVecOp_Clear:
+		bitVec.Clear(i)
+		model.Clear(i)
+	}
+}


### PR DESCRIPTION
This seems generally useful for cheaper "marking",
data structures compared to hand-rolling something
on top of []bool, which wastes memory unnecessarily.
