### PR TITLE
feat(pathx): Introduce fallible Parse(Abs|Rel)Path functions

### DIFF
--- a/common/core/pathx/errors.go
+++ b/common/core/pathx/errors.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package pathx
+
+import (
+	"code.kibou.tools/common/assert"
+	"code.kibou.tools/common/errorx"
+)
+
+type AbsPathParseError struct {
+	kind      AbsPathParseErrorKind
+	inputPath string
+}
+
+type AbsPathParseErrorKind uint8
+
+const (
+	AbsPathParseErrorKind_Empty AbsPathParseErrorKind = iota + 1
+	AbsPathParseErrorKind_NotAbsolute
+)
+
+func NewAbsPathParseError(kind AbsPathParseErrorKind, inputPath string) *AbsPathParseError {
+	switch kind {
+	case AbsPathParseErrorKind_Empty:
+		assert.Preconditionf(inputPath == "", "input path should be empty for AbsPathParseErrorKind_Empty")
+	case AbsPathParseErrorKind_NotAbsolute:
+		assert.Preconditionf(inputPath != "", "input path should be non-empty for AbsPathParseErrorKind_NotAbsolute")
+	default:
+		assert.PanicUnknownCase[any](kind)
+	}
+	return &AbsPathParseError{kind: kind, inputPath: inputPath}
+}
+
+func (e *AbsPathParseError) Kind() AbsPathParseErrorKind {
+	return e.kind
+}
+
+func (e *AbsPathParseError) InputPath() string {
+	return e.inputPath
+}
+
+func (e *AbsPathParseError) Error() string {
+	fmt := errorx.NewStableFormatter()
+	e.FormatError(fmt)
+	return fmt.Finish()
+}
+
+func (e *AbsPathParseError) FormatError(fmt errorx.Formatter) {
+	switch e.kind {
+	case AbsPathParseErrorKind_Empty:
+		fmt.FormatConstMsg("empty absolute path")
+	case AbsPathParseErrorKind_NotAbsolute:
+		fmt.FormatConstMsg("not an absolute path")
+		fmt.FormatDynamic(errorx.ValueKind_Path, "input", e.inputPath)
+	default:
+		assert.PanicUnknownCase[any](e.kind)
+	}
+}
+
+type RelPathParseError struct {
+	kind      RelPathParseErrorKind
+	inputPath string
+}
+
+type RelPathParseErrorKind uint8
+
+const (
+	RelPathParseErrorKind_Empty RelPathParseErrorKind = iota + 1
+	RelPathParseErrorKind_NotRelative
+)
+
+func NewRelPathParseError(kind RelPathParseErrorKind, inputPath string) *RelPathParseError {
+	switch kind {
+	case RelPathParseErrorKind_Empty:
+		assert.Preconditionf(inputPath == "", "input path should be empty for RelPathParseErrorKind_Empty")
+	case RelPathParseErrorKind_NotRelative:
+		assert.Preconditionf(inputPath != "", "input path should be non-empty for RelPathParseErrorKind_NotRelative")
+	default:
+		assert.PanicUnknownCase[any](kind)
+	}
+	return &RelPathParseError{kind: kind, inputPath: inputPath}
+}
+
+func (e *RelPathParseError) Kind() RelPathParseErrorKind {
+	return e.kind
+}
+
+func (e *RelPathParseError) InputPath() string {
+	return e.inputPath
+}
+
+func (e *RelPathParseError) Error() string {
+	fmt := errorx.NewStableFormatter()
+	e.FormatError(fmt)
+	return fmt.Finish()
+}
+
+func (e *RelPathParseError) FormatError(fmt errorx.Formatter) {
+	switch e.kind {
+	case RelPathParseErrorKind_Empty:
+		fmt.FormatConstMsg("empty relative path")
+	case RelPathParseErrorKind_NotRelative:
+		fmt.FormatConstMsg("not a relative path")
+		fmt.FormatDynamic(errorx.ValueKind_Path, "input", e.inputPath)
+	default:
+		assert.PanicUnknownCase[any](e.kind)
+	}
+}

--- a/common/core/pathx/pathx.go
+++ b/common/core/pathx/pathx.go
@@ -27,13 +27,32 @@ type AbsPath struct {
 	value string
 }
 
