### PR TITLE
feat(errorx): Introduce Formatter and FormattedError interfaces

### DIFF
--- a/common/errorx/formatter.go
+++ b/common/errorx/formatter.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package errorx
+
+// Precondition for all methods: key should be a constant string,
+// not a dynamically generated string.
+type Formatter interface {
+	// Requirement: If the Formatter only supports a limited set of ValueKinds,
+	// FormatValue should assert that the kind is one of the supported ValueKinds
+	// instead of silently picking some default (redaction/hashing/exposure).
+	FormatDynamic(kind ValueKind, key string, value string)
+	// Requirement: FormatBool must not panic.
+	FormatBool(key string, value bool)
+	// Requirement: FormatUint64 must not panic.
+	FormatUint64(key string, value uint64)
+	// Requirement: FormatUintptr must not panic.
+	FormatUintptr(key string, value uintptr)
+	// Requirement: FormatInt64 must not panic.
+	FormatInt64(key string, value int64)
+	// Requirement: FormatFloat64 must not panic.
+	FormatFloat64(key string, value float64)
+	// Precondition: value must be a constant string, not a dynamically generated
+	// string.
+	//
+	// Requirement: FormatConstMsg must not panic.
+	FormatConstMsg(value string)
+	// Precondition: value must be a constant string, not a dynamically generated
+	// string.
+	//
+	// Requirement: FormatConstString must not panic.
+	FormatConstString(key string, value string)
+	// Precondition: forEach must be non-nil.
+	FormatGroup(key string, forEach func(Formatter))
+	// Requirement: If Err() returns a non-nil value, subsequent calls to
+	// Err() must return the same logical value.
+	Err() *FormatterError
+}
+
+// ValueKind represents an enum which covers the different kinds
+// of values which may be formatted. This is to allow preserving
+// coarse-grained type information for letting a formatter
+// decide on redaction on a per kind basis.
+//
+// Applications may introduce custom ValueKind constants with
+// values from -1, -2, ...
+//
+// Libraries should generally not introduce their own constants,
+// because these may collide with the constants introduced by
+// other libraries. The existing constants should suffice for
+// the most common cases.
+type ValueKind int32
+
+const (
+	ValueKind_Bool ValueKind = iota + 1
+	ValueKind_Uint64
+	ValueKind_Uintptr
+	ValueKind_Int64
+	ValueKind_Float64
+	ValueKind_ConstString
+	ValueKind_Path
+
+	// Insert new values here!
+
+	ValueKind_StdMax           = ValueKind_Path
+	ValueKind_StdMin ValueKind = 1
+)
+
+type FormatterError struct {
+	kind  FormatterErrorKind
+	inner error
+}
+
+func NewFormatterError(kind FormatterErrorKind, inner error) *FormatterError {
+	return &FormatterError{kind, inner}
+}
+
+func (e *FormatterError) Kind() FormatterErrorKind {
+	return e.kind
+}
+
+func (e *FormatterError) Unwrap() error {
+	return e.inner
+}
+
+type FormatterErrorKind uint8
+
+const (
+	FormatterErrorKind_BufferFull FormatterErrorKind = iota + 1
+	FormatterErrorKind_IOFailed
+)

