### PR TITLE
refactor(check): Avoid dependency check->pathx

### DIFF
--- a/common/check/check.go
+++ b/common/check/check.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"code.kibou.tools/common/assert"
-	"code.kibou.tools/common/core/pathx"
 )
 
 func init() {
@@ -139,11 +138,7 @@ func (h Harness) Close(c io.Closer) {
 // AssertSame compares want and got using cmp.Diff and fails with a diff if they differ.
 // Additional cmp options may be provided to customize comparison.
 func AssertSame[T any](h BasicHarness, want, got T, what string, opts ...cmp.Option) {
-	defaultOpts := cmp.Options{
-		cmp.AllowUnexported(pathx.AbsPath{}, pathx.RelPath{}, pathx.RootRelPath{}),
-	}
-	allOpts := append(defaultOpts, opts...)
-	if diff := cmp.Diff(want, got, allOpts...); diff != "" {
+	if diff := cmp.Diff(want, got, opts...); diff != "" {
 		h.Assertf(false, "%s mismatch (-want +got):\n%s", what, diff)
 	}
 }

--- a/common/core/pathx/pathx.go
+++ b/common/core/pathx/pathx.go
@@ -40,6 +40,10 @@ func (p AbsPath) String() string {
 	return p.value
 }
 
+func (p AbsPath) Compare(other AbsPath) int {
+	return strings.Compare(p.value, other.value)
+}
+
 // Dir returns the parent directory of p, or None if p is a filesystem root.
 func (p AbsPath) Dir() option.Option[AbsPath] {
 	rootLen := p.rootLen()
@@ -181,6 +185,10 @@ func NewRelPath(path string) RelPath {
 // String is guaranteed to be "." if a relative path for the current directory.
 func (p RelPath) String() string {
 	return p.value
+}
+
+func (p RelPath) Compare(other RelPath) int {
+	return strings.Compare(p.value, other.value)
 }
 
 // Dir returns the parent directory of p, or None if p is ".".
@@ -342,6 +350,13 @@ func NewRootRelPath(root AbsPath, subpath RelPath) RootRelPath {
 
 func (p RootRelPath) String() string {
 	return p.value.value
+}
+
+func (p RootRelPath) Compare(other RootRelPath) int {
+	if c := p.root.Compare(other.root); c != 0 {
+		return c
+	}
+	return p.value.Compare(other.value)
 }
 
 func (p RootRelPath) AsAbsPath() AbsPath {

--- a/common/core/pathx/pathx_testkit/pathx_testkit.go
+++ b/common/core/pathx/pathx_testkit/pathx_testkit.go
@@ -9,10 +9,20 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	"pgregory.net/rapid"
 
 	"code.kibou.tools/common/core/pathx"
 )
+
+// CompareOptions returns cmp options for comparing pathx values without accessing unexported fields.
+func CompareOptions() []cmp.Option {
+	return []cmp.Option{
+		cmp.Comparer(func(a, b pathx.AbsPath) bool { return a.Compare(b) == 0 }),
+		cmp.Comparer(func(a, b pathx.RelPath) bool { return a.Compare(b) == 0 }),
+		cmp.Comparer(func(a, b pathx.RootRelPath) bool { return a.Compare(b) == 0 }),
+	}
+}
 
 // ComponentGen generates a short, safe-looking path component.
 // It emits no separators or dot-only names, and on Unix it will not produce

--- a/common/envx/envx_path/find_executable_test.go
+++ b/common/envx/envx_path/find_executable_test.go
@@ -17,6 +17,7 @@ import (
 	"code.kibou.tools/common/check"
 	. "code.kibou.tools/common/check/prelude"
 	"code.kibou.tools/common/core/pathx"
+	"code.kibou.tools/common/core/pathx/pathx_testkit"
 	"code.kibou.tools/common/envx"
 	"code.kibou.tools/common/envx/envx_path"
 	"code.kibou.tools/common/errorx"
@@ -56,7 +57,7 @@ func testFindExecutableHappyPath(h check.Harness) {
 			env := testEnv(envVars)
 
 			got := Do(envx_path.FindExecutable(fs, env, exe.LookupName))(h)
-			check.AssertSame(h, fs.Root().Join(exeRel), got, "FindExecutable")
+			check.AssertSame(h, fs.Root().Join(exeRel), got, "FindExecutable", pathx_testkit.CompareOptions()...)
 		})
 
 		h.Run("Missing candidates are skipped", func(h check.Harness) {
@@ -74,7 +75,7 @@ func testFindExecutableHappyPath(h check.Harness) {
 			env := testEnv(envVars)
 
 			got := Do(envx_path.FindExecutable(fs, env, exe.LookupName))(h)
-			check.AssertSame(h, fs.Root().Join(exeRel), got, "FindExecutable after missing candidate")
+			check.AssertSame(h, fs.Root().Join(exeRel), got, "FindExecutable after missing candidate", pathx_testkit.CompareOptions()...)
 		})
 	})
 
@@ -102,7 +103,7 @@ func testFindExecutableHappyPath(h check.Harness) {
 
 			env := testEnv(map[string]string{"PATH": binDir.String()})
 			gotPath := Do(envx_path.FindExecutable(fs, env, "tool"))(h)
-			check.AssertSame(h, exePath, gotPath, "FindExecutable path")
+			check.AssertSame(h, exePath, gotPath, "FindExecutable path", pathx_testkit.CompareOptions()...)
 		})
 
 		h.Run("Explicit extension matches exec.LookPath", func(h check.Harness) {
@@ -117,7 +118,7 @@ func testFindExecutableHappyPath(h check.Harness) {
 
 			env := testEnv(map[string]string{"PATH": binDir.String()})
 			gotPath := Do(envx_path.FindExecutable(fs, env, "tool.txt"))(h)
-			check.AssertSame(h, txtPath, gotPath, "FindExecutable path")
+			check.AssertSame(h, txtPath, gotPath, "FindExecutable path", pathx_testkit.CompareOptions()...)
 		})
 	})
 }
@@ -166,7 +167,7 @@ func testFindExecutableErrorCases(h check.Harness) {
 		h.Assertf(ok, "expected *ExeSearchError, got %T", err)
 		check.AssertSame(h, 1, len(searchErr.IgnoredPaths()), "IgnoredPaths count")
 		ignored := searchErr.IgnoredPaths()[0]
-		check.AssertSame(h, fs.Root().Join(exeRel), ignored.Path, "IgnoredPath.Path")
+		check.AssertSame(h, fs.Root().Join(exeRel), ignored.Path, "IgnoredPath.Path", pathx_testkit.CompareOptions()...)
 		h.Assertf(errorx.GetRootCauseAsValue(ignored.Err, envx_path.NotExecutableErr),
 			"expected not-executable error, got %v", ignored.Err)
 
@@ -216,7 +217,7 @@ func testFindExecutableErrorCases(h check.Harness) {
 			gotPath, gotErr := envx_path.FindExecutable(fs, env, exe.LookupName)
 			h.Assertf(errorx.GetRootCauseAsValue(gotErr, envx_path.ErrDot),
 				"expected FindExecutable error %v to wrap ErrDot", gotErr)
-			check.AssertSame(h, root.Join(exeRel), gotPath, "FindExecutable path")
+			check.AssertSame(h, root.Join(exeRel), gotPath, "FindExecutable path", pathx_testkit.CompareOptions()...)
 		})
 
 		h.Run("Stat errors are skipped", func(h check.Harness) {
@@ -244,7 +245,7 @@ func testFindExecutableErrorCases(h check.Harness) {
 			h.Assertf(ok, "expected *ExeSearchError, got %T", err)
 			check.AssertSame(h, 1, len(searchErr.IgnoredPaths()), "IgnoredPaths count")
 			ignored := searchErr.IgnoredPaths()[0]
-			check.AssertSame(h, binDir.JoinComponents(exe.Name), ignored.Path, "IgnoredPath.Path")
+			check.AssertSame(h, binDir.JoinComponents(exe.Name), ignored.Path, "IgnoredPath.Path", pathx_testkit.CompareOptions()...)
 			h.Assertf(errorx.GetRootCauseAsValue(ignored.Err, os.ErrPermission),
 				"expected permission error, got %v", ignored.Err)
 

--- a/common/fsx/fsx_walk/walk_test.go
+++ b/common/fsx/fsx_walk/walk_test.go
@@ -18,6 +18,7 @@ import (
 	. "code.kibou.tools/common/check/prelude"
 	"code.kibou.tools/common/core/option"
 	"code.kibou.tools/common/core/pathx"
+	"code.kibou.tools/common/core/pathx/pathx_testkit"
 	"code.kibou.tools/common/core/result"
 	"code.kibou.tools/common/fsx/fsx_testkit"
 	"code.kibou.tools/common/fsx/fsx_walk"
@@ -140,7 +141,7 @@ ignored/
 
 		_, err := fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true})
 		walkErr := requireWalkError(h, err, fsx_walk.WalkErrorKind_FSRootNotRepo)
-		check.AssertSame(h, fs.Root(), walkErr.Path(), "WalkError.Path()")
+		check.AssertSame(h, fs.Root(), walkErr.Path(), "WalkError.Path()", pathx_testkit.CompareOptions()...)
 		h.Assertf(strings.Contains(walkErr.Error(), "not a git repository root"),
 			"WalkError.Error() = %q, want repository-root message", walkErr.Error())
 		h.NoErrorf(walkErr.Unwrap(), "WalkError.Unwrap()")
@@ -165,7 +166,7 @@ func testFaults(h check.Harness) {
 
 		_, err := fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: false})
 		walkErr := requireWalkError(h, err, fsx_walk.WalkErrorKind_IOFailed)
-		check.AssertSame(h, fs.Root(), walkErr.Path(), "WalkError.Path()")
+		check.AssertSame(h, fs.Root(), walkErr.Path(), "WalkError.Path()", pathx_testkit.CompareOptions()...)
 		h.Assertf(walkErr.Unwrap() != nil, "WalkError.Unwrap() = nil, want underlying error")
 		h.Assertf(strings.Contains(walkErr.Error(), fs.Root().String()),
 			"got: WalkError.Error() = %q\nwant: root path %v to appear in it", walkErr.Error(), fs.Root())
@@ -255,7 +256,7 @@ blocked/
 			},
 			walkErr.GitIgnorePattern(),
 			"GitIgnorePattern()",
-			cmp.AllowUnexported(source_code.Position{}),
+			append(pathx_testkit.CompareOptions(), cmp.AllowUnexported(source_code.Position{}))...,
 		)
 		h.Assertf(strings.Contains(walkErr.Error(), "blocked/"),
 			"WalkError.Error() = %q, want ignored pattern", walkErr.Error())
@@ -363,7 +364,7 @@ func testGitIgnore_PreservesAllParseErrors(h check.Harness) {
 		},
 		parseSnippets.Snippets(),
 		"parse error snippets",
-		cmp.AllowUnexported(source_code.Position{}),
+		append(pathx_testkit.CompareOptions(), cmp.AllowUnexported(source_code.Position{}))...,
 	)
 }
 

