### PR TITLE
feat(common): Add wrapper package for Unicode segmentation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,6 +100,14 @@ linters:
           deny:
             - pkg: "code.kibou.tools/common/core$"
               desc: "common/core is an aggregate convenience package for other modules; code under common/ should import smaller common/core/* packages directly"
+        NoDirectRivoUniseg:
+          files:
+            - $all
+            - "!**/common/internal/uniseg/*.go"
+          list-mode: lax
+          deny:
+            - pkg: "github.com/rivo/uniseg$"
+              desc: "use common/internal/uniseg instead of importing rivo/uniseg directly"
     importas:
       no-unaliased: true
       alias:

--- a/common/go.mod
+++ b/common/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cockroachdb/errors v1.12.0
 	github.com/google/go-cmp v0.7.0
 	github.com/muesli/termenv v0.16.0
+	github.com/rivo/uniseg v0.4.7
 	golang.org/x/term v0.40.0
 	pgregory.net/rapid v1.2.0
 )
@@ -169,7 +170,6 @@ require (
 	github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
 	github.com/raeperd/recvcheck v0.2.0 // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/ryancurrah/gomodguard v1.4.1 // indirect
 	github.com/ryanrolds/sqlclosecheck v0.5.1 // indirect

--- a/common/internal/uniseg/uniseg.go
+++ b/common/internal/uniseg/uniseg.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package uniseg
+
+import (
+	"iter"
+	"unicode/utf8"
+
+	"code.kibou.tools/common/assert"
+	rivouniseg "github.com/rivo/uniseg"
+
+	"code.kibou.tools/common/collections"
+	"code.kibou.tools/common/core/option"
+	"code.kibou.tools/common/ranges"
+)
+
+// SegmentedText stores text together with its grapheme cluster boundaries.
+type SegmentedText struct {
+	text string
+	// boundaries[i] is true iff i == len(text) or if
+	// text[i] is the start byte of a grapheme cluster.
+	//
+	// boundaries.Len() == len(text) + 1
+	boundaries collections.BitVec
+}
+
+// Pre-condition: text is valid UTF-8.
+func NewSegmentedText(text string) SegmentedText {
+	boundaries := collections.NewBitVec(len(text) + 1)
+	boundaries.Set(0)
+	for cluster := range GraphemeClusters(text) {
+		boundaries.Set(cluster.Span().End())
+	}
+	return SegmentedText{text: text, boundaries: boundaries}
+}
+
+// CheckSpan checks that the bounds of the span line up with
+// UTF-8 codepoint boundaries and grapheme cluster boundaries.
+//
+// Pre-condition: span ⊆ [0, len(t.text)).
+func (t *SegmentedText) CheckSpan(span ranges.Span[int]) *SpanBoundaryError {
+	start := span.Start()
+	end := span.End()
+	if start != len(t.text) && !utf8.RuneStart(t.text[start]) {
+		return &SpanBoundaryError{SpanBoundaryErrorKind_NotUTF8Boundary, ranges.Bound_Start, span, option.None[ranges.Span[int]]()}
+	}
+	if end != len(t.text) && !utf8.RuneStart(t.text[end]) {
+		return &SpanBoundaryError{SpanBoundaryErrorKind_NotUTF8Boundary, ranges.Bound_End, span, option.None[ranges.Span[int]]()}
+	}
+	if !t.boundaries.Get(start) {
+		return &SpanBoundaryError{SpanBoundaryErrorKind_NotGraphemeBoundary, ranges.Bound_Start, span, t.findContainingGraphemeCluster(start)}
+	}
+	if !t.boundaries.Get(end) {
+		return &SpanBoundaryError{SpanBoundaryErrorKind_NotGraphemeBoundary, ranges.Bound_End, span, t.findContainingGraphemeCluster(end)}
+	}
+	return nil
+}
+
+func (t *SegmentedText) findContainingGraphemeCluster(offset int) option.Option[ranges.Span[int]] {
+	if offset < 0 || t.boundaries.Len() <= offset || t.boundaries.Get(offset) {
+		return option.None[ranges.Span[int]]()
+	}
+	start, ok := t.boundaries.FindAtOrBefore(offset).Get()
+	if !ok {
+		return option.None[ranges.Span[int]]()
+	}
+	end, ok := t.boundaries.FindAtOrAfter(offset).Get()
+	if !ok {
+		return option.None[ranges.Span[int]]()
+	}
+	return option.Some(ranges.NewSpan(start, end))
+}
+
+// GraphemeCluster is one user-perceived character within a string.
+type GraphemeCluster struct {
+	graphemes *rivouniseg.Graphemes
+}
+
+// GraphemeClusters iterates over the grapheme clusters in s.
+func GraphemeClusters(s string) iter.Seq[GraphemeCluster] {
+	return func(yield func(GraphemeCluster) bool) {
+		graphemes := rivouniseg.NewGraphemes(s)
+		cluster := GraphemeCluster{graphemes}
+		for graphemes.Next() {
+			if !yield(cluster) {
+				return
+			}
+		}
+	}
+}
+
+// Str returns the substring for this grapheme cluster.
+func (c GraphemeCluster) Str() string { return c.graphemes.Str() }
+
+// Span returns the byte span for this grapheme cluster in the original string.
+func (c GraphemeCluster) Span() ranges.Span[int] {
+	start, end := c.graphemes.Positions()
+	return ranges.NewSpan(start, end)
+}
+
+// ComputeWidth returns the monospace display width of s.
+func ComputeWidth(s string) int { return rivouniseg.StringWidth(s) }
+
+type SpanBoundaryError struct {
+	kind                      SpanBoundaryErrorKind
+	bound                     ranges.Bound
+	span                      ranges.Span[int]
+	containingGraphemeCluster option.Option[ranges.Span[int]]
+}
+
+type SpanBoundaryErrorKind uint8
+
+const (
+	SpanBoundaryErrorKind_NotUTF8Boundary SpanBoundaryErrorKind = iota + 1
+	SpanBoundaryErrorKind_NotGraphemeBoundary
+)
+
+// Kind returns which boundary a particular span failed to line up with.
+func (e *SpanBoundaryError) Kind() SpanBoundaryErrorKind { return e.kind }
+
+// Bound represents the end/edge of the span which did not correctly
+// line up with the codepoint/grapheme cluster boundary.
+func (e *SpanBoundaryError) Bound() ranges.Bound { return e.bound }
+
+// Span returns the input span passed to CheckSpan.
+func (e *SpanBoundaryError) Span() ranges.Span[int] { return e.span }
+
+// ByteOffset returns the offending offset which did not correctly
+// line up with a codepoint/grapheme cluster boundary.
+func (e *SpanBoundaryError) ByteOffset() int {
+	switch e.bound {
+	case ranges.Bound_Start:
+		return e.span.Start()
+	case ranges.Bound_End:
+		return e.span.End()
+	default:
+		return assert.PanicUnknownCase[int](e.bound)
+	}
+}
+
+// ContainingGraphemeCluster returns the span corresponding to
+// the grapheme cluster which contains the ByteOffset.
+func (e *SpanBoundaryError) ContainingGraphemeCluster() option.Option[ranges.Span[int]] {
+	return e.containingGraphemeCluster
+}

--- a/common/internal/uniseg/uniseg_test.go
+++ b/common/internal/uniseg/uniseg_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package uniseg_test
+
+import (
+	"strings"
+	"testing"
+
+	"code.kibou.tools/common/internal/uniseg"
+)
+
+func BenchmarkNewSegmentedText(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		unit string
+	}{
+		{name: "ASCII", unit: "a"},
+		{name: "Accented", unit: "é"},
+		{name: "SimpleEmoji", unit: "🙂"},
+		{name: "ComplexEmoji", unit: "👩‍💻"},
+	} {
+		for _, count := range []int{10, 100, 1000} {
+			text := strings.Repeat(tc.unit, count)
+			b.Run(tc.name+"/count="+itoa(count), func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(text)))
+				for b.Loop() {
+					_ = uniseg.NewSegmentedText(text)
+				}
+			})
+		}
+	}
+}
+
+func itoa(n int) string {
+	switch n {
+	case 10:
+		return "10"
+	case 100:
+		return "100"
+	case 1000:
+		return "1000"
+	default:
+		return "unknown"
+	}
+}

--- a/common/ranges/bound.go
+++ b/common/ranges/bound.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package ranges
+
+import "code.kibou.tools/common/assert"
+
+// Bound identifies one of the two bounds of a half-open span.
+type Bound bool
+
+const (
+	Bound_Start Bound = false
+	Bound_End   Bound = true
+)
+
+func (b Bound) String() string {
+	switch b {
+	case Bound_Start:
+		return "start"
+	case Bound_End:
+		return "end"
+	default:
+		return assert.PanicUnknownCase[string](b)
+	}
+}


### PR DESCRIPTION
Diagnostic formatting needs to detect well-formedness of
offsets by checking if offsets line up with grapheme
cluster boundaries. So we need some form of Unicode-aware
segmentation. Using rivo/uniseg since that was already an
indirect dependency earlier.

Use a wrapper package so that we can potentially replace
the implementation without directly relying on those types
in our code.

This logic will be tested in the downstream diagnostic
formatting machinery, so skipping having tests here.

I did some rough benchmarks -- on an M4, the cost of
segmentation is about 20-50ns per byte, which seems quite
high, so the total can be a few µs for hundreds of emojis.

Perhaps worth optimizing later on.