### PR TITLE
feat(diag): Introduce package for structured errors

### DIFF
--- a/base/core/option/bounds_checked.go
+++ b/base/core/option/bounds_checked.go
@@ -57,3 +57,15 @@ func (b BoundsChecked[T]) Unwrap() T {
 	}
 	return b.value
 }
+
+// Expect asserts that the value has not overflowed, and gets that value.
+//
+// Example message: "overflow checking during <type> construction guarantees that <field> should be within bounds"
+//
+// Pre-condition: The value must not have Overflowed.
+func (b BoundsChecked[T]) Expect(invariantMsg string) T {
+	if b.overflowed {
+		assert.Invariant(false, invariantMsg)
+	}
+	return b.value
+}

--- a/base/core/result/partial.go
+++ b/base/core/result/partial.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package result
+
+import (
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/core/option"
+)
+
+// Partial represents the outcome of an operation which can produce:
+//
+// - A value
+// - An error
+// - Both a value and an error.
+//
+// This is useful when callers can recover a degraded value from an error.
+type Partial[T any, E any] struct {
+	value option.Option[T]
+	err   *E
+}
+
+// NewPartial constructs a Partial value.
+//
+// Pre-condition: If err is nil, then value must be some.
+func NewPartial[T any, E any](value option.Option[T], err *E) Partial[T, E] {
+	if err == nil && value.IsNone() {
+		assert.Precondition(false, "NewPartial must get value | error | both, but got no value with nil error")
+	}
+	return Partial[T, E]{value: value, err: err}
+}
+
+// Value returns the computed value for the 'value' and 'both' cases
+// of a Partial.
+//
+// If Err() returned nil, then this is guaranteed to be Some(v).
+// Otherwise, this may be Some(v) or None.
+func (p Partial[T, E]) Value() option.Option[T] { return p.value }
+
+// Err returns the error for the 'error' and 'both' cases of a Partial.
+//
+// If this method returns nil, then Value() is guaranteed to return Some(v).
+func (p Partial[T, E]) Err() *E { return p.err }