+func ParseAbsPath(path string) (AbsPath, *AbsPathParseError) {
+	if path == "" {
+		return AbsPath{}, NewAbsPathParseError(AbsPathParseErrorKind_Empty, path)
+	}
+	if !filepath.IsAbs(path) {
+		return AbsPath{}, NewAbsPathParseError(AbsPathParseErrorKind_NotAbsolute, path)
+	}
+	return AbsPath{LexicallyNormalize(path)}, nil
+}
+
 // MustParseAbsPath creates an AbsPath from an already-absolute path string.
 //
 // Pre-condition: path is non-empty and absolute per [filepath.IsAbs].
 func MustParseAbsPath(path string) AbsPath {
-	assert.Preconditionf(path != "", "path is empty")
-	assert.Preconditionf(filepath.IsAbs(path), "path is not absolute: %q", path)
-	return AbsPath{LexicallyNormalize(path)}
+	absPath, err := ParseAbsPath(path)
+	if err != nil {
+		switch err.Kind() {
+		case AbsPathParseErrorKind_Empty:
+			assert.Preconditionf(false, "MustParseAbsPath called with empty path")
+		case AbsPathParseErrorKind_NotAbsolute:
+			assert.Preconditionf(false, "MustParseAbsPath called with non-absolute path: %q", path)
+		default:
+			assert.PanicUnknownCase[any](err.Kind())
+		}
+	}
+	return absPath
 }
 
 func (p AbsPath) String() string {
@@ -173,13 +192,33 @@ func Dot() RelPath {
 	return RelPath{"."}
 }
 
+// ParseRelPath creates a RelPath from a relative path string.
+func ParseRelPath(path string) (RelPath, *RelPathParseError) {
+	if path == "" {
+		return RelPath{}, NewRelPathParseError(RelPathParseErrorKind_Empty, path)
+	}
+	if filepath.IsAbs(path) {
+		return RelPath{}, NewRelPathParseError(RelPathParseErrorKind_NotRelative, path)
+	}
+	return RelPath{LexicallyNormalize(path)}, nil
+}
+
 // MustParseRelPath creates a RelPath from a relative path string.
 //
 // Pre-condition: path is non-empty and not absolute per [filepath.IsAbs].
 func MustParseRelPath(path string) RelPath {
-	assert.Preconditionf(path != "", "path is empty")
-	assert.Preconditionf(!filepath.IsAbs(path), "path is not relative: %q", path)
-	return RelPath{LexicallyNormalize(path)}
+	relPath, err := ParseRelPath(path)
+	if err != nil {
+		switch err.Kind() {
+		case RelPathParseErrorKind_Empty:
+			assert.Preconditionf(false, "MustParseRelPath called with empty path")
+		case RelPathParseErrorKind_NotRelative:
+			assert.Preconditionf(false, "MustParseRelPath called with absolute path: %q", path)
+		default:
+			assert.PanicUnknownCase[any](err.Kind())
+		}
+	}
+	return relPath
 }
 
 // String is guaranteed to be "." if a relative path for the current directory.

--- a/common/core/pathx/pathx_test.go
+++ b/common/core/pathx/pathx_test.go
@@ -501,21 +501,55 @@ func TestPathFormatting(t *testing.T) {
 
 func TestRejectsEmptyPaths(t *testing.T) {
 	h := check.New(t)
-	want := assert.AssertionError{Fmt: "precondition violation: path is empty", Args: nil}
 
 	tests := []struct {
 		name string
+		want assert.AssertionError
 		call func()
 	}{
-		{name: "MustParseAbsPath", call: func() { _ = pathx.MustParseAbsPath("") }},
-		{name: "MustParseRelPath", call: func() { _ = pathx.MustParseRelPath("") }},
+		{
+			name: "MustParseAbsPath",
+			want: assert.AssertionError{Fmt: "precondition violation: MustParseAbsPath called with empty path", Args: nil},
+			call: func() { _ = pathx.MustParseAbsPath("") },
+		},
+		{
+			name: "MustParseRelPath",
+			want: assert.AssertionError{Fmt: "precondition violation: MustParseRelPath called with empty path", Args: nil},
+			call: func() { _ = pathx.MustParseRelPath("") },
+		},
 	}
 
 	for _, tt := range tests {
 		h.Run(tt.name, func(h check.Harness) {
-			h.AssertPanicsWith(want, tt.call)
+			h.AssertPanicsWith(tt.want, tt.call)
 		})
 	}
+}
+
+func TestPathParseErrorConstructors(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	absEmpty := pathx.NewAbsPathParseError(pathx.AbsPathParseErrorKind_Empty, "")
+	check.AssertSame(h, pathx.AbsPathParseErrorKind_Empty, absEmpty.Kind(), "AbsPathParseError.Kind()")
+	check.AssertSame(h, "", absEmpty.InputPath(), "AbsPathParseError.InputPath()")
+	check.AssertSame(h, "empty absolute path", absEmpty.Error(), "AbsPathParseError.Error()")
+
+	absNotAbsolute := pathx.NewAbsPathParseError(pathx.AbsPathParseErrorKind_NotAbsolute, "relative")
+	check.AssertSame(h, pathx.AbsPathParseErrorKind_NotAbsolute, absNotAbsolute.Kind(), "AbsPathParseError.Kind()")
+	check.AssertSame(h, "relative", absNotAbsolute.InputPath(), "AbsPathParseError.InputPath()")
+	check.AssertSame(h, `not an absolute path (input="relative")`, absNotAbsolute.Error(), "AbsPathParseError.Error()")
+
+	relEmpty := pathx.NewRelPathParseError(pathx.RelPathParseErrorKind_Empty, "")
+	check.AssertSame(h, pathx.RelPathParseErrorKind_Empty, relEmpty.Kind(), "RelPathParseError.Kind()")
+	check.AssertSame(h, "", relEmpty.InputPath(), "RelPathParseError.InputPath()")
+	check.AssertSame(h, "empty relative path", relEmpty.Error(), "RelPathParseError.Error()")
+
+	absPath := h.T().TempDir()
+	relNotRelative := pathx.NewRelPathParseError(pathx.RelPathParseErrorKind_NotRelative, absPath)
+	check.AssertSame(h, pathx.RelPathParseErrorKind_NotRelative, relNotRelative.Kind(), "RelPathParseError.Kind()")
+	check.AssertSame(h, absPath, relNotRelative.InputPath(), "RelPathParseError.InputPath()")
+	check.AssertSame(h, fmt.Sprintf("not a relative path (input=%q)", absPath), relNotRelative.Error(), "RelPathParseError.Error()")
 }
 
 func TestHasPathSeparators(t *testing.T) {


### PR DESCRIPTION
So far, I think we've mostly been working with already-known
or validated paths. It's useful to push the validation down
into the library instead of relying on the caller doing the
checks and then calling the function with the assertion.

For creating values in tests, it's useful to continue to
have the MustParse variants of the functions.