--- a/common/errorx/stable_formatter.go
+++ b/common/errorx/stable_formatter.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package errorx
+
+import (
+	"strconv"
+	"unsafe"
+
+	"code.kibou.tools/common/assert"
+)
+
+// StableFormatter implements Formatter using a deterministic, single-line,
+// human-readable format.
+//
+// StableFormatter does not redact values. It is intended for tests and other
+// callers that want a stable rendering contract instead of snapshotting a
+// human-facing pretty formatter.
+//
+// StableFormatter always renders formatted fields in parentheses, even when
+// there is no surrounding message text.
+//
+// StableFormatter values must be constructed with [NewStableFormatter] and must
+// not be copied.
+type StableFormatter struct {
+	self       *StableFormatter
+	buf        []byte
+	state      fmtState
+	fieldCount int
+}
+
+type fmtState uint8
+
+const (
+	// fmtState_Empty means the formatter has not emitted anything yet.
+	fmtState_Empty fmtState = iota + 1
+	// fmtState_Text means the formatter has emitted text that should precede any
+	// following field list.
+	fmtState_Text
+	// fmtState_ParenFields means the formatter is emitting a parenthesized field
+	// list.
+	fmtState_ParenFields
+)
+
+var _ Formatter = (*StableFormatter)(nil)
+
+// NewStableFormatter returns an empty StableFormatter.
+func NewStableFormatter() *StableFormatter {
+	f := &StableFormatter{self: nil, buf: nil, state: fmtState_Empty, fieldCount: 0}
+	f.self = f
+	return f
+}
+
+// Finish returns the formatted output and consumes the formatter's current
+// buffer. Formatting after Finish starts a fresh buffer.
+func (f *StableFormatter) Finish() string {
+	f.copyCheck()
+	switch f.state {
+	case fmtState_Empty, fmtState_Text:
+		// Nothing to close.
+	case fmtState_ParenFields:
+		f.buf = append(f.buf, ')')
+	default:
+		return assert.PanicUnknownCase[string](f.state)
+	}
+	f.state = fmtState_Empty
+	f.fieldCount = 0
+	var out string
+	if len(f.buf) > 0 {
+		out = unsafe.String(&f.buf[0], len(f.buf))
+	}
+	f.buf = nil
+	return out
+}
+
+func (f *StableFormatter) FormatDynamic(vk ValueKind, key string, value string) {
+	f.copyCheck()
+	if vk < ValueKind_StdMin || ValueKind_StdMax < vk {
+		assert.Preconditionf(false, "value kind %d is out of range [%d, %d]",
+			vk, ValueKind_StdMin, ValueKind_StdMax)
+	}
+	f.appendField(func(buf []byte) []byte {
+		buf = appendKeyPrefix(buf, key)
+		return strconv.AppendQuote(buf, value)
+	})
+}
+
+func (f *StableFormatter) FormatBool(key string, value bool) {
+	f.copyCheck()
+	f.appendField(func(buf []byte) []byte {
+		buf = appendKeyPrefix(buf, key)
+		return strconv.AppendBool(buf, value)
+	})
+}
+
+func (f *StableFormatter) FormatUint64(key string, value uint64) {
+	f.copyCheck()
+	f.appendField(func(buf []byte) []byte {
+		buf = appendKeyPrefix(buf, key)
+		return strconv.AppendUint(buf, value, 10)
+	})
+}
+
+func (f *StableFormatter) FormatUintptr(key string, value uintptr) {
+	f.copyCheck()
+	f.appendField(func(buf []byte) []byte {
+		buf = appendKeyPrefix(buf, key)
+		return strconv.AppendUint(buf, uint64(value), 10)
+	})
+}
+
+func (f *StableFormatter) FormatInt64(key string, value int64) {
+	f.copyCheck()
+	f.appendField(func(buf []byte) []byte {
+		buf = appendKeyPrefix(buf, key)
+		return strconv.AppendInt(buf, value, 10)
+	})
+}
+
+func (f *StableFormatter) FormatFloat64(key string, value float64) {
+	f.copyCheck()
+	f.appendField(func(buf []byte) []byte {
+		buf = appendKeyPrefix(buf, key)
+		// 'g': switch between compact and general format
+		// depending on the value.
+		// -1: minimize number of digits used.
+		return strconv.AppendFloat(buf, value, 'g', -1, 64)
+	})
+}
+
+func (f *StableFormatter) FormatConstMsg(value string) {
+	f.copyCheck()
+	f.closeFieldList()
+	if value != "" {
+		f.buf = append(f.buf, value...)
+		f.state = fmtState_Text
+	}
+}
+
+func (f *StableFormatter) FormatConstString(key string, value string) {
+	f.copyCheck()
+	f.appendField(func(buf []byte) []byte {
+		buf = appendKeyPrefix(buf, key)
+		return strconv.AppendQuote(buf, value)
+	})
+}
+
+func (f *StableFormatter) FormatGroup(key string, forEach func(Formatter)) {
+	f.copyCheck()
+	f.appendField(func(buf []byte) []byte {
+		buf = appendKeyPrefix(buf, key)
+		return append(buf, '{')
+	})
+
+	parentState := f.state
+	parentFieldCount := f.fieldCount
+	f.state = fmtState_Empty
+	f.fieldCount = 0
+	forEach(f)
+	f.closeFieldList()
+	f.buf = append(f.buf, '}')
+	f.state = parentState
+	f.fieldCount = parentFieldCount
+}
+
+func (f *StableFormatter) Err() *FormatterError {
+	f.copyCheck()
+	return nil
+}
+
+func (f *StableFormatter) copyCheck() {
+	if f.self != f {
+		if f.self == nil {
+			assert.Invariantf(false, "StableFormatter was not constructed with NewStableFormatter")
+		}
+		assert.Invariantf(false, "StableFormatter was copied")
+	}
+}
+
+func (f *StableFormatter) appendField(write func([]byte) []byte) {
+	switch f.state {
+	case fmtState_Empty, fmtState_Text:
+		f.openFieldList()
+	case fmtState_ParenFields:
+		// Continue the current field list.
+	default:
+		assert.PanicUnknownCase[any](f.state)
+	}
+	if f.fieldCount > 0 {
+		f.buf = append(f.buf, ", "...)
+	}
+	f.buf = write(f.buf)
+	f.fieldCount++
+}
+
+func (f *StableFormatter) openFieldList() {
+	f.fieldCount = 0
+	switch f.state {
+	case fmtState_Empty:
+		f.buf = append(f.buf, '(')
+	case fmtState_Text:
+		f.buf = append(f.buf, " ("...)
+	case fmtState_ParenFields:
+		assert.PanicInvariantViolation[any]("field list is already open")
+	default:
+		assert.PanicUnknownCase[any](f.state)
+	}
+	f.state = fmtState_ParenFields
+}
+
+func (f *StableFormatter) closeFieldList() {
+	switch f.state {
+	case fmtState_Empty, fmtState_Text:
+		// Nothing to close.
+	case fmtState_ParenFields:
+		f.buf = append(f.buf, ')')
+		f.state = fmtState_Text
+	default:
+		assert.PanicUnknownCase[any](f.state)
+	}
+	f.fieldCount = 0
+}
+
+func appendKeyPrefix(buf []byte, key string) []byte {
+	if key == "" {
+		return buf
+	}
+	buf = append(buf, key...)
+	return append(buf, '=')
+}

