### PR TITLE
ci: Run linting using stable toolchain

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -121,19 +121,18 @@ jobs:
     # don't want them occupied by lint-only jobs.
     if: inputs.os == 'ubuntu-latest'
     runs-on: ${{ inputs.os }}
-    needs: build-head
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-head-toolchain
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          os: ${{ inputs.os }}
+          go-version: 1.25.x
+          # setup-go cache warns when GOCACHE is customized; we manage caching explicitly.
+          cache: false
       - name: Lint
         shell: bash
         run: |
-          export GOROOT="$PWD/go"
-          export PATH="$GOROOT/bin:$PATH"
           export CGO_ENABLED=0
           patterns=$(go run ./misc/cmd/kido list --type=go-module --provenance=first-party | sed 's|.*|./&/...|')
           # Version is pinned via the tool dependency in common/go.mod;


### PR DESCRIPTION
When there are changes to the AST, it causes tooling
to break, including the linters. These fixes are not
rolled out immediately. For example, recently, there
have been some changes related to generic methods for
the upcoming Go 1.27, but tooling APIs have separate
tracking issues with no clear ETA. (See Related: tags
below.)

(Not saying it's someone's fault, just trying to state
the facts).

This means that trying to compile golangci-lint with
the HEAD toolchain can break.

We don't want to prevent merging changes from golang/go
HEAD because delaying the automerge means that more
changes need to be merged at once, instead of a small
amount of changes every day.

So we relax the CI to run linting with stable instead.
If we want to introduce a separate check, we could
introduce a non-blocking one in the future.