--- a/common/fsx/stat_test.go
+++ b/common/fsx/stat_test.go
@@ -82,14 +82,16 @@ func TestFSStat(t *testing.T) {
 			_, err := repoFS.Stat(rel, opts)
 			statErr := requireStatError(h, err, rel, opts)
 			check.AssertSame(h, rel, statErr.ShortestMissing(),
-				"ShortestMissing() with OnErrorTraverseParents=false")
+				"ShortestMissing() with OnErrorTraverseParents=false",
+				pathx_testkit.CompareOptions()...)
 
 			opts.OnErrorTraverseParents = true
 			_, err = repoFS.Stat(rel, opts)
 			statErr = requireStatError(h, err, rel, opts)
 			wantShortestMissing := joinedRelPath(components[:existingPrefixLen+1])
 			check.AssertSame(h, wantShortestMissing, statErr.ShortestMissing(),
-				"ShortestMissing() with OnErrorTraverseParents=true")
+				"ShortestMissing() with OnErrorTraverseParents=true",
+				pathx_testkit.CompareOptions()...)
 		})
 	})
 }


### PR DESCRIPTION
Instead, we expose comparison options directly in a
separate package pathx_testkit, that can be used
by callers as necessary.

check is meant to be a fairly low-level package,
so it doesn't make sense to hard-code knowledge
of individual domain-specific packages in here.