--- a/common/errorx/stable_formatter_test.go
+++ b/common/errorx/stable_formatter_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package errorx
+
+import (
+	"math"
+	"testing"
+
+	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/check"
+)
+
+func TestStableFormatter(t *testing.T) {
+	h := check.New(t)
+
+	h.Run("message with field", func(h check.Harness) {
+		h.Parallel()
+
+		f := NewStableFormatter()
+		f.FormatConstMsg("not an absolute path")
+		f.FormatDynamic(ValueKind_Path, "input", "foo\nbar")
+
+		check.AssertSame(h, `not an absolute path (input="foo\nbar")`, f.Finish(), "stable formatter output")
+	})
+
+	h.Run("string fields", func(h check.Harness) {
+		h.Parallel()
+
+		f := NewStableFormatter()
+		f.FormatConstString("message", "hello\tworld")
+		f.FormatDynamic(ValueKind_Path, "custom", `custom "value"`)
+
+		want := `(message="hello\tworld", custom="custom \"value\"")`
+		check.AssertSame(h, want, f.Finish(), "stable formatter output")
+	})
+
+	h.Run("scalar fields", func(h check.Harness) {
+		h.Parallel()
+
+		f := NewStableFormatter()
+		f.FormatBool("ok", true)
+		f.FormatUint64("count", 42)
+		f.FormatUintptr("addr", uintptr(4096))
+		f.FormatInt64("offset", -7)
+		f.FormatFloat64("ratio", 1.5)
+		f.FormatFloat64("nan", math.NaN())
+
+		want := "(ok=true, count=42, addr=4096, offset=-7, ratio=1.5, nan=NaN)"
+		check.AssertSame(h, want, f.Finish(), "stable formatter output")
+	})
+
+	h.Run("groups", func(h check.Harness) {
+		h.Parallel()
+
+		f := NewStableFormatter()
+		f.FormatGroup("outer", func(g Formatter) {
+			g.FormatConstString("inner", "value")
+			g.FormatGroup("empty", func(Formatter) {})
+		})
+
+		check.AssertSame(h, `(outer={(inner="value", empty={})})`, f.Finish(), "stable formatter output")
+	})
+
+	h.Run("empty keys", func(h check.Harness) {
+		h.Parallel()
+
+		f := NewStableFormatter()
+		f.FormatDynamic(ValueKind_Path, "", "leading")
+		f.FormatConstMsg("msg")
+		f.FormatBool("", true)
+		f.FormatConstString("", "const")
+		f.FormatGroup("", func(g Formatter) {
+			g.FormatConstMsg("inner")
+			g.FormatUint64("", 3)
+		})
+
+		want := `("leading")msg (true, "const", {inner (3)})`
+		check.AssertSame(h, want, f.Finish(), "stable formatter output")
+	})
+
+	h.Run("rejects unsupported value kind", func(h check.Harness) {
+		h.Parallel()
+
+		f := NewStableFormatter()
+		want := assert.AssertionError{
+			Fmt: "precondition violation: value kind %d is out of range [%d, %d]",
+			Args: []any{
+				ValueKind(-1),
+				ValueKind_StdMin,
+				ValueKind_StdMax,
+			},
+		}
+		h.AssertPanicsWith(want, func() {
+			f.FormatDynamic(ValueKind(-1), "custom", "custom value")
+		})
+	})
+}


### PR DESCRIPTION
One of the friction points with the standard Error() string
interface is that it's trivial to accidentally leak
sensitive data or PII into logs when using it.

Having a push-based formatting API with a coarse Kind
that is extensible by applications allows for redaction
of textual values with coarse-grained granularity,
with optional full redaction/hashing for unknown kinds.
