### PR TITLE
refactor(pathx): Rename New(Abs|Rel)Path->MustParse(Abs|Rel)Path

### DIFF
--- a/common/check/golden/golden.go
+++ b/common/check/golden/golden.go
@@ -70,7 +70,7 @@ func NewSnapshotDirSet(subdirs ...string) *SnapshotDirSet {
 		logger:  logx.NewLogger(os.Stderr, logx.ColorSupport_AutoDetect),
 	}
 	for _, subdir := range subdirs {
-		rootRel := pathx.NewRelPath(subdir)
+		rootRel := pathx.MustParseRelPath(subdir)
 		dir := &snapshotDir{
 			pkgRelPath: rootRel,
 			mu:         sync.Mutex{},
@@ -115,7 +115,7 @@ func (dirSet *SnapshotDirSet) Run(m *testing.M) int {
 //  2. set.Run has initialized the snapshot directory set.
 func (dirSet *SnapshotDirSet) FS(h check.Harness, root string) SnapshotFS {
 	h.T().Helper()
-	rootRel := pathx.NewRelPath(root)
+	rootRel := pathx.MustParseRelPath(root)
 	dir, ok := dirSet.subdirs.Lookup(rootRel).Get()
 	h.Assertf(ok, "unknown snapshot directory %q", root)
 

--- a/common/core/pathx.go
+++ b/common/core/pathx.go
@@ -13,16 +13,16 @@ type AbsPath = pathx.AbsPath
 
 type RelPath = pathx.RelPath
 
-type RootRelPath = pathx.RootRelPath
-
-func NewAbsPath(path string) AbsPath {
-	return pathx.NewAbsPath(path)
+// MustParseAbsPath creates an AbsPath from an already-absolute path string.
+//
+// Pre-condition: path is non-empty and absolute per [filepath.IsAbs].
+func MustParseAbsPath(path string) AbsPath {
+	return pathx.MustParseAbsPath(path)
 }
 
-func NewRelPath(path string) RelPath {
-	return pathx.NewRelPath(path)
-}
-
-func NewRootRelPath(root AbsPath, subpath RelPath) RootRelPath {
-	return pathx.NewRootRelPath(root, subpath)
+// MustParseRelPath creates a RelPath from a relative path string.
+//
+// Pre-condition: path is non-empty and not absolute per [filepath.IsAbs].
+func MustParseRelPath(path string) RelPath {
+	return pathx.MustParseRelPath(path)
 }

--- a/common/core/pathx/pathx.go
+++ b/common/core/pathx/pathx.go
@@ -27,10 +27,10 @@ type AbsPath struct {
 	value string
 }
 
-// NewAbsPath creates an AbsPath from an already-absolute path string.
+// MustParseAbsPath creates an AbsPath from an already-absolute path string.
 //
 // Pre-condition: path is non-empty and absolute per [filepath.IsAbs].
-func NewAbsPath(path string) AbsPath {
+func MustParseAbsPath(path string) AbsPath {
 	assert.Preconditionf(path != "", "path is empty")
 	assert.Preconditionf(filepath.IsAbs(path), "path is not absolute: %q", path)
 	return AbsPath{LexicallyNormalize(path)}
@@ -73,7 +73,7 @@ func (p AbsPath) rootLen() int {
 
 func (p AbsPath) Split() (AbsPath, fsx_name.Name) {
 	dir, file := filepath.Split(p.value)
-	return NewAbsPath(dir), fsx_name.New(file)
+	return MustParseAbsPath(dir), fsx_name.New(file)
 }
 
 // Ancestors returns an iterator over p's ancestor absolute paths,
@@ -114,7 +114,7 @@ func (p AbsPath) lexicallyContainsSlow(child RelPath) bool {
 }
 
 func (p AbsPath) Join(rel RelPath) AbsPath {
-	return NewAbsPath(filepath.Join(p.value, rel.value))
+	return MustParseAbsPath(filepath.Join(p.value, rel.value))
 }
 
 // AppendExtension returns p with ext appended.
@@ -130,7 +130,7 @@ func (p AbsPath) AppendExtension(ext string) AbsPath {
 		assert.Preconditionf(!HasPathSeparators(lastCharStr),
 			"path %q ends with a path separator; so it's not a valid file path", p.value)
 	}
-	return NewAbsPath(p.value + ext)
+	return MustParseAbsPath(p.value + ext)
 }
 
 // JoinComponents joins individual path components onto p.
@@ -143,7 +143,7 @@ func (p AbsPath) JoinComponents(pathElems ...string) AbsPath {
 		assert.Preconditionf(!HasPathSeparators(elem), "path element contains separator: %q", elem)
 		parts = append(parts, elem)
 	}
-	return NewAbsPath(filepath.Join(parts...))
+	return MustParseAbsPath(filepath.Join(parts...))
 }
 
 // MakeRelativeTo is the equivalent of filepath.Rel with typed paths.
@@ -158,7 +158,7 @@ func (p AbsPath) MakeRelativeTo(root AbsPath) option.Option[RootRelPath] {
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return option.None[RootRelPath]()
 	}
-	return option.Some(NewRootRelPath(root, NewRelPath(rel)))
+	return option.Some(NewRootRelPath(root, MustParseRelPath(rel)))
 }
 
 // RelPath carries a relative path that has gone through [LexicallyNormalize].
@@ -173,10 +173,10 @@ func Dot() RelPath {
 	return RelPath{"."}
 }
 
-// NewRelPath creates a RelPath from a relative path string.
+// MustParseRelPath creates a RelPath from a relative path string.
 //
 // Pre-condition: path is non-empty and not absolute per [filepath.IsAbs].
-func NewRelPath(path string) RelPath {
+func MustParseRelPath(path string) RelPath {
 	assert.Preconditionf(path != "", "path is empty")
 	assert.Preconditionf(!filepath.IsAbs(path), "path is not relative: %q", path)
 	return RelPath{LexicallyNormalize(path)}
@@ -197,11 +197,11 @@ func (p RelPath) Dir() option.Option[RelPath] {
 	if parent == p.value || parent == "." {
 		return option.None[RelPath]()
 	}
-	return option.Some(NewRelPath(parent))
+	return option.Some(MustParseRelPath(parent))
 }
 
 func (p RelPath) Join(rel RelPath) RelPath {
-	return NewRelPath(filepath.Join(p.value, rel.value))
+	return MustParseRelPath(filepath.Join(p.value, rel.value))
 }
 
 // RelativeTo returns p expressed as a relative path from base.
@@ -223,7 +223,7 @@ func (p RelPath) RelativeTo(base RelPath) RelPath {
 
 func (p RelPath) JoinOne(name fsx_name.Name) RelPath {
 	// TODO: Use an unchecked code path here, because we know the invariant can't be violated.
-	return NewRelPath(filepath.Join(p.value, name.String()))
+	return MustParseRelPath(filepath.Join(p.value, name.String()))
 }
 
 // JoinComponents joins individual path components onto p.
@@ -236,7 +236,7 @@ func (p RelPath) JoinComponents(pathElems ...string) RelPath {
 		assert.Preconditionf(!HasPathSeparators(elem), "path element contains separator: %q", elem)
 		parts = append(parts, elem)
 	}
-	return NewRelPath(filepath.Join(parts...))
+	return MustParseRelPath(filepath.Join(parts...))
 }
 
 // Ancestors returns an iterator over p's ancestor relative paths,

--- a/common/core/pathx/pathx_test.go
+++ b/common/core/pathx/pathx_test.go
@@ -36,8 +36,8 @@ func TestMakeRelativeTo(t *testing.T) {
 			rootSegs := segmentsGen.Draw(t, "root_segments")
 			pathSegs := segmentsGen.Draw(t, "path_segments")
 
-			root := pathx.NewAbsPath(filepath.Join(append([]string{base}, rootSegs...)...))
-			path := pathx.NewAbsPath(filepath.Join(append([]string{base}, pathSegs...)...))
+			root := pathx.MustParseAbsPath(filepath.Join(append([]string{base}, rootSegs...)...))
+			path := pathx.MustParseAbsPath(filepath.Join(append([]string{base}, pathSegs...)...))
 			_ = path.MakeRelativeTo(root)
 		})
 	})
@@ -45,7 +45,7 @@ func TestMakeRelativeTo(t *testing.T) {
 	h.Run("InsideRoot", func(h check.Harness) {
 		h.Parallel()
 
-		root := pathx.NewAbsPath(h.T().TempDir())
+		root := pathx.MustParseAbsPath(h.T().TempDir())
 		inside := root.JoinComponents("a", "b")
 		rel := inside.MakeRelativeTo(root)
 		h.Assertf(rel.IsSome(), "inside path should be relative to root")
@@ -55,15 +55,15 @@ func TestMakeRelativeTo(t *testing.T) {
 	h.Run("OutsideRoot", func(h check.Harness) {
 		h.Parallel()
 
-		root := pathx.NewAbsPath(h.T().TempDir())
-		outside := root.Join(pathx.NewRelPath(filepath.Join("..", "outside")))
+		root := pathx.MustParseAbsPath(h.T().TempDir())
+		outside := root.Join(pathx.MustParseRelPath(filepath.Join("..", "outside")))
 		h.Assertf(!outside.MakeRelativeTo(root).IsSome(), "outside path should not be relative to root")
 	})
 
 	h.Run("ContainedPathRoundTrip", func(h check.Harness) {
 		h.Parallel()
 
-		root := pathx.NewAbsPath(h.T().TempDir())
+		root := pathx.MustParseAbsPath(h.T().TempDir())
 		safeRelGen := pathx_testkit.SafeRelPathGen()
 		rapid.Check(h.T(), func(t *rapid.T) {
 			basic := check.NewBasic(t)
@@ -84,7 +84,7 @@ func TestMakeRelativeTo(t *testing.T) {
 	h.Run("RejectsEscapingPaths", func(h check.Harness) {
 		h.Parallel()
 
-		root := pathx.NewAbsPath(h.T().TempDir())
+		root := pathx.MustParseAbsPath(h.T().TempDir())
 		escapingRelGen := pathx_testkit.EscapingRelPathGen()
 		rapid.Check(h.T(), func(t *rapid.T) {
 			basic := check.NewBasic(t)
@@ -105,7 +105,7 @@ func TestSplit(t *testing.T) {
 	h.Run("RoundTrip", func(h check.Harness) {
 		h.Parallel()
 
-		root := pathx.NewAbsPath(h.T().TempDir())
+		root := pathx.MustParseAbsPath(h.T().TempDir())
 		componentsGen := rapid.SliceOfN(pathx_testkit.ComponentGen(), 1, 6)
 		rapid.Check(h.T(), func(t *rapid.T) {
 			basic := check.NewBasic(t)
@@ -114,7 +114,7 @@ func TestSplit(t *testing.T) {
 			dir, file := path.Split()
 			check.AssertSame(basic, components[len(components)-1], file.String(), "Split() file")
 
-			reconstructed := dir.Join(pathx.NewRelPath(file.String()))
+			reconstructed := dir.Join(pathx.MustParseRelPath(file.String()))
 			check.AssertSame(basic, path.String(), reconstructed.String(), "Split() round-trip")
 		})
 	})
@@ -123,7 +123,7 @@ func TestSplit(t *testing.T) {
 func TestAbsPathAncestors(t *testing.T) {
 	h := check.New(t)
 
-	path := pathx.NewAbsPath(h.T().TempDir()).JoinComponents("a", "b", "c")
+	path := pathx.MustParseAbsPath(h.T().TempDir()).JoinComponents("a", "b", "c")
 	got := iterx.Collect(iterx.Map(path.Ancestors(), pathx.AbsPath.String))
 	var reverse []string
 	for parent, ok := path.Dir().Get(); ok; parent, ok = parent.Dir().Get() {
@@ -152,7 +152,7 @@ func TestRelPathComponents(t *testing.T) {
 
 	for _, tt := range tests {
 		h.Run(tt.path, func(h check.Harness) {
-			got := iterx.Collect(pathx.NewRelPath(tt.path).Components())
+			got := iterx.Collect(pathx.MustParseRelPath(tt.path).Components())
 			check.AssertSame(h, tt.want, got, fmt.Sprintf("Components(%q)", tt.path))
 		})
 	}
@@ -174,7 +174,7 @@ func TestRelPathAncestors(t *testing.T) {
 
 	for _, tt := range tests {
 		h.Run(tt.path, func(h check.Harness) {
-			got := iterx.Collect(iterx.Map(pathx.NewRelPath(tt.path).Ancestors(), pathx.RelPath.String))
+			got := iterx.Collect(iterx.Map(pathx.MustParseRelPath(tt.path).Ancestors(), pathx.RelPath.String))
 			check.AssertSame(h, tt.want, got, fmt.Sprintf("Ancestors(%q)", tt.path))
 		})
 	}
@@ -199,7 +199,7 @@ func TestRelPathRelativeTo(t *testing.T) {
 
 	for _, tt := range tests {
 		h.Run(fmt.Sprintf("%s_from_%s", tt.path, tt.base), func(h check.Harness) {
-			got := pathx.NewRelPath(tt.path).RelativeTo(pathx.NewRelPath(tt.base))
+			got := pathx.MustParseRelPath(tt.path).RelativeTo(pathx.MustParseRelPath(tt.base))
 			check.AssertSame(h, tt.want, got.String(),
 				fmt.Sprintf("RelativeTo(%q, %q)", tt.path, tt.base))
 		})
@@ -211,7 +211,7 @@ func TestRelPathRelativeTo(t *testing.T) {
 			Args: []any{"b", "a"},
 		}
 		h.AssertPanicsWith(want, func() {
-			_ = pathx.NewRelPath("a").RelativeTo(pathx.NewRelPath("b"))
+			_ = pathx.MustParseRelPath("a").RelativeTo(pathx.MustParseRelPath("b"))
 		})
 	})
 
@@ -222,14 +222,14 @@ func TestRelPathRelativeTo(t *testing.T) {
 			Args: []any{"a", "ab"},
 		}
 		h.AssertPanicsWith(want, func() {
-			_ = pathx.NewRelPath("ab").RelativeTo(pathx.NewRelPath("a"))
+			_ = pathx.MustParseRelPath("ab").RelativeTo(pathx.MustParseRelPath("a"))
 		})
 	})
 }
 
 func TestLexicallyContains(t *testing.T) {
 	h := check.New(t)
-	root := pathx.NewAbsPath(t.TempDir())
+	root := pathx.MustParseAbsPath(t.TempDir())
 
 	tests := []struct {
 		path string
@@ -244,7 +244,7 @@ func TestLexicallyContains(t *testing.T) {
 
 	for _, tt := range tests {
 		h.Run(tt.path, func(h check.Harness) {
-			got := root.LexicallyContains(pathx.NewRelPath(tt.path))
+			got := root.LexicallyContains(pathx.MustParseRelPath(tt.path))
 			h.Assertf(got == tt.want, "LexicallyContains(%q) = %v, want %v", tt.path, got, tt.want)
 		})
 	}
@@ -270,7 +270,7 @@ func TestAbsPathDir(t *testing.T) {
 		}
 		for _, tt := range tests {
 			h.Run(tt.path, func(h check.Harness) {
-				dir, ok := pathx.NewAbsPath(tt.path).Dir().Get()
+				dir, ok := pathx.MustParseAbsPath(tt.path).Dir().Get()
 				got := option.NewOption(dir.String(), ok)
 				h.Assertf(option.Compare(tt.want, got) == 0,
 					"Dir(%q) = %v, want %v", tt.path, got, tt.want)
@@ -294,7 +294,7 @@ func TestAbsPathDir(t *testing.T) {
 		}
 		for _, tt := range tests {
 			h.Run(tt.path, func(h check.Harness) {
-				dir, ok := pathx.NewAbsPath(tt.path).Dir().Get()
+				dir, ok := pathx.MustParseAbsPath(tt.path).Dir().Get()
 				got := option.NewOption(dir.String(), ok)
 				h.Assertf(option.Compare(tt.want, got) == 0,
 					"Dir(%q) = %v, want %v", tt.path, got, tt.want)
@@ -319,7 +319,7 @@ func TestRelPathDir(t *testing.T) {
 
 	for _, tt := range tests {
 		h.Run(tt.path, func(h check.Harness) {
-			dir, ok := pathx.NewRelPath(tt.path).Dir().Get()
+			dir, ok := pathx.MustParseRelPath(tt.path).Dir().Get()
 			got := option.NewOption(dir.String(), ok)
 			h.Assertf(option.Compare(tt.want, got) == 0,
 				"Dir(%q) = %v, want %v", tt.path, got, tt.want)
@@ -329,8 +329,8 @@ func TestRelPathDir(t *testing.T) {
 
 func TestJoinMatchesJoinComponents(t *testing.T) {
 	h := check.New(t)
-	root := pathx.NewAbsPath(t.TempDir())
-	rel := pathx.NewRelPath(filepath.Join("a", "b", "c"))
+	root := pathx.MustParseAbsPath(t.TempDir())
+	rel := pathx.MustParseRelPath(filepath.Join("a", "b", "c"))
 
 	got := root.Join(rel)
 	want := root.JoinComponents("a", "b", "c")
@@ -343,7 +343,7 @@ func TestAppendExtension(t *testing.T) {
 	h.Run("AppendsExtension", func(h check.Harness) {
 		h.Parallel()
 
-		root := pathx.NewAbsPath(h.T().TempDir())
+		root := pathx.MustParseAbsPath(h.T().TempDir())
 		path := root.JoinComponents("tool")
 		got := path.AppendExtension(".exe")
 		check.AssertSame(h, root.JoinComponents("tool.exe").String(), got.String(), "AppendExtension")
@@ -361,7 +361,7 @@ func TestAppendExtension(t *testing.T) {
 	h.Run("PanicsOnTrailingSeparator", func(h check.Harness) {
 		h.Parallel()
 
-		path := pathx.NewAbsPath(h.T().TempDir() + string(filepath.Separator))
+		path := pathx.MustParseAbsPath(h.T().TempDir() + string(filepath.Separator))
 		want := assert.AssertionError{
 			Fmt:  "precondition violation: path %q ends with a path separator; so it's not a valid file path",
 			Args: []any{path.String()},
@@ -435,8 +435,8 @@ func TestLexicallyNormalize(t *testing.T) {
 
 func TestRootRelPathBasics(t *testing.T) {
 	h := check.New(t)
-	root := pathx.NewAbsPath(t.TempDir())
-	rel := pathx.NewRelPath(filepath.Join("dir", "file.txt"))
+	root := pathx.MustParseAbsPath(t.TempDir())
+	rel := pathx.MustParseRelPath(filepath.Join("dir", "file.txt"))
 	rootRelPath := pathx.NewRootRelPath(root, rel)
 	check.AssertSame(h, rel.String(), rootRelPath.String(), "RootRelPath.String()")
 	check.AssertSame(h, root.Join(rel).String(), rootRelPath.AsAbsPath().String(), "RootRelPath.AsAbsPath()")
@@ -458,8 +458,8 @@ func TestPathFormatting(t *testing.T) {
 	relStr := filepath.Join("a", "b")
 	rootRelStr := relStr // RootRelPath.String() returns just the relative portion.
 
-	abs := pathx.NewAbsPath(absStr)
-	rel := pathx.NewRelPath(relStr)
+	abs := pathx.MustParseAbsPath(absStr)
+	rel := pathx.MustParseRelPath(relStr)
 	rootRel := pathx.NewRootRelPath(abs, rel)
 
 	tests := []struct {
@@ -507,8 +507,8 @@ func TestRejectsEmptyPaths(t *testing.T) {
 		name string
 		call func()
 	}{
-		{name: "NewAbsPath", call: func() { _ = pathx.NewAbsPath("") }},
-		{name: "NewRelPath", call: func() { _ = pathx.NewRelPath("") }},
+		{name: "MustParseAbsPath", call: func() { _ = pathx.MustParseAbsPath("") }},
+		{name: "MustParseRelPath", call: func() { _ = pathx.MustParseRelPath("") }},
 	}
 
 	for _, tt := range tests {

--- a/common/core/pathx/pathx_testkit/pathx_testkit.go
+++ b/common/core/pathx/pathx_testkit/pathx_testkit.go
@@ -62,7 +62,7 @@ func SafeRelPathGen() *rapid.Generator[pathx.RelPath] {
 			return pathx.Dot()
 		}
 		// Use strings.Join to avoid the Clean operation invoked by filepath.Join.
-		return pathx.NewRelPath(strings.Join(components, string(filepath.Separator)))
+		return pathx.MustParseRelPath(strings.Join(components, string(filepath.Separator)))
 	})
 }
 
@@ -95,6 +95,6 @@ func EscapingRelPathGen() *rapid.Generator[pathx.RelPath] {
 			}
 		}
 		// Use strings.Join to avoid the Clean operation invoked by filepath.Join.
-		return pathx.NewRelPath(strings.Join(components, string(filepath.Separator)))
+		return pathx.MustParseRelPath(strings.Join(components, string(filepath.Separator)))
 	})
 }

--- a/common/envx/envx_path/find_executable.go
+++ b/common/envx/envx_path/find_executable.go
@@ -66,9 +66,9 @@ func FindExecutable(fs fsx.FS, env envx.Env, name string) (pathx.AbsPath, error)
 	for searchDir := range searchDirs(pathEnvVar) {
 		var dir pathx.AbsPath
 		if searchDir.isRelative {
-			dir = fs.Root().Join(pathx.NewRelPath(searchDir.pathEntry))
+			dir = fs.Root().Join(pathx.MustParseRelPath(searchDir.pathEntry))
 		} else {
-			dir = pathx.NewAbsPath(searchDir.pathEntry)
+			dir = pathx.MustParseAbsPath(searchDir.pathEntry)
 		}
 		if !dir.MakeRelativeTo(fs.Root()).IsSome() {
 			err := errorx.NewProblem(errorx.Code_AccessDenied,

--- a/common/envx/envx_path/find_executable_test.go
+++ b/common/envx/envx_path/find_executable_test.go
@@ -42,7 +42,7 @@ func testFindExecutableHappyPath(h check.Harness) {
 
 	h.Run("PATH behavior", func(h check.Harness) {
 		fs := newMemFS(h, fakeRoot.JoinComponents("path-behavior"))
-		binRel := pathx.NewRelPath("bin")
+		binRel := pathx.MustParseRelPath("bin")
 		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
 		exeRel := binRel.JoinComponents(exe.Name)
 		writeExecutable(h, fs, exeRel)
@@ -84,9 +84,9 @@ func testFindExecutableHappyPath(h check.Harness) {
 			h.T().Skip("Windows-specific exec.LookPath compatibility tests")
 		}
 
-		root := pathx.NewAbsPath(h.T().TempDir())
+		root := pathx.MustParseAbsPath(h.T().TempDir())
 		fs := Do(syscaps.FS(root))(h)
-		binRel := pathx.NewRelPath("bin")
+		binRel := pathx.MustParseRelPath("bin")
 		binDir := root.Join(binRel)
 		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
 
@@ -154,7 +154,7 @@ func testFindExecutableErrorCases(h check.Harness) {
 		}
 
 		fs := newMemFS(h, fakeRoot.JoinComponents("non-executable-candidates"))
-		binRel := pathx.NewRelPath("bin")
+		binRel := pathx.MustParseRelPath("bin")
 		exeRel := binRel.JoinComponents(exe.Name)
 		fsx_testkit.WriteFile(h, fs, exeRel, "#!/bin/sh\n")
 
@@ -188,9 +188,9 @@ func testFindExecutableErrorCases(h check.Harness) {
 	})
 
 	h.Run("exec.LookPath compatibility", func(h check.Harness) {
-		root := pathx.NewAbsPath(h.T().TempDir())
+		root := pathx.MustParseAbsPath(h.T().TempDir())
 		fs := Do(syscaps.FS(root))(h)
-		binRel := pathx.NewRelPath("bin")
+		binRel := pathx.MustParseRelPath("bin")
 		binDir := root.Join(binRel)
 		h.NoErrorf(fs.MkdirAll(binRel, 0o755), "MkdirAll(%q)", binRel)
 		exeRel := binRel.JoinComponents(exe.Name)

--- a/common/fsx/fsx.go
+++ b/common/fsx/fsx.go
@@ -232,7 +232,7 @@ func (fs rootedFS) MkdirTemp(dir pathx.RelPath, pattern string) (pathx.RelPath, 
 	if err != nil {
 		return pathx.RelPath{}, err
 	}
-	return pathx.NewRelPath(tmpDir), nil
+	return pathx.MustParseRelPath(tmpDir), nil
 }
 
 // RemoveAll removes the file or directory at the given root-relative path

--- a/common/fsx/fsx_testkit/fsx_testkit.go
+++ b/common/fsx/fsx_testkit/fsx_testkit.go
@@ -22,7 +22,7 @@ import (
 // TempDirFS returns a host FS rooted at a new test temporary directory.
 func TempDirFS(h check.Harness) fsx.FS {
 	h.T().Helper()
-	fs, err := syscaps.FS(pathx.NewAbsPath(h.T().TempDir()))
+	fs, err := syscaps.FS(pathx.MustParseAbsPath(h.T().TempDir()))
 	h.NoErrorf(err, "FS(TempDir())")
 	return fs
 }
@@ -51,7 +51,7 @@ func WriteTree(h check.Harness, fs fsx.FS, tree map[string]string) {
 	h.T().Helper()
 	for path, content := range tree {
 		h.Assertf(path != "", "path must not be empty")
-		rel := pathx.NewRelPath(path)
+		rel := pathx.MustParseRelPath(path)
 		if strings.HasSuffix(path, "/") {
 			h.Assertf(content == "", "directory path %q must have empty content", path)
 			h.NoErrorf(fs.MkdirAll(rel, 0o755), "MkdirAll(%q)", rel)
@@ -137,7 +137,7 @@ func injectedFSError() error {
 
 func FakeRoot() pathx.AbsPath {
 	if runtime.GOOS == "windows" {
-		return pathx.NewAbsPath(`C:\virtual-root`)
+		return pathx.MustParseAbsPath(`C:\virtual-root`)
 	}
-	return pathx.NewAbsPath("/virtual-root")
+	return pathx.MustParseAbsPath("/virtual-root")
 }

--- a/common/fsx/fsx_walk/example_test.go
+++ b/common/fsx/fsx_walk/example_test.go
@@ -28,7 +28,7 @@ func Example_iterative() {
 		panic(err)
 	}
 	mustWrite := func(path, content string) {
-		rel := pathx.NewRelPath(path)
+		rel := pathx.MustParseRelPath(path)
 		if dir, ok := rel.Dir().Get(); ok {
 			if err := fs.MkdirAll(dir, 0o755); err != nil {
 				panic(err)

--- a/common/fsx/fsx_walk/walk_test.go
+++ b/common/fsx/fsx_walk/walk_test.go
@@ -75,7 +75,7 @@ func TestWalk(t *testing.T) {
 				h.T().Skipf("symlinks not supported on this platform")
 			}
 
-			fs := Do(syscaps.FS(pathx.NewAbsPath(link)))(h)
+			fs := Do(syscaps.FS(pathx.MustParseAbsPath(link)))(h)
 
 			_, err := fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: false})
 			walkErr := requireWalkError(h, err, fsx_walk.WalkErrorKind_RootNotDir)
@@ -175,7 +175,7 @@ func testFaults(h check.Harness) {
 	h.Run("InitialGitStat", func(h check.Harness) {
 		h.Parallel()
 
-		fs := fsx_testkit.NewFaultyFS(h, fsx_testkit.NewMemFS(h), fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Stat, Rel: pathx.NewRelPath(".git")})
+		fs := fsx_testkit.NewFaultyFS(h, fsx_testkit.NewMemFS(h), fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Stat, Rel: pathx.MustParseRelPath(".git")})
 
 		_, err := fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true})
 		_ = requireWalkError(h, err, fsx_walk.WalkErrorKind_IOFailed)
@@ -189,7 +189,7 @@ func testFaults(h check.Harness) {
 			".git": "gitdir: root\n",
 			"a/":   "",
 		})
-		fs := fsx_testkit.NewFaultyFS(h, baseFS, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Stat, Rel: pathx.NewRelPath("a/.git")})
+		fs := fsx_testkit.NewFaultyFS(h, baseFS, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Stat, Rel: pathx.MustParseRelPath("a/.git")})
 
 		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
 		_ = requireWalkError(h, firstWalkError(h, entries), fsx_walk.WalkErrorKind_IOFailed)
@@ -203,7 +203,7 @@ func testFaults(h check.Harness) {
 			".git": "gitdir: root\n",
 			"a/":   "",
 		})
-		fs := fsx_testkit.NewFaultyFS(h, baseFS, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Open, Rel: pathx.NewRelPath("a/.gitignore")})
+		fs := fsx_testkit.NewFaultyFS(h, baseFS, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Open, Rel: pathx.MustParseRelPath("a/.gitignore")})
 
 		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
 		_ = requireWalkError(h, firstWalkError(h, entries), fsx_walk.WalkErrorKind_IOFailed)
@@ -216,7 +216,7 @@ func testFaults(h check.Harness) {
 		fsx_testkit.WriteTree(h, baseFS, map[string]string{
 			"a/": "",
 		})
-		fs := fsx_testkit.NewFaultyFS(h, baseFS, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Open, Rel: pathx.NewRelPath("a")})
+		fs := fsx_testkit.NewFaultyFS(h, baseFS, fsx_testkit.Fault{Op: fsx_testkit.FaultOp_Open, Rel: pathx.MustParseRelPath("a")})
 
 		entries := Do(fsx_walk.WalkNonDet(fs, pathx.Dot(), fsx_walk.WalkOptions{RespectGitIgnore: false}))(h)
 		_ = requireWalkError(h, firstWalkError(h, entries), fsx_walk.WalkErrorKind_IOFailed)
@@ -246,11 +246,11 @@ blocked/
 
 	h.Run("Ignores root subtree when blocked by ancestor", func(h check.Harness) {
 		h.Parallel()
-		_, err := fsx_walk.WalkNonDet(fs, pathx.NewRelPath("blocked/child"), fsx_walk.WalkOptions{RespectGitIgnore: true})
+		_, err := fsx_walk.WalkNonDet(fs, pathx.MustParseRelPath("blocked/child"), fsx_walk.WalkOptions{RespectGitIgnore: true})
 		walkErr := requireWalkError(h, err, fsx_walk.WalkErrorKind_RootIsIgnored)
 		check.AssertSame(h,
 			source_code.Snippet{
-				Path:     pathx.NewRelPath(".gitignore"),
+				Path:     pathx.MustParseRelPath(".gitignore"),
 				Position: source_code.NewPosition(2, 1),
 				Text:     "blocked/",
 			},
@@ -264,14 +264,14 @@ blocked/
 
 	h.Run("Walks subtree with ancestor gitignore matchers", func(h check.Harness) {
 		h.Parallel()
-		entries := Do(fsx_walk.WalkNonDet(fs, pathx.NewRelPath("open/child"), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.MustParseRelPath("open/child"), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
 		got := collectPaths(h, entries)
 		checkVisitedPaths(h, []string{"file.go"}, got)
 	})
 
 	h.Run("Walks subtree when gitignore is disabled", func(h check.Harness) {
 		h.Parallel()
-		entries := Do(fsx_walk.WalkNonDet(fs, pathx.NewRelPath("blocked/child"), fsx_walk.WalkOptions{RespectGitIgnore: false}))(h)
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.MustParseRelPath("blocked/child"), fsx_walk.WalkOptions{RespectGitIgnore: false}))(h)
 		got := collectPaths(h, entries)
 		checkVisitedPaths(h, []string{"file.txt"}, got)
 	})
@@ -308,7 +308,7 @@ func testGitIgnore_ResetsAtNestedRepo(h check.Harness) {
 
 	h.Run("ExplicitSubtree", func(h check.Harness) {
 		h.Parallel()
-		entries := Do(fsx_walk.WalkNonDet(fs, pathx.NewRelPath("nested/child"), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
+		entries := Do(fsx_walk.WalkNonDet(fs, pathx.MustParseRelPath("nested/child"), fsx_walk.WalkOptions{RespectGitIgnore: true}))(h)
 		got := collectPaths(h, entries)
 		checkVisitedPaths(h, []string{"file.txt"}, got)
 	})
@@ -359,8 +359,8 @@ func testGitIgnore_PreservesAllParseErrors(h check.Harness) {
 	h.Assertf(ok, "WalkError.Unwrap() = %T, want an error with Snippets() []source_code.Snippet", walkErr.Unwrap())
 	check.AssertSame(h,
 		[]source_code.Snippet{
-			{Path: pathx.NewRelPath(".gitignore"), Position: source_code.NewPosition(1, 2), Text: "!"},
-			{Path: pathx.NewRelPath(".gitignore"), Position: source_code.NewPosition(2, 4), Text: "** *"},
+			{Path: pathx.MustParseRelPath(".gitignore"), Position: source_code.NewPosition(1, 2), Text: "!"},
+			{Path: pathx.MustParseRelPath(".gitignore"), Position: source_code.NewPosition(2, 4), Text: "** *"},
 		},
 		parseSnippets.Snippets(),
 		"parse error snippets",
@@ -428,8 +428,8 @@ func testGitIgnore_ConcurrentSiblingWarnings(h check.Harness) {
 	}
 	check.AssertSame(h,
 		map[string][]string{
-			"a": {fs.Root().Join(pathx.NewRelPath("a/.gitignore")).String()},
-			"b": {fs.Root().Join(pathx.NewRelPath("b/.gitignore")).String()},
+			"a": {fs.Root().Join(pathx.MustParseRelPath("a/.gitignore")).String()},
+			"b": {fs.Root().Join(pathx.MustParseRelPath("b/.gitignore")).String()},
 		},
 		got,
 		"parse warning paths",

--- a/common/fsx/stat.go
+++ b/common/fsx/stat.go
@@ -61,7 +61,7 @@ func (fs rootedFS) Stat(rel pathx.RelPath, opts StatOptions) (os.FileInfo, error
 		}
 	}
 	if lo < len(seps) {
-		return nil, &StatError{fsError: err, shortestMissing: pathx.NewRelPath(raw[:seps[lo]])}
+		return nil, &StatError{fsError: err, shortestMissing: pathx.MustParseRelPath(raw[:seps[lo]])}
 	}
 	// All ancestors exist; the leaf itself is the shallowest missing.
 	return nil, &StatError{fsError: err, shortestMissing: rel}

--- a/common/fsx/stat_test.go
+++ b/common/fsx/stat_test.go
@@ -38,7 +38,7 @@ func TestFSStat(t *testing.T) {
 			h.T().Skipf("symlinks not supported on this platform")
 		}
 
-		repoFS := Do(syscaps.FS(pathx.NewAbsPath(link)))(h)
+		repoFS := Do(syscaps.FS(pathx.MustParseAbsPath(link)))(h)
 
 		followed := Do(repoFS.Stat(pathx.Dot(), fsx.StatOptions{
 			FollowFinalSymlink:     true,
@@ -60,7 +60,7 @@ func TestFSStat(t *testing.T) {
 	h.Run("ShortestMissingProperties", func(h check.Harness) {
 		h.Parallel()
 
-		root := pathx.NewAbsPath(h.T().TempDir())
+		root := pathx.MustParseAbsPath(h.T().TempDir())
 		componentsGen := rapid.SliceOfN(pathx_testkit.ComponentGen(), 1, 6)
 		rapid.Check(h.T(), func(t *rapid.T) {
 			h := check.NewBasic(t)
@@ -100,7 +100,7 @@ func joinedRelPath(components []string) pathx.RelPath {
 	if len(components) == 0 {
 		return pathx.Dot()
 	}
-	return pathx.NewRelPath(filepath.Join(components...))
+	return pathx.MustParseRelPath(filepath.Join(components...))
 }
 
 func requireStatError(h check.BasicHarness, err error, rel pathx.RelPath, opts fsx.StatOptions) *fsx.StatError {

--- a/common/syscaps/syscaps.go
+++ b/common/syscaps/syscaps.go
@@ -45,7 +45,7 @@ func WorkingDirectory() (pathx.AbsPath, error) {
 	if err != nil {
 		return pathx.AbsPath{}, err
 	}
-	return pathx.NewAbsPath(wd), nil
+	return pathx.MustParseAbsPath(wd), nil
 }
 
 // FS returns a rooted filesystem backed by the host operating system.

--- a/common/syscaps/syscaps_test.go
+++ b/common/syscaps/syscaps_test.go
@@ -60,7 +60,7 @@ func TestFSReadDirOnFileReturnsError(t *testing.T) {
 
 	repoFS := fsx_testkit.TempDirFS(h)
 
-	fileRel := pathx.NewRelPath("file.txt")
+	fileRel := pathx.MustParseRelPath("file.txt")
 	h.NoErrorf(repoFS.WriteFile(fileRel, []byte("data"), 0o644), "WriteFile(%q)", fileRel)
 
 	gotAny := false

--- a/misc/cmd/kido/list.go
+++ b/misc/cmd/kido/list.go
@@ -18,7 +18,7 @@ import (
 )
 
 func loadWorkspaceConfig(repoFS fsx.FS) (_ config.WorkspaceConfig, retErr error) {
-	path := NewRelPath("misc/repo-configuration.json")
+	path := MustParseRelPath("misc/repo-configuration.json")
 	f, err := repoFS.Open(path, fsx.OpenOptions{Mode: fsx.OpenMode_ReadOnly})
 	if err != nil {
 		return config.WorkspaceConfig{}, errorx.Wrapf("+stacks", err, "open %s", path)

--- a/misc/cmd/kido/main.go
+++ b/misc/cmd/kido/main.go
@@ -43,7 +43,7 @@ func newWorkspaceFromGit(runner cmdx.Runner) (Workspace, error) {
 	if err != nil {
 		return Workspace{}, errorx.Wrapf("nostack", err, "determine git repository root")
 	}
-	repoRoot := NewAbsPath(strings.TrimSpace(output.Stdout))
+	repoRoot := MustParseAbsPath(strings.TrimSpace(output.Stdout))
 	repoFS, err := syscaps.FS(repoRoot)
 	if err != nil {
 		return Workspace{}, errorx.Wrapf("+stacks", err, "open repo filesystem at %s", repoRoot)

--- a/misc/cmd/kido/sync_branch.go
+++ b/misc/cmd/kido/sync_branch.go
@@ -177,7 +177,7 @@ func formatLease(branch string, remoteHead Option[remoteRef]) string {
 func createSyncWorktree(
 	ctx logx.LogCtx, runner cmdx.BaseRunner, repoFS fsx.FS, base string,
 ) (RelPath, func() error, error) {
-	tmpRoot := NewRelPath(".cache").JoinComponents("tmp")
+	tmpRoot := MustParseRelPath(".cache").JoinComponents("tmp")
 	if err := repoFS.MkdirAll(tmpRoot, 0o755); err != nil {
 		return RelPath{}, nil, errorx.Wrapf("+stacks", err, "create temp root %s", tmpRoot)
 	}

--- a/misc/internal/licenses/licenses_test.go
+++ b/misc/internal/licenses/licenses_test.go
@@ -82,7 +82,7 @@ func repoRootFromMiscDir(h check.Harness, workingDir AbsPath) AbsPath {
 func loadWorkspaceConfig(h check.Harness, repoFS fsx.FS) config.WorkspaceConfig {
 	h.T().Helper()
 
-	path := NewRelPath("misc/repo-configuration.json")
+	path := MustParseRelPath("misc/repo-configuration.json")
 	f := DoMsg(repoFS.Open(path, fsx.OpenOptions{Mode: fsx.OpenMode_ReadOnly}))(h, "opening %s", path)
 	defer h.Close(f)
 
@@ -110,7 +110,7 @@ func visitFirstPartyGoFiles[T any](
 		}()
 	}
 
-	for entryRes := range repoFS.ReadDir(NewRelPath(".")) {
+	for entryRes := range repoFS.ReadDir(MustParseRelPath(".")) {
 		entry := DoMsg(entryRes.Get())(h, "reading repository root %s", repoFS.Root())
 		if !entry.IsDir() {
 			continue
@@ -121,7 +121,7 @@ func visitFirstPartyGoFiles[T any](
 			continue
 		}
 
-		moduleRoot := NewRelPath(".").JoinComponents(name.String())
+		moduleRoot := MustParseRelPath(".").JoinComponents(name.String())
 		goModInfo, err := repoFS.Stat(moduleRoot.JoinComponents("go.mod"), fsx.StatOptions{
 			FollowFinalSymlink:     false,
 			OnErrorTraverseParents: false,

--- a/misc/mappings_test.go
+++ b/misc/mappings_test.go
@@ -32,7 +32,7 @@ func TestWorkspaceConfig(t *testing.T) {
 	h.Assertf(ok, "working directory %s must have a parent", workingDir)
 	repoFS := DoMsg(syscaps.FS(repoRoot))(h, "opening repo FS")
 
-	f := DoMsg(repoFS.Open(NewRelPath("misc/repo-configuration.json"), fsx.OpenOptions{Mode: fsx.OpenMode_ReadOnly}))(h, "opening repo-configuration.json")
+	f := DoMsg(repoFS.Open(MustParseRelPath("misc/repo-configuration.json"), fsx.OpenOptions{Mode: fsx.OpenMode_ReadOnly}))(h, "opening repo-configuration.json")
 	t.Cleanup(func() { _ = f.Close() })
 
 	wsConfig := Do(config.Load(f))(h)
@@ -68,7 +68,7 @@ func TestWorkspaceConfig(t *testing.T) {
 	h.Run("WorkflowProjectChoices", func(h check.Harness) {
 		h.Parallel()
 
-		workflowBytes := DoMsg(repoFS.ReadFile(NewRelPath(".github/workflows/upstream-sync.yml")))(h,
+		workflowBytes := DoMsg(repoFS.ReadFile(MustParseRelPath(".github/workflows/upstream-sync.yml")))(h,
 			"reading upstream-sync.yml")
 
 		var workflow struct {
@@ -96,7 +96,7 @@ func TestWorkspaceConfig(t *testing.T) {
 	h.Run("LinterExclusions", func(h check.Harness) {
 		h.Parallel()
 
-		lintBytes := DoMsg(repoFS.ReadFile(NewRelPath(".golangci.yml")))(h,
+		lintBytes := DoMsg(repoFS.ReadFile(MustParseRelPath(".golangci.yml")))(h,
 			"reading .golangci.yml")
 
 		var lintCfg struct {


### PR DESCRIPTION
MustVerb aligns better with Go conventions, such
as regexp.MustCompile. Yes, it's more verbose.
In a later PR, I'll introduce error-returning variants
such as ParseAbsPath and ParseRelPath.