--- a/base/diag/Design.djot
+++ b/base/diag/Design.djot
@@ -1,0 +1,206 @@
+::: metadata
+references:
+  packages:
+    - code.kibou.tools/base/diag
+    - code.kibou.tools/base/errorx
+    - code.kibou.tools/base/core/result
+  declarations:
+    - diag.Diagnostic
+    - diag.CodedDiagnostic
+    - diag.Snippet
+    - diag.TextSnippet
+    - diag.TextSnippetBuilder
+:::
+
+# Design of the `diag` package
+
+The design of the interfaces in the [diag]{.sym} package
+is inspired by the Rust library [miette](https://github.com/zkat/miette).
+
+The focus of this library is on the _presentational_
+aspect of errors, to guide library design in a way
+which leads to applications surfacing errors consistently
+to developers.
+
+## Key design goals
+
+1. Provide a standard way to provide more structured
+   information across library boundaries, compared to
+   the standard `error` interface, which only surfaces
+   a `string` message.
+2. Make it possible to have a holistic, consistent
+   story for reporting errors in applications.
+3. Address the common needs of presenting errors that
+   arise in various circumstances:
+
+   - Errors in explicitly passed or implicitly read files
+   - Errors in various kinds of input (e.g. env vars,
+     command-line arguments)
+   - Errors encountered during execution
+
+## Non-goals
+
+The main non-goal of this package is to avoid dictating
+a particular _semantics_ for errors. For example,
+the following are out-of-scope:
+
+1. Creating a detailed taxonomy for all possible kinds of errors.
+
+2. Handle all possible error reporting needs. For example,
+   RPC between servers may care about retryability, idempotence,
+   correlation IDs and so on. Logging code may care about redaction.
+
+   It should be possible to layer these aspects "inside"
+   or "outside" the layers provided by the APIs in this
+   package, without needing changes in the design
+   of this package itself.
+
+For semantics, different applications have different needs,
+and it seems very difficult to come up with a taxonomy
+that works for everything.
+
+## The [Diagnostic]{.sym} interface
+
+This interface is meant to be used by libraries
+which want to report detailed errors. Its logical
+shape is as follows:
+
+```go
+type Diagnostic interface {
+    Severity() (Error | Warning)
+    Attribution() (External | Internal)
+    Message() string
+    Snippets() Seq[Snippet]
+    Notes() Seq[Note]
+}
+```
+
+This is deliberately a pull-based design (like miette)
+-- a push-based design would look more like
+[errorx.FormattedError]{.sym}. The reason for this
+is to allow renderers to omit certain parts of the
+diagnostic as necessary, and to own the control flow.
+
+For example, in a "quiet" mode for a CLI tool,
+one might just care about the return value of `Severity()`,
+and count the number of diagnostics.
+If that's non-zero, then the CLI can exit 1 without
+doing any rendering.
+
+### The [Severity()]{.sym target="diag.Diagnostic.Severity"} method
+
+The severity is meant to be limited to two possibilities,
+because whether an operation can be continued
+(after hitting this error)
+is a binary yes/no at a _specific layer_ in the code.
+This may vary across layers, but disallowing a more
+ambiguous state makes the transitions clearer.
+
+The more common case is expected to be `Error`,
+but warnings share many of the same presentational needs,
+so it makes sense to group these together.
+
+### The [Attribution()]{.sym target="diag.Diagnostic.Attribution"} method
+
+When an error comes up in production, such as when
+seeing a log line, one of the first questions that
+comes to mind is "which code is responsible for this error".
+
+If a function call is seen as a contract
+("if you give me the input that I expect,
+I'll give you the output that you want"),
+then `Attribution()` is a way of saying
+which party failed to uphold a part of the contract.
+Documenting this at the time of error creation
+means that the implicit assumption in your head
+about what logic is responsible for what
+gets materialized into the code.
+
+Yes, in practice, this is not going to be perfect.
+For example, you may see an error being attributed
+externally, but the problem is actually due to a bug
+in the [error domain]{.term} which created the error.
+However, this will at least make it clearer as to
+which code is to be fixed.
+
+### The [Message()]{.sym target="diag.Diagnostic.Message"} method
+
+This returns a simple `string` instead of a dedicated
+type for markup/attributed text, because the latter is
+much more complex, and pessimizes the common case
+with more friction when constructing diagnostics.
+
+Instead, markup can be layered inside the implementor
+of `Diagnostic`.
+
+### [`Snippets()`]{.sym target="diag.Diagnostic.Snippets"} and [`Notes()`]{.sym target="diag.Diagnostic.Notes"}
+
+With diagnostics, it's often valuable to have contextual
+information about the error by default. For example,
+when a filesystem operation fails, it's useful to
+have information about the filepaths which were involved.
+
+If it's a problem with a configuration file,
+it's valuable to know which line(s) caused
+the error.
+
+Using sequences for the return types allows
+for trivial implementation of the methods
+(no snippets/notes => return empty iterator)
+as well as a standard way to communicate
+contextual information.
+
+In the future, it may make sense to potentially split
+out a smaller interface from `Diagnostic`
+which does not expose these 2 methods.
+
+### No `Code` by default on `Diagnostic`
+
+This interface deliberately does not include
+a code, as that's usually a concern for
+large libraries or applications. Instead,
+that's separated out into [CodedDiagnostic]{.sym}
+interface.
+
+## The [Snippet]{.sym} interface
+
+Snippets for binary data and textual data have different requirements:
+
+1. For textual data, one typically wants to
+   display line ranges.
+2. For binary data, one typically wants to
+   display byte offsets (similar to tools
+   like [ImHex](https://github.com/WerWolv/ImHex)).
+
+This rules out a design where information
+(like byte offsets or line numbers or gutters)
+is pre-rendered as part of the `Snippet` API.
+
+`Snippet` is a closed marker interface to
+avoid consolidating all API methods into
+more generic names (e.g. "starting line"
+and "starting byte offset" benefit from
+having different names), while preserving
+the ability to match on a closed set of
+types.
+
+### The [TextSnippet]{.sym} type and the builder API
+
+We use a builder API shape here because:
+
+1. Some fields are optional and some are required.
+   The API shape makes it clearer which fields
+   are mandatory (arguments to `NewTextSnippet`)
+   and which fields are optional (the rest).
+2. Not exposing the fields prevents users from
+   tampering with the data.
+3. Different errors can be detected for different
+   fragments, and using an API which returns `(T, error)`
+   on individual attachment operations would introduce
+   a large amount of boilerplate error handling for callers
+   for questionable benefit.
+
+[TextSnippetBuilder.Build]{.sym} returns [result.Partial]{.sym}
+because a bug in your diagnostic construction code,
+while still technically a defect,
+shouldn't prevent you from reporting an error to your users.

--- a/base/diag/builder.go
+++ b/base/diag/builder.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package diag
+
+import (
+	"iter"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/iterx"
+)
+
+// Report is a struct which implements the Diagnostic
+// interface using pre-computed data.
+type Report struct {
+	severity    Severity
+	attribution Attribution
+	message     string
+	snippets    []Snippet
+	notes       []Note
+}
+
+// NewReport creates a new Report.
+//
+// Precondition: message must be non-empty.
+//
+// Postcondition: The returned pointer is non-nil.
+func NewReport(severity Severity, attribution Attribution, message string) *Report {
+	switch severity {
+	case Severity_Error, Severity_Warning:
+	default:
+		assert.PanicUnknownCase[any](severity)
+	}
+	switch attribution {
+	case Attribution_Internal, Attribution_External:
+	default:
+		assert.PanicUnknownCase[any](attribution)
+	}
+	assert.Precondition(message != "", "diagnostic message should be non-empty")
+	return &Report{
+		severity:    severity,
+		attribution: attribution,
+		message:     message,
+		snippets:    nil,
+		notes:       nil,
+	}
+}
+
+// WithSnippet attaches a Snippet to the receiver.
+//
+// The receiver is returned for chaining.
+func (d *Report) WithSnippet(snippet Snippet) *Report {
+	d.snippets = append(d.snippets, snippet)
+	return d
+}
+
+// WithNote attaches a Note to the receiver.
+//
+// The receiver is returned for chaining.
+func (d *Report) WithNote(note Note) *Report {
+	d.notes = append(d.notes, note)
+	return d
+}
+
+var _ Diagnostic = (*Report)(nil)
+
+func (d *Report) Severity() Severity       { return d.severity }
+func (d *Report) Attribution() Attribution { return d.attribution }
+func (d *Report) Message() string          { return d.message }
+func (d *Report) Snippets() iter.Seq[Snippet] {
+	return iterx.FromSlice(d.snippets)
+}
+func (d *Report) Notes() iter.Seq[Note] { return iterx.FromSlice(d.notes) }
+
+// CodedReport is a Report paired with a Code.
+type CodedReport[C Code] struct {
+	report *Report
+	code   C
+}
+
+// NewCodedReport constructs a new CodedReport.
+//
+// Precondition: message is non-empty.
+//
+// Postcondition: The returned pointer is non-nil.
+func NewCodedReport[C Code](severity Severity, attribution Attribution, message string, code C) *CodedReport[C] {
+	return &CodedReport[C]{report: NewReport(severity, attribution, message), code: code}
+}
+
+// WithSnippet attaches a Snippet to the receiver.
+//
+// The receiver is returned for chaining.
+func (d *CodedReport[C]) WithSnippet(snippet Snippet) *CodedReport[C] {
+	d.report.WithSnippet(snippet)
+	return d
+}
+
+// WithNote attaches a Note to the receiver.
+//
+// The receiver is returned for chaining.
+func (d *CodedReport[C]) WithNote(note Note) *CodedReport[C] {
+	d.report.WithNote(note)
+	return d
+}
+
+var _ CodedDiagnostic[Code] = (*CodedReport[Code])(nil)
+
+func (d *CodedReport[C]) Severity() Severity       { return d.report.Severity() }
+func (d *CodedReport[C]) Attribution() Attribution { return d.report.Attribution() }
+func (d *CodedReport[C]) Code() C                  { return d.code }
+func (d *CodedReport[C]) Message() string          { return d.report.Message() }
+func (d *CodedReport[C]) Snippets() iter.Seq[Snippet] {
+	return d.report.Snippets()
+}
+func (d *CodedReport[C]) Notes() iter.Seq[Note] { return d.report.Notes() }

--- a/base/diag/diagnostic.go
+++ b/base/diag/diagnostic.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package diag provides functionality for reporting rich diagnostics
+// with customizable formatting.
+//
+// The primary intended user of this package is command-line tools.
+// Applications like daemons or servers may also use this package for
+// local development, and convert the data to structured logs when running
+// standalone.
+package diag
+
+import (
+	"iter"
+
+	"code.kibou.tools/base/assert"
+	. "code.kibou.tools/base/core/option"
+)
+
+// Diagnostic is a structured, renderer-agnostic description of an error.
+type Diagnostic interface {
+	// Severity describes whether an operation can/cannot be
+	// successfully completed.
+	Severity() Severity
+	// Attribution indicates which error domain is responsible for having
+	// caused this error.
+	//
+	// In the context of a generic library:
+	//
+	// - If the presence of this diagnostic indicates a bug or something
+	//   suboptimal in the library, then the return value should be
+	//   Attribution_Internal.
+	// - If the presence of this diagnostic indicates something wrong or
+	//   suboptimal with the caller, the environment (e.g. filesystem
+	//   or network operations) or something else external to the library
+	//   (such as some problem in a dependency), then the return value
+	//   should be Attribution_External.
+	//
+	// In the context of an application:
+	//
+	// -
+	Attribution() Attribution
+	// Message indicates the key message of this error.
+	//
+	// Requirement: The returned string must be non-empty.
+	Message() string
+	// Snippets returns any source snippets associated with the diagnostic.
+	//
+	// Repeated calls to this method must return an identical sequence.
+	Snippets() iter.Seq[Snippet]
+	// Notes returns any associated notes related to the diagnostic.
+	//
+	// Repeated calls to this method must return an identical sequence.
+	Notes() iter.Seq[Note]
+}
+
+type CodedDiagnostic[C Code] interface {
+	Diagnostic
+	Code() C
+}
+
+// Code is an identifier for a diagnostic meant to be stable
+// across SemVer-compatible versions.
+type Code interface {
+	// Requirement: The returned string must be non-empty.
+	String() string
+	// SeeAlso returns a diagnostic-code-specific pointer to more information
+	// about the error.
+	//
+	// For example:
+	// - In a server, this may be the URL to the docs which describe the error
+	//   code.
+	// - In a command-line tool, this may be a command invocation like
+	//   "mytool explain BUILD001".
+	//
+	// Renderers own the surrounding prose. For example, [RenderPretty] prepends
+	// [RenderPrettyOptions.SeeAlsoPrefix] to this value.
+	//
+	// Requirement: If the returned value is Some, it must be non-empty.
+	//
+	SeeAlso() Option[string]
+}
+
+// Severity indicates whether a particular diagnostic
+// may or may not lead to unsuccessful execution of the program.
+type Severity uint8
+
+const (
+	// Severity_Error applies to a diagnostic D if the program
+	// will not complete executing successfully upon encountering
+	// it, regardless of any other diagnostics.
+	Severity_Error Severity = iota + 1
+	// Severity_Warning applies to diagnostic D if the program's
+	// successful execution does not depend on it being issued,
+	// but the diagnostic is meant to indicate something anomalous.
+	//
+	// Examples of reasons to issue warnings:
+	//
+	// - Very expensive operations (in time or other resource consumption)
+	// - Potential bugs in user input
+	Severity_Warning
+)
+
+// Text returns an English description of the Severity
+// value suitable for rendering.
+//
+// The first letter of the string will be uppercase.
+func (s Severity) Text() string {
+	switch s {
+	case Severity_Error:
+		return "Error"
+	case Severity_Warning:
+		return "Warning"
+	default:
+		return assert.PanicUnknownCase[string](s)
+	}
+}
+
+// Attribution coarsely describes "who" is responsible for
+// an error.
+//
+// For more details, see [Diagnostic.Attribution] and the
+// design docs.
+type Attribution uint8
+
+const (
+	// Attribution_Internal marks an error/warning as being caused by
+	// the error domain it originated in.
+	Attribution_Internal Attribution = iota + 1
+	// Attribution_External marks a diagnostic as being caused by
+	// something outside the error domain it originated in.
+	Attribution_External
+)
+
+func (a Attribution) String() string {
+	switch a {
+	case Attribution_Internal:
+		return "internal"
+	case Attribution_External:
+		return "external"
+	default:
+		return assert.PanicUnknownCase[string](a)
+	}
+}
+
+func (a Attribution) Text() string {
+	switch a {
+	case Attribution_Internal:
+		return "Internal"
+	case Attribution_External:
+		return ""
+	default:
+		return assert.PanicUnknownCase[string](a)
+	}
+}
+
+// NoteKind tags a [Note] with the role it plays in a diagnostic.
+type NoteKind uint8
+
+const (
+	// NoteKind_Suggestion proposes a fix or alternative ("hint:").
+	NoteKind_Suggestion NoteKind = iota + 1
+	// NoteKind_Context describes the surrounding situation ("note:").
+	NoteKind_Context
+)
+
+// Text returns an English description of the NoteKind
+// value, suitable for rendering.
+//
+// The first letter of the string will be lowercase.
+func (k NoteKind) Text() string {
+	switch k {
+	case NoteKind_Suggestion:
+		return "hint"
+	case NoteKind_Context:
+		return "note"
+	default:
+		return assert.PanicUnknownCase[string](k)
+	}
+}
+
+// Note is a single annotation attached to a diagnostic. It carries a kind
+// (context vs suggestion) and a non-empty message.
+type Note struct {
+	kind NoteKind
+	msg  string
+}
+
+// NewNote constructs a Note.
+//
+// Pre-conditions:
+//
+// 1. kind is one of the defined [NoteKind] constants
+// 2. msg must be non-empty.
+func NewNote(kind NoteKind, msg string) Note {
+	switch kind {
+	case NoteKind_Suggestion, NoteKind_Context:
+	default:
+		assert.PanicUnknownCase[any](kind)
+	}
+	if msg == "" {
+		assert.Precondition(false, "diag.NewNote: msg should be non-empty")
+	}
+	return Note{kind: kind, msg: msg}
+}
+
+// Kind returns the [NoteKind].
+func (n Note) Kind() NoteKind { return n.kind }
+
+// Msg returns the non-empty note message.
+func (n Note) Msg() string { return n.msg }

--- a/base/diag/snippet.go
+++ b/base/diag/snippet.go
@@ -1,0 +1,660 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package diag
+
+import (
+	"fmt"
+	"iter"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"code.kibou.tools/base/assert"
+	. "code.kibou.tools/base/core/option"
+	"code.kibou.tools/base/core/result"
+	"code.kibou.tools/base/errorx"
+	"code.kibou.tools/base/fsx/fsx_name"
+	"code.kibou.tools/base/internal/uniseg"
+	"code.kibou.tools/base/iterx"
+	"code.kibou.tools/base/ranges"
+	"code.kibou.tools/base/utf8"
+)
+
+// Snippet marks the set of snippet types supported by this package.
+//
+// This is a closed interface; only types defined in this package can implement
+// it. Renderers should type switch over the concrete snippet types they support.
+type Snippet interface {
+	isSnippet()
+}
+
+// TextSnippet pairs a relevant textual excerpt with zero or more annotations on
+// sub-parts of that excerpt, explaining the containing Diagnostic in more
+// detail.
+//
+// Text snippets may be used to describe fragments of files, command-line
+// arguments, environment variables, input read from stdin, data obtained over
+// the network etc.
+//
+// See [TextSnippetBuilder.WithLocation] for examples.
+type TextSnippet struct {
+	text      string
+	location  Option[errorx.Phrase]
+	startLine Option[int]
+	labels    []LabeledSpan
+}
+
+func (TextSnippet) isSnippet() {}
+
+// Text gets the original text associated with this TextSnippet.
+//
+// Post-condition: The returned string is non-empty.
+func (s TextSnippet) Text() string { return s.text }
+
+// Location gets the location set by WithLocation.
+func (s TextSnippet) Location() Option[errorx.Phrase] { return s.location }
+
+// StartLine gets the start line set by WithStartLine.
+func (s TextSnippet) StartLine() Option[int] { return s.startLine }
+
+// Labels returns the labels attached to this TextSnippet in insertion order.
+// The returned slice must not be modified.
+func (s TextSnippet) Labels() []LabeledSpan {
+	return s.labels
+}
+
+// TextSnippetBuilder incrementally constructs a [TextSnippet].
+//
+// Call [TextSnippetBuilder.Build] to perform validation checks.
+type TextSnippetBuilder struct {
+	text      string
+	location  Option[errorx.Phrase]
+	startLine Option[int]
+	labels    []snippetBuilderLabel
+}
+
+// snippetBuilderLabel stores a label attached while building a snippet.
+type snippetBuilderLabel struct {
+	span    ranges.Span[int]
+	msg     errorx.Phrase
+	options LabelOptions
+}
+
+// NewTextSnippet starts constructing a text snippet from the associated text.
+//
+// For example, if you're diagnosing an error in a configuration file, you'd do:
+//
+//	partial := diag.NewTextSnippet(configLine).
+//				WithLocation(errorx.NewPhrase(configFilePath.String())).
+//				AtRange(...).Attach(...).
+//				Build()
+//
+// The text is the only required field. Calling other methods is optional.
+//
+// The input text is expected to be valid UTF-8. Invalid UTF-8 will lead to
+// an error later in [TextSnippetBuilder.Build].
+//
+// Precondition: text must be non-empty.
+func NewTextSnippet(text string) *TextSnippetBuilder {
+	if text == "" {
+		assert.Precondition(false, "diag.NewTextSnippet: text parameter must be non-empty")
+	}
+	return &TextSnippetBuilder{
+		text:      text,
+		location:  None[errorx.Phrase](),
+		startLine: None[int](),
+		labels:    nil,
+	}
+}
+
+// WithLocation describes where the snippet was sourced from.
+//
+// Examples of potential values:
+//   - A file path.
+//   - "standard input"
+//   - "<command line argument #1>".
+//   - "the MYAPP_HEALTHZ_INTERVAL environment variable"
+//
+// Precondition: location must be non-empty, and must not already be set on
+// the receiver.
+func (b *TextSnippetBuilder) WithLocation(location errorx.Phrase) *TextSnippetBuilder {
+	assert.Precondition(!location.IsEmpty(), "snippet location should be non-empty")
+	assert.Precondition(b.location.IsNone(), "snippet location already set")
+	b.location = Some(location)
+	return b
+}
+
+// WithStartLine sets the 1-based original source line corresponding to the
+// first line of the snippet.
+//
+// Precondition: startLine must be positive, and must not already be set on the
+// receiver.
+func (b *TextSnippetBuilder) WithStartLine(startLine int) *TextSnippetBuilder {
+	if startLine <= 0 {
+		assert.Preconditionf(false, "startLine parameter (%d) must be >= 1", startLine)
+	}
+	assert.Precondition(b.startLine.IsNone(), "snippet start line already set")
+	b.startLine = Some(startLine)
+	return b
+}
+
+// AtRange creates a temporary struct for attaching a label to a snippet
+// for the given half-open byte range [startByte, startByte+byteLen).
+//
+// For example, to label `foo()` in the text `x := foo()`:
+//
+//	|x| |:|=| |f|o|o|(|)|
+//	0 1 2 3 4 5 6 7 8 9 10
+//
+// pass startByte == 5 and byteLen == 5. The end offset is therefore
+// startByte + byteLen == 10, which may equal len(Text()).
+//
+// Preconditions:
+// - startByte ∈ [0, len(s.Text()))
+// - byteLen > 0
+// - startByte + byteLen ∈ [startByte + 1, len(s.Text())]
+//
+// If these preconditions are not upheld, AtRange will panic.
+func (b *TextSnippetBuilder) AtRange(startByte, byteLen int) LabelAttacher {
+	span := checkedLabelSpan(b.text, startByte, startByte+byteLen, false)
+	return LabelAttacher{src: b, span: span}
+}
+
+// AtPos creates a temporary struct for attaching a zero-width label to a
+// snippet at the given byte position.
+//
+// The position may be len(Text()), which is useful for diagnostics about a
+// missing token at the end of the snippet. For example, in `x := foo()`:
+//
+//	|x| |:|=| |f|o|o|(|)|
+//	0 1 2 3 4 5 6 7 8 9 10
+//
+// passing bytePos == 10 points just after the ')'.
+//
+// Precondition: bytePos ∈ [0, len(s.Text())]
+//
+// If this precondition is not upheld, AtPos will panic.
+func (b *TextSnippetBuilder) AtPos(bytePos int) LabelAttacher {
+	span := checkedLabelSpan(b.text, bytePos, bytePos, true)
+	return LabelAttacher{src: b, span: span}
+}
+
+// Build attempts to construct a TextSnippet from a TextSnippetBuilder.
+//
+// If there are any errors, those are recorded in the returned *SnippetError.
+// Some kinds of errors that can happen:
+//
+//   - The snippet text was invalid UTF-8. In this case, interpreting byte
+//     offsets correctly is tricky, so no TextSnippet is returned.
+//     The corresponding SnippetError visualizes the invalid bytes.
+//   - Label offsets pointing to the middle of a codepoint or a grapheme cluster.
+//     This is handled by dropping the label, and returning a TextSnippet,
+//     along with a non-nil SnippetError.
+//
+// SnippetError also implements Diagnostic, so that can be printed alongside/after
+// the primary Diagnostic which contains the built TextSnippet. See the methods
+// on SnippetError for more details.
+func (b *TextSnippetBuilder) Build() result.Partial[TextSnippet, SnippetError] {
+	text := b.text
+	var problems []snippetProblem
+	if invalidSpan, ok := utf8.FirstInvalidSpan(text).Get(); ok {
+		problems = append(problems, newInvalidUTF8SnippetProblem(invalidSpan))
+		return result.NewPartial(None[TextSnippet](), &SnippetError{text, problems, captureSnippetCallSite()})
+	}
+
+	segmentedText := uniseg.NewSegmentedText(text)
+	labels := make([]LabeledSpan, 0, len(b.labels))
+	for _, label := range b.labels {
+		if err := segmentedText.CheckSpan(label.span); err != nil {
+			problems = append(problems, newBoundarySnippetProblem(label.msg, err))
+			continue
+		}
+		labels = append(labels, LabeledSpan{SourceSpan{label.span}, label.msg, label.options})
+	}
+
+	snippet := TextSnippet{
+		text:      text,
+		location:  b.location,
+		startLine: b.startLine,
+		labels:    labels,
+	}
+	var err *SnippetError = nil
+	if len(problems) != 0 {
+		err = &SnippetError{text, problems, captureSnippetCallSite()}
+	}
+	return result.NewPartial(Some(snippet), err)
+}
+
+// LabelAttacher is an intermediate struct to offer a more natural API
+// for TextSnippet construction.
+type LabelAttacher struct {
+	src  *TextSnippetBuilder
+	span ranges.Span[int]
+}
+
+// Attach appends a label for the span selected by [TextSnippetBuilder.AtRange]
+// or [TextSnippetBuilder.AtPos], then returns the underlying builder.
+//
+// The variadic list of edits allows customizing the label.
+//
+// Precondition: label must be non-empty.
+func (a LabelAttacher) Attach(label errorx.Phrase, edits ...LabelEdit) *TextSnippetBuilder {
+	if label.IsEmpty() {
+		assert.Precondition(false, "label should be non-empty")
+	}
+	options := LabelOptions{isEmphasized: false}
+	for _, edit := range edits {
+		options.Apply(edit)
+	}
+	a.src.labels = append(a.src.labels, snippetBuilderLabel{span: a.span, msg: label, options: options})
+	return a.src
+}
+
+// SnippetError reports invalid snippet construction discovered by
+// [TextSnippetBuilder.Build].
+type SnippetError struct {
+	// Original snippet text passed to NewTextSnippet. May be invalid UTF-8.
+	text string
+	// List of issues found by TextSnippetBuilder.Build.
+	//
+	// Always non-empty.
+	problems []snippetProblem
+	// Best-effort source location of the Build call which triggered
+	// creation of this SnippetError
+	callSite Option[snippetCallSite]
+}
+
+var _ Diagnostic = (*SnippetError)(nil)
+
+func (e *SnippetError) Error() string { return e.Message() }
+
+func (e *SnippetError) Severity() Severity       { return Severity_Warning }
+func (e *SnippetError) Attribution() Attribution { return Attribution_Internal }
+func (e *SnippetError) Message() string {
+	if len(e.problems) == 1 {
+		return e.problems[0].message()
+	}
+	return "Invalid source snippet"
+}
+func (e *SnippetError) Snippets() iter.Seq[Snippet] {
+	return func(yield func(Snippet) bool) {
+		for _, problem := range e.problems {
+			if snippet, ok := e.problemSnippet(problem).Get(); ok {
+				if !yield(snippet) {
+					return
+				}
+			}
+		}
+	}
+}
+func (e *SnippetError) Notes() iter.Seq[Note] {
+	return iterx.Once(NewNote(NoteKind_Context, "this may be a bug in the program constructing this diagnostic"))
+}
+
+func (e *SnippetError) problemSnippet(problem snippetProblem) Option[TextSnippet] {
+	switch problem.kind {
+	case snippetProblemKind_InvalidUTF8:
+		data := problem.invalidUTF8Data.Expect("invalid UTF-8 snippet problem should have data")
+		return byteRangeSnippet(e.text, data.span, replacementLabel(data.span), e.callSite)
+	case snippetProblemKind_SpanNotUTF8Boundary:
+		data := problem.boundaryData.Expect("UTF-8 boundary snippet problem should have data")
+		offset := data.byteOffset()
+		return codePointOffsetSnippet(e.text, offset, spanBoundLabel(data.bound, offset), e.callSite)
+	case snippetProblemKind_SpanNotGraphemeBoundary:
+		data := problem.boundaryData.Expect("grapheme boundary snippet problem should have data")
+		offset := data.byteOffset()
+		return graphemeOffsetSnippet(e.text, data.containing, offset, spanBoundLabel(data.bound, offset), e.callSite)
+	default:
+		assert.PanicUnknownCase[any](problem.kind)
+	}
+	return None[TextSnippet]()
+}
+
+// snippetProblem represents an error discovered during snippet building.
+type snippetProblem struct {
+	kind snippetProblemKind
+	// Some iff kind is snippetProblemKind_InvalidUTF8.
+	invalidUTF8Data Option[snippetInvalidUTF8Data]
+	// Some iff kind is one of the boundary problem kinds.
+	boundaryData Option[snippetBoundaryData]
+}
+
+type snippetProblemKind uint8
+
+const (
+	snippetProblemKind_InvalidUTF8 snippetProblemKind = iota + 1
+	snippetProblemKind_SpanNotUTF8Boundary
+	snippetProblemKind_SpanNotGraphemeBoundary
+)
+
+type snippetInvalidUTF8Data struct {
+	// The bad Span which led to this error.
+	span ranges.Span[int]
+}
+
+type snippetBoundaryData struct {
+	// The label attached to the bad Span.
+	label errorx.Phrase
+	// The bad Span which led to this error.
+	span ranges.Span[int]
+	// The edge of span which led to this error.
+	bound ranges.Bound
+	// containing is optionally a larger Span than span.
+	// E.g. if the boundary error corresponds to a bound
+	// (start or end) within a grapheme cluster, then containing
+	// is the Span for that grapheme cluster.
+	containing Option[ranges.Span[int]]
+}
+
+// snippetCallSite identifies the source location of the call that produced a
+// snippet construction error.
+type snippetCallSite struct {
+	file fsx_name.Name
+	line int
+}
+
+// LabeledSpan is the pairing of a SourceSpan and an associated label.
+type LabeledSpan struct {
+	span    SourceSpan
+	msg     errorx.Phrase
+	options LabelOptions
+}
+
+func (l LabeledSpan) Span() SourceSpan      { return l.span }
+func (l LabeledSpan) Msg() errorx.Phrase    { return l.msg }
+func (l LabeledSpan) Options() LabelOptions { return l.options }
+
+type LabelOptions struct {
+	isEmphasized bool
+}
+
+func (o *LabelOptions) IsEmphasized() bool { return o.isEmphasized }
+
+func (o *LabelOptions) Apply(edit LabelEdit) {
+	if val, ok := edit.Emphasize.Get(); ok {
+		o.isEmphasized = val
+	}
+}
+
+type LabelEdit struct {
+	Emphasize Option[bool]
+}
+
+func Emphasize() LabelEdit {
+	return LabelEdit{Emphasize: Some(true)}
+}
+
+// SourceSpan represents a byte range of a [TextSnippet.Text].
+type SourceSpan struct {
+	span ranges.Span[int]
+}
+
+func (s SourceSpan) StartByte() int { return s.span.Start() }
+
+// ByteLen returns the non-negative length of this SourceSpan.
+//
+// The zero case can happen for spans created using TextSnippetBuilder.AtPos.
+func (s SourceSpan) ByteLen() int {
+	return s.span.Length().Expect("overflow checking happens during construction; so value should be in-bounds")
+}
+
+func (s SourceSpan) EndByte() int { return s.span.End() }
+
+func (s SourceSpan) CompareStrict(other SourceSpan) int {
+	return s.span.CompareStrict(other.span)
+}
+
+func newSnippetProblem(kind snippetProblemKind) snippetProblem {
+	return snippetProblem{kind, None[snippetInvalidUTF8Data](), None[snippetBoundaryData]()}
+}
+
+func newInvalidUTF8SnippetProblem(span ranges.Span[int]) snippetProblem {
+	problem := newSnippetProblem(snippetProblemKind_InvalidUTF8)
+	problem.invalidUTF8Data = Some(snippetInvalidUTF8Data{span})
+	return problem
+}
+
+func newBoundarySnippetProblem(label errorx.Phrase, err *uniseg.SpanBoundaryError) snippetProblem {
+	var kind snippetProblemKind
+	switch err.Kind() {
+	case uniseg.SpanBoundaryErrorKind_NotUTF8Boundary:
+		kind = snippetProblemKind_SpanNotUTF8Boundary
+	case uniseg.SpanBoundaryErrorKind_NotGraphemeBoundary:
+		kind = snippetProblemKind_SpanNotGraphemeBoundary
+	default:
+		assert.PanicUnknownCase[any](err.Kind())
+	}
+	problem := newSnippetProblem(kind)
+	problem.boundaryData = Some(snippetBoundaryData{label, err.Span(), err.Bound(), err.ContainingGraphemeCluster()})
+	return problem
+}
+
+func (d snippetBoundaryData) byteOffset() int {
+	switch d.bound {
+	case ranges.Bound_Start:
+		return d.span.Start()
+	case ranges.Bound_End:
+		return d.span.End()
+	default:
+		return assert.PanicUnknownCase[int](d.bound)
+	}
+}
+
+func (p snippetProblem) message() string {
+	switch p.kind {
+	case snippetProblemKind_InvalidUTF8:
+		return "Invalid UTF-8; replacing invalid bytes with U+FFFD"
+	case snippetProblemKind_SpanNotUTF8Boundary:
+		return fmt.Sprintf("Label span %s inside a UTF-8 codepoint; dropping label %q", p.boundVerb(), p.labelText())
+	case snippetProblemKind_SpanNotGraphemeBoundary:
+		return fmt.Sprintf("Label span %s inside a grapheme cluster; dropping label %q", p.boundVerb(), p.labelText())
+	default:
+		return assert.PanicUnknownCase[string](p.kind)
+	}
+}
+
+func (p snippetProblem) labelText() string {
+	data := p.boundaryData.Expect("snippet boundary problem should have data")
+	text, ok := data.label.Get()
+	assert.Invariant(ok, "snippet boundary problem should have label text")
+	return text
+}
+
+func (p snippetProblem) boundVerb() string {
+	bound := p.boundaryData.Expect("snippet boundary problem should have data").bound
+	switch bound {
+	case ranges.Bound_Start:
+		return "starts"
+	case ranges.Bound_End:
+		return "ends"
+	default:
+		return assert.PanicUnknownCase[string](bound)
+	}
+}
+
+// checkedLabelSpan constructs a label span after checking byte-range bounds.
+//
+// Preconditions:
+// - start ∈ [0, len(text)]
+// - end ∈ [start, len(text)]
+// - if allowEmpty is false, start < end
+func checkedLabelSpan(text string, start int, end int, allowEmpty bool) ranges.Span[int] {
+	if end < start {
+		assert.Preconditionf(false, "label span end %d before start %d", end, start)
+	}
+	if start < 0 {
+		assert.Preconditionf(false, "label span start %d before 0", start)
+	}
+	if len(text) < start {
+		assert.Preconditionf(false, "label span start %d after snippet end %d", start, len(text))
+	}
+	if len(text) < end {
+		assert.Preconditionf(false, "label span end %d after snippet end %d", end, len(text))
+	}
+	span := ranges.NewSpan(start, end)
+	if !allowEmpty && span.IsEmpty() {
+		assert.Precondition(false, "label range should be non-empty")
+	}
+	return span
+}
+
+func byteRangeSnippet(text string, span ranges.Span[int], label string, callSite Option[snippetCallSite]) Option[TextSnippet] {
+	return byteVisualizationSnippet(text, span.Start(), span.End(), callSite, []byteVisualizationLabel{{
+		span:         span,
+		label:        label,
+		isEmphasized: true,
+	}})
+}
+
+func byteOffsetSnippet(text string, offset int, label string, callSite Option[snippetCallSite]) Option[TextSnippet] {
+	end := offset + 1
+	if len(text) < end {
+		end = offset
+	}
+	return byteRangeSnippet(text, ranges.NewSpan(offset, end), label, callSite)
+}
+
+func codePointOffsetSnippet(text string, offset int, label string, callSite Option[snippetCallSite]) Option[TextSnippet] {
+	codePoint, ok := utf8.CodePointContaining(text, offset).Get()
+	if !ok {
+		return byteOffsetSnippet(text, offset, label, callSite)
+	}
+	end := offset + 1
+	if len(text) < end {
+		end = offset
+	}
+	return byteVisualizationSnippet(text, codePoint.Start(), codePoint.End(), callSite, []byteVisualizationLabel{
+		{span: codePoint, label: fmt.Sprintf("codepoint %q", text[codePoint.Start():codePoint.End()]), isEmphasized: false},
+		{span: ranges.NewSpan(offset, end), label: label, isEmphasized: true},
+	})
+}
+
+func graphemeOffsetSnippet(text string, containing Option[ranges.Span[int]], offset int, label string, callSite Option[snippetCallSite]) Option[TextSnippet] {
+	cluster, ok := containing.Get()
+	if !ok {
+		return byteOffsetSnippet(text, offset, label, callSite)
+	}
+	end := offset + 1
+	if len(text) < end {
+		end = offset
+	}
+	return byteVisualizationSnippet(text, cluster.Start(), cluster.End(), callSite, []byteVisualizationLabel{
+		{span: cluster, label: fmt.Sprintf("grapheme cluster \"%s\"", text[cluster.Start():cluster.End()]), isEmphasized: false},
+		{span: ranges.NewSpan(offset, end), label: label, isEmphasized: true},
+	})
+}
+
+type byteVisualizationLabel struct {
+	span         ranges.Span[int]
+	label        string
+	isEmphasized bool
+}
+
+type byteVisualization struct {
+	text       string
+	starts     []int
+	ends       []int
+	sourceBase int
+}
+
+func byteVisualizationSnippet(text string, focusStart int, focusEnd int, callSite Option[snippetCallSite], labels []byteVisualizationLabel) Option[TextSnippet] {
+	viz := newByteVisualization(text, focusStart, focusEnd)
+	snippetLabels := make([]LabeledSpan, 0, len(labels))
+	for _, label := range labels {
+		start := viz.position(label.span.Start())
+		end := viz.endPosition(label.span.End() - 1)
+		if start == end {
+			continue
+		}
+		snippetLabels = append(snippetLabels, LabeledSpan{
+			span:    SourceSpan{span: ranges.NewSpan(start, end)},
+			msg:     errorx.NewPhrase(label.label),
+			options: LabelOptions{isEmphasized: label.isEmphasized},
+		})
+	}
+	if len(snippetLabels) == 0 {
+		return None[TextSnippet]()
+	}
+	return Some(TextSnippet{
+		text:      viz.text,
+		location:  Some(snippetTextLocation(callSite)),
+		startLine: None[int](),
+		labels:    snippetLabels,
+	})
+}
+
+func newByteVisualization(text string, start int, end int) byteVisualization {
+	const contextBytes = 3
+	lo := max(0, start-contextBytes)
+	hi := min(len(text), end+contextBytes)
+
+	var b strings.Builder
+	starts := make([]int, hi-lo)
+	ends := make([]int, hi-lo)
+	if lo > 0 {
+		b.WriteString("..., ")
+	}
+	for i := lo; i < hi; i++ {
+		if i > lo {
+			b.WriteString(", ")
+		}
+		starts[i-lo] = b.Len()
+		b.WriteString(byteToken(text[i]))
+		ends[i-lo] = b.Len()
+	}
+	if hi < len(text) {
+		b.WriteString(", ...")
+	}
+	return byteVisualization{text: b.String(), starts: starts, ends: ends, sourceBase: lo}
+}
+
+func (v byteVisualization) position(sourceOffset int) int {
+	return v.starts[sourceOffset-v.sourceBase]
+}
+
+func (v byteVisualization) endPosition(sourceOffset int) int {
+	return v.ends[sourceOffset-v.sourceBase]
+}
+
+func replacementLabel(span ranges.Span[int]) string {
+	if span.End() == span.Start()+1 {
+		return fmt.Sprintf("replacing index %d", span.Start())
+	}
+	return fmt.Sprintf("replacing indexes %d-%d", span.Start(), span.End()-1)
+}
+
+func byteToken(b byte) string {
+	if 0x20 <= b && b <= 0x7e && b != '\'' && b != '\\' {
+		return fmt.Sprintf("'%c' (0x%02x)", b, b)
+	}
+	return fmt.Sprintf("0x%02X", b)
+}
+
+// spanBoundLabel returns the label denoting a [Start n | End n] value.
+func spanBoundLabel(bound ranges.Bound, offset int) string {
+	switch bound {
+	case ranges.Bound_Start:
+		return fmt.Sprintf("label.span.start = %d", offset)
+	case ranges.Bound_End:
+		return fmt.Sprintf("label.span.end = %d", offset)
+	default:
+		return assert.PanicUnknownCase[string](bound)
+	}
+}
+
+func snippetTextLocation(callSite Option[snippetCallSite]) errorx.Phrase {
+	if callSite, ok := callSite.Get(); ok {
+		return errorx.NewPhrase(fmt.Sprintf("snippet text (for TextSnippetBuilder.Build at %s:%d)", callSite.file.String(), callSite.line))
+	}
+	return errorx.NewPhrase("snippet text")
+}
+
+func captureSnippetCallSite() Option[snippetCallSite] {
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		return None[snippetCallSite]()
+	}
+	return Some(snippetCallSite{file: fsx_name.New(filepath.Base(file)), line: line})
+}

--- a/base/errorx/phrase.go
+++ b/base/errorx/phrase.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package errorx
+
+import (
+	"strings"
+
+	"code.kibou.tools/base/assert"
+)
+
+// Phrase is a short human-readable string used as a fragment of a
+// single-line error message.
+//
+// A valid Phrase must be non-empty and not contain newlines,
+// so that it can be substituted into single-line messages
+// without disturbing the surrounding layout.
+//
+// Usage guidelines:
+//   - As a parameter type: If a Phrase is passed as a parameter, it
+//     is expected to be non-empty. For passing optional values,
+//     parameter types should use Option[Phrase].
+//   - As a field type: A struct may store a zero-value Phrase to
+//     indicate the absence of one (to save on space). Such a field
+//     should not be exported. Exported fields of type Phrase can be
+//     assumed to be non-empty.
+type Phrase struct {
+	s string
+}
+
+// NewPhrase constructs a new Phrase from s.
+//
+// Pre-condition: s is non-empty and contains no newlines.
+func NewPhrase(s string) Phrase {
+	assert.Precondition(s != "", "empty Phrase")
+	if strings.IndexByte(s, '\n') >= 0 {
+		assert.Precondition(false, "Phrase contains newline")
+	}
+	return Phrase{s: s}
+}
+
+// Get returns the underlying text and whether the Phrase is non-empty.
+func (p Phrase) Get() (text string, present bool) {
+	return p.s, p.s != ""
+}
+
+// IsEmpty reports whether p is the zero (absent) Phrase.
+func (p Phrase) IsEmpty() bool {
+	return p.s == ""
+}

--- a/base/iterx/iterx.go
+++ b/base/iterx/iterx.go
@@ -17,6 +17,13 @@ func Empty[T any]() iter.Seq[T] {
 	return func(func(T) bool) {}
 }
 
+// Once returns an iterator which yields value once.
+func Once[T any](value T) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		_ = yield(value)
+	}
+}
+
 // FromSlice yields the elements of slice in order.
 func FromSlice[S ~[]T, T any](slice S) iter.Seq[T] {
 	return func(yield func(T) bool) {


### PR DESCRIPTION
Introduces a Diagnostic interface which allows reporting
errors with more details such as source code snippets
and notes.

For example, for file format parsing, we want all logic
to consistently be able to report issues with line numbers,
highlight snippets in source code etc. So JSON parsing,
YAML parsing, etc. should all report errors through a
shared interface.

Applications may optionally use the CodedDiagnostic
interface to attach application-specific error codes
to errors.

For more details, see the associated Design.djot file.

In follow-up PRs, I'll introduce the rendering logic.