### PR TITLE
feat(base): Introduce a utf8 package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,6 +108,15 @@ linters:
           deny:
             - pkg: "github.com/rivo/uniseg$"
               desc: "use base/internal/uniseg instead of importing rivo/uniseg directly"
+        NoStdlibUTF8:
+          files:
+            - "base/**/*.go"
+            - "misc/**/*.go"
+            - "!**/base/utf8/*.go"
+          list-mode: lax
+          deny:
+            - pkg: "unicode/utf8$"
+              desc: "use base/utf8 instead of unicode/utf8 directly"
     importas:
       no-unaliased: true
       alias:

--- a/base/check/benchmark/benchmark.go
+++ b/base/check/benchmark/benchmark.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package benchmark
+
+import "runtime"
+
+// BlackHole acts as an optimization barrier for benchmark results.
+//
+//go:noinline
+func BlackHole[T any](v T) {
+	runtime.KeepAlive(v)
+}

--- a/base/internal/uniseg/uniseg.go
+++ b/base/internal/uniseg/uniseg.go
@@ -6,7 +6,6 @@ package uniseg
 
 import (
 	"iter"
-	"unicode/utf8"
 
 	"code.kibou.tools/base/assert"
 	rivouniseg "github.com/rivo/uniseg"
@@ -14,6 +13,7 @@ import (
 	"code.kibou.tools/base/collections"
 	"code.kibou.tools/base/core/option"
 	"code.kibou.tools/base/ranges"
+	"code.kibou.tools/base/utf8"
 )
 
 // SegmentedText stores text together with its grapheme cluster boundaries.
@@ -43,10 +43,10 @@ func NewSegmentedText(text string) SegmentedText {
 func (t *SegmentedText) CheckSpan(span ranges.Span[int]) *SpanBoundaryError {
 	start := span.Start()
 	end := span.End()
-	if start != len(t.text) && !utf8.RuneStart(t.text[start]) {
+	if start != len(t.text) && !utf8.IsPotentialStartOfRune(t.text[start]) {
 		return &SpanBoundaryError{SpanBoundaryErrorKind_NotUTF8Boundary, ranges.Bound_Start, span, option.None[ranges.Span[int]]()}
 	}
-	if end != len(t.text) && !utf8.RuneStart(t.text[end]) {
+	if end != len(t.text) && !utf8.IsPotentialStartOfRune(t.text[end]) {
 		return &SpanBoundaryError{SpanBoundaryErrorKind_NotUTF8Boundary, ranges.Bound_End, span, option.None[ranges.Span[int]]()}
 	}
 	if !t.boundaries.Get(start) {

--- a/base/utf8/text.go
+++ b/base/utf8/text.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package utf8
+
+import (
+	"strconv"
+	"strings"
+	stdutf8 "unicode/utf8"
+
+	"code.kibou.tools/base/assert"
+	. "code.kibou.tools/base/core/option"
+	"code.kibou.tools/base/ranges"
+)
+
+// Text is a string known to contain valid UTF-8.
+type Text struct {
+	text string
+}
+
+// ParseText validates s as UTF-8 text.
+func ParseText(s string) (Text, *TextParseError) {
+	if span, ok := firstInvalidSpan(s).Get(); ok {
+		firstInvalidBytes := invalidBytesPrefix(s, span)
+		length := span.Length().Unwrap()
+		return Text{}, NewTextParseError(len(s), span, firstInvalidBytes[:length])
+	}
+	return Text{text: s}, nil
+}
+
+// MustParseText validates s as UTF-8 text and panics if validation fails.
+func MustParseText(s string) Text {
+	text, err := ParseText(s)
+	if err != nil {
+		assert.Preconditionf(false, "%v", err)
+	}
+	return text
+}
+
+// String returns the underlying valid UTF-8 string.
+func (t Text) String() string {
+	return t.text
+}
+
+// CodePointContaining returns the byte span of the UTF-8 codepoint containing
+// offset, if offset lies strictly inside a codepoint.
+//
+// If offset already lies on a codepoint boundary, the result is None.
+//
+// Precondition: offset ∈ [0, len(t.String())].
+func (t Text) CodePointContaining(offset int) Option[ranges.Span[int]] {
+	text := t.text
+	if offset < 0 || len(text) < offset {
+		assert.Preconditionf(false, "offset %d outside text bounds [0, %d]", offset, len(text))
+	}
+	if offset == 0 || offset == len(text) {
+		return None[ranges.Span[int]]()
+	}
+
+	start := offset - 1
+	for start >= 0 && !IsPotentialStartOfRune(text[start]) {
+		start--
+	}
+	if start < 0 {
+		return None[ranges.Span[int]]()
+	}
+
+	decoded := TryDecodeFirstRune(text[start:])
+	end := start + decoded.ByteLen()
+	if start < offset && offset < end {
+		return Some(ranges.NewSpan(start, end))
+	}
+	return None[ranges.Span[int]]()
+}
+
+// TextParseError reports invalid UTF-8 found while parsing a Text.
+type TextParseError struct {
+	// firstInvalidSpan is the first non-empty byte span at which UTF-8
+	// parsing fails, after a valid UTF-8 prefix of the input.
+	//
+	// Length() ∈ [1, 4].
+	//
+	// The bytes in this span are one of:
+	//
+	// - A malformed UTF-8 sequence: the bytes are not a valid UTF-8 encoding,
+	//   and cannot be extended to one;
+	// - A truncated UTF-8 sequence: the bytes are a proper prefix of a valid
+	//   UTF-8 encoding, but the input ended.
+	firstInvalidSpan ranges.Span[int]
+	// firstInvalidBytes stores the first firstInvalidSpan.Length() bytes from
+	// firstInvalidSpan. Remaining entries are zero and ignored.
+	firstInvalidBytes [4]byte
+}
+
+// NewTextParseError constructs a TextParseError from the first UTF-8 parse
+// failure in an input of length inputLen.
+//
+// Preconditions:
+//   - firstInvalidSpan is within [0, inputLen]
+//   - len(invalidUTF8) ∈ [1, 4]
+//   - len(invalidUTF8) == firstInvalidSpan.Length()
+//   - invalidUTF8 is either malformed UTF-8, or is truncated UTF-8 ending
+//     at inputLen
+func NewTextParseError(inputLen int, firstInvalidSpan ranges.Span[int], invalidUTF8 []byte) *TextParseError {
+	start := firstInvalidSpan.Start()
+	if start < 0 {
+		assert.Preconditionf(false, "invalid UTF-8 span start %d before 0", start)
+	}
+	end := firstInvalidSpan.End()
+	if inputLen < end {
+		assert.Preconditionf(false, "invalid UTF-8 span end %d after input length %d", end, inputLen)
+	}
+	// start >= 0 => Length() cannot overflow
+	length := firstInvalidSpan.Length().Unwrap()
+	if len(invalidUTF8) != length {
+		assert.Preconditionf(false, "invalid byte prefix length %d; expected span length %d", len(invalidUTF8), length)
+	}
+	if len(invalidUTF8) < 1 || 4 < len(invalidUTF8) {
+		assert.Preconditionf(false, "invalid byte prefix length %d outside [1, 4]", len(invalidUTF8))
+	}
+	if !stdutf8.FullRune(invalidUTF8) && end != inputLen {
+		assert.Preconditionf(false, "truncated UTF-8 span end %d before input length %d", end, inputLen)
+	}
+	var storedBytes [4]byte
+	copy(storedBytes[:], invalidUTF8)
+	return &TextParseError{firstInvalidSpan: firstInvalidSpan, firstInvalidBytes: storedBytes}
+}
+
+// FirstInvalidSpan returns the first span of consecutive invalid UTF-8 bytes.
+func (e *TextParseError) FirstInvalidSpan() ranges.Span[int] {
+	return e.firstInvalidSpan
+}
+
+func (e *TextParseError) Error() string {
+	span := e.firstInvalidSpan
+	length := span.Length().Unwrap()
+
+	var b strings.Builder
+	b.Grow(maxTextParseErrorStringLen)
+	if length == 1 {
+		b.WriteString("invalid UTF-8 byte 0x")
+		writeInvalidBytesHex(&b, e.firstInvalidBytes, 1)
+		b.WriteString(" at byte offset ")
+		writeInt(&b, span.Start())
+		return b.String()
+	}
+
+	b.WriteString("invalid UTF-8 bytes ")
+	b.WriteString("0x")
+	writeInvalidBytesHex(&b, e.firstInvalidBytes, length)
+	b.WriteString(" at byte span [")
+	writeInt(&b, span.Start())
+	b.WriteString(", ")
+	writeInt(&b, span.End())
+	b.WriteByte(')')
+	return b.String()
+}
+
+const maxTextParseErrorStringLen = len("invalid UTF-8 bytes 0x") + 2*4 + len(" at byte span [") + 19 + len(", ") + 19 + len(")")
+
+func invalidBytesPrefix(s string, span ranges.Span[int]) [4]byte {
+	var prefix [4]byte
+	copy(prefix[:], s[span.Start():span.End()])
+	return prefix
+}
+
+// Precondition: length ∈ [0, len(bytes)].
+func writeInvalidBytesHex(b *strings.Builder, bytes [4]byte, length int) {
+	const hexDigits = "0123456789ABCDEF"
+	for i := range length {
+		value := bytes[i]
+		b.WriteByte(hexDigits[value>>4])
+		b.WriteByte(hexDigits[value&0x0f])
+	}
+}
+
+func writeInt(b *strings.Builder, n int) {
+	var buf [20]byte
+	b.Write(strconv.AppendInt(buf[:0], int64(n), 10))
+}

--- a/base/utf8/text_test.go
+++ b/base/utf8/text_test.go
@@ -1,0 +1,310 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package utf8_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	stdutf8 "unicode/utf8"
+
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/check"
+	"code.kibou.tools/base/check/benchmark"
+	"code.kibou.tools/base/ranges"
+	. "code.kibou.tools/base/utf8"
+)
+
+func TestText(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("ParseText", func(h check.Harness) {
+		h.Run("unit", testParseTextUnit)
+		h.Run("property", testParseTextProperty)
+	})
+	h.Run("MustParseText", testMustParseText)
+	h.Run("Text.CodePointContaining", func(h check.Harness) {
+		h.Run("unit", testCodePointContainingUnit)
+		h.Run("property", testCodePointContainingProperty)
+	})
+}
+
+func testParseTextUnit(h check.Harness) {
+	h.Parallel()
+
+	valid, err := ParseText("aé😀")
+	check.AssertSame(h, (*TextParseError)(nil), err, "valid text error")
+	check.AssertSame(h, "aé😀", valid.String(), "valid text String")
+
+	cases := []struct {
+		name    string
+		text    string
+		want    ranges.Span[int]
+		wantErr string
+	}{
+		{
+			name:    "single invalid byte",
+			text:    string([]byte{'a', 0xff, 'b'}),
+			want:    ranges.NewSpan(1, 2),
+			wantErr: "invalid UTF-8 byte 0xFF at byte offset 1",
+		},
+		{
+			name:    "unexpected continuation byte",
+			text:    string([]byte{0x80, 'x'}),
+			want:    ranges.NewSpan(0, 1),
+			wantErr: "invalid UTF-8 byte 0x80 at byte offset 0",
+		},
+		{
+			name:    "overlong lead byte",
+			text:    string([]byte{0xc0, 0x80}),
+			want:    ranges.NewSpan(0, 1),
+			wantErr: "invalid UTF-8 byte 0xC0 at byte offset 0",
+		},
+		{
+			name:    "bad second byte in two-byte sequence",
+			text:    string([]byte{0xc2, 'A'}),
+			want:    ranges.NewSpan(0, 2),
+			wantErr: "invalid UTF-8 bytes 0xC241 at byte span [0, 2)",
+		},
+		{
+			name:    "truncated two-byte sequence",
+			text:    string([]byte{0xc2}),
+			want:    ranges.NewSpan(0, 1),
+			wantErr: "invalid UTF-8 byte 0xC2 at byte offset 0",
+		},
+		{
+			name:    "truncated three-byte sequence after second byte",
+			text:    string([]byte{0xe2, 0x82}),
+			want:    ranges.NewSpan(0, 2),
+			wantErr: "invalid UTF-8 bytes 0xE282 at byte span [0, 2)",
+		},
+		{
+			name:    "overlong three-byte sequence",
+			text:    string([]byte{0xe0, 0x80, 0x80}),
+			want:    ranges.NewSpan(0, 2),
+			wantErr: "invalid UTF-8 bytes 0xE080 at byte span [0, 2)",
+		},
+		{
+			name:    "surrogate three-byte sequence",
+			text:    string([]byte{0xed, 0xa0, 0x80}),
+			want:    ranges.NewSpan(0, 2),
+			wantErr: "invalid UTF-8 bytes 0xEDA0 at byte span [0, 2)",
+		},
+		{
+			name:    "bad third byte in three-byte sequence",
+			text:    string([]byte{0xe2, 0x82, 'A'}),
+			want:    ranges.NewSpan(0, 3),
+			wantErr: "invalid UTF-8 bytes 0xE28241 at byte span [0, 3)",
+		},
+		{
+			name:    "bad third byte in EE-EF sequence",
+			text:    string([]byte{0xee, 0x80, 'A'}),
+			want:    ranges.NewSpan(0, 3),
+			wantErr: "invalid UTF-8 bytes 0xEE8041 at byte span [0, 3)",
+		},
+		{
+			name:    "bad second byte in four-byte sequence",
+			text:    string([]byte{0xf0, 0x80, 0x80, 0x80}),
+			want:    ranges.NewSpan(0, 2),
+			wantErr: "invalid UTF-8 bytes 0xF080 at byte span [0, 2)",
+		},
+		{
+			name:    "bad second byte in F1-F3 sequence",
+			text:    string([]byte{0xf1, 'A'}),
+			want:    ranges.NewSpan(0, 2),
+			wantErr: "invalid UTF-8 bytes 0xF141 at byte span [0, 2)",
+		},
+		{
+			name:    "bad second byte in F4 sequence",
+			text:    string([]byte{0xf4, 0x90, 0x80, 0x80}),
+			want:    ranges.NewSpan(0, 2),
+			wantErr: "invalid UTF-8 bytes 0xF490 at byte span [0, 2)",
+		},
+		{
+			name:    "truncated four-byte sequence after third byte",
+			text:    string([]byte{0xf0, 0x9f, 0x98}),
+			want:    ranges.NewSpan(0, 3),
+			wantErr: "invalid UTF-8 bytes 0xF09F98 at byte span [0, 3)",
+		},
+		{
+			name:    "bad third byte in four-byte sequence",
+			text:    string([]byte{0xf0, 0x9f, 'A'}),
+			want:    ranges.NewSpan(0, 3),
+			wantErr: "invalid UTF-8 bytes 0xF09F41 at byte span [0, 3)",
+		},
+		{
+			name:    "bad fourth byte in four-byte sequence",
+			text:    string([]byte{0xf0, 0x9f, 0x98, 'A'}),
+			want:    ranges.NewSpan(0, 4),
+			wantErr: "invalid UTF-8 bytes 0xF09F9841 at byte span [0, 4)",
+		},
+	}
+
+	for _, tc := range cases {
+		_, err := ParseText(tc.text)
+		h.Assertf(err != nil, "%s: expected parse error", tc.name)
+		check.AssertSame(h, 0, err.FirstInvalidSpan().CompareStrict(tc.want), tc.name+" first invalid span")
+		check.AssertSame(h, tc.wantErr, err.Error(), tc.name+" error")
+	}
+}
+
+func testParseTextProperty(h check.Harness) {
+	h.Parallel()
+
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		bytes := rapid.SliceOfN(rapid.Uint8(), 0, 64).Draw(t, "bytes")
+		text := string(bytes)
+
+		parsed, err := ParseText(text)
+		wantValid := stdutf8.ValidString(text)
+		check.AssertSame(h, wantValid, err == nil, "ParseText validity")
+		if wantValid {
+			check.AssertSame(h, text, parsed.String(), "parsed text")
+			return
+		}
+
+		h.Assertf(err != nil, "invalid UTF-8 should return a TextParseError")
+		span := err.FirstInvalidSpan()
+		length := span.Length().Unwrap()
+		h.Assertf(0 <= span.Start(), "span start %d before 0", span.Start())
+		h.Assertf(span.End() <= len(text), "span end %d after text length %d", span.End(), len(text))
+		h.Assertf(1 <= length && length <= 4, "span length %d outside [1, 4]", length)
+		check.AssertSame(h, true, stdutf8.ValidString(text[:span.Start()]), "prefix before invalid span is valid")
+		check.AssertSame(h, false, stdutf8.ValidString(text[:span.End()]), "prefix through invalid span is invalid")
+		h.Assertf(err.Error() != "", "error message should be non-empty")
+	})
+}
+
+func testMustParseText(h check.Harness) {
+	h.Parallel()
+
+	cases := []string{
+		"",
+		"ASCII",
+		"aé😀",
+		"\uFFFD",
+		"e\u0301",
+		"👩‍💻",
+		"界",
+		"नमस्ते",
+		"مرحبا",
+		"שלום",
+		"🏳️‍🌈",
+		"🇺🇳",
+	}
+	for _, tc := range cases {
+		text := MustParseText(tc)
+		check.AssertSame(h, tc, text.String(), "MustParseText String")
+	}
+}
+
+func testCodePointContainingUnit(h check.Harness) {
+	h.Parallel()
+
+	text := MustParseText("aé😀")
+	cases := []struct {
+		name string
+		off  int
+		want ranges.Span[int]
+		ok   bool
+	}{
+		{name: "start", off: 0, want: ranges.NewSpan(0, 0), ok: false},
+		{name: "between ASCII and two-byte", off: 1, want: ranges.NewSpan(0, 0), ok: false},
+		{name: "inside two-byte", off: 2, want: ranges.NewSpan(1, 3), ok: true},
+		{name: "between two-byte and four-byte", off: 3, want: ranges.NewSpan(0, 0), ok: false},
+		{name: "inside four-byte first continuation", off: 4, want: ranges.NewSpan(3, 7), ok: true},
+		{name: "inside four-byte second continuation", off: 5, want: ranges.NewSpan(3, 7), ok: true},
+		{name: "inside four-byte third continuation", off: 6, want: ranges.NewSpan(3, 7), ok: true},
+		{name: "end", off: 7, want: ranges.NewSpan(0, 0), ok: false},
+	}
+
+	for _, tc := range cases {
+		got, ok := text.CodePointContaining(tc.off).Get()
+		check.AssertSame(h, tc.ok, ok, tc.name+" present")
+		if ok {
+			check.AssertSame(h, 0, got.CompareStrict(tc.want), tc.name+" span")
+		}
+	}
+
+	h.AssertPanicsWith(
+		assert.AssertionError{Fmt: "precondition violation: offset %d outside text bounds [0, %d]", Args: []any{-1, 7}},
+		func() { _ = text.CodePointContaining(-1) },
+	)
+	h.AssertPanicsWith(
+		assert.AssertionError{Fmt: "precondition violation: offset %d outside text bounds [0, %d]", Args: []any{8, 7}},
+		func() { _ = text.CodePointContaining(8) },
+	)
+}
+
+func testCodePointContainingProperty(h check.Harness) {
+	h.Parallel()
+
+	partsGen := rapid.SliceOfN(rapid.SampledFrom([]string{"", "a", "é", "😀", "\u0301", "\uFFFD", "👩‍💻"}), 0, 40)
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		parts := partsGen.Draw(t, "parts")
+		text := strings.Join(parts, "")
+		parsed := MustParseText(text)
+
+		for offset := 0; offset <= len(text); offset++ {
+			want := ranges.NewSpan(0, 0)
+			wantOK := false
+			for start, r := range text {
+				end := start + stdutf8.RuneLen(r)
+				if start < offset && offset < end {
+					want = ranges.NewSpan(start, end)
+					wantOK = true
+					break
+				}
+			}
+
+			got, gotOK := parsed.CodePointContaining(offset).Get()
+			check.AssertSame(h, wantOK, gotOK, "presence")
+			if gotOK {
+				check.AssertSame(h, 0, got.CompareStrict(want), "span")
+			}
+		}
+	})
+}
+
+func BenchmarkParseTextVsStdlibValidString(b *testing.B) {
+	for _, charCount := range []int{10, 100, 1000, 10000} {
+		input := validUTF8TextWithCharCount(charCount)
+		name := "chars=" + strconv.Itoa(charCount)
+
+		b.Run(name+"/ParseText", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				text, err := ParseText(input)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmark.BlackHole(text)
+			}
+		})
+
+		b.Run(name+"/stdlib.ValidString", func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				valid := stdutf8.ValidString(input)
+				benchmark.BlackHole(valid)
+			}
+		})
+	}
+}
+
+func validUTF8TextWithCharCount(charCount int) string {
+	pattern := []rune{'a', 'é', '😀', '界'}
+	var b strings.Builder
+	b.Grow(charCount * 4)
+	for i := 0; i < charCount; i++ {
+		b.WriteRune(pattern[i%len(pattern)])
+	}
+	return b.String()
+}

--- a/base/utf8/utf8.go
+++ b/base/utf8/utf8.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package utf8 provides UTF-8 helpers used by Kibou code.
+package utf8
+
+import (
+	stdutf8 "unicode/utf8"
+
+	"code.kibou.tools/base/assert"
+	. "code.kibou.tools/base/core/option"
+	"code.kibou.tools/base/ranges"
+)
+
+// ReplacementChar is the Unicode replacement character.
+const ReplacementChar = stdutf8.RuneError
+
+// TryDecodeFirstRune tries to decode the first rune in s.
+//
+// The result kind is:
+//   - RuneDecodingResultKind_Valid if s starts with a valid UTF-8 encoding.
+//   - RuneDecodingResultKind_Invalid if s starts with invalid UTF-8.
+//   - RuneDecodingResultKind_Empty if s is empty.
+func TryDecodeFirstRune(s string) RuneDecodingResult {
+	r, size := stdutf8.DecodeRuneInString(s)
+	return RuneDecodingResult{r: r, byteLen: uint8(size)}
+}
+
+// RuneDecodingResult is the result of trying to decode a rune.
+//
+// This is logically a union of the form:
+//
+//	  Valid { byteLen int, r rune } (byteLen ∈ [1, 4])
+//	| Invalid { byteLen int = 1 }
+//	| Empty { byteLen int = 0 }
+type RuneDecodingResult struct {
+	r       rune
+	byteLen uint8
+}
+
+type RuneDecodingResultKind uint8
+
+const (
+	RuneDecodingResultKind_Valid RuneDecodingResultKind = iota + 1
+	RuneDecodingResultKind_Invalid
+	RuneDecodingResultKind_Empty
+)
+
+// Rune returns the decoded rune.
+//
+// Precondition: Kind() == RuneDecodingResultKind_Valid.
+func (r RuneDecodingResult) Rune() rune {
+	if r.Kind() != RuneDecodingResultKind_Valid {
+		assert.Precondition(false, "RuneDecodingResult.Rune requires a valid decoding result")
+	}
+	return r.r
+}
+
+// ByteLen returns the number of bytes read while decoding.
+func (r RuneDecodingResult) ByteLen() int {
+	return int(r.byteLen)
+}
+
+// Kind returns the decoding outcome.
+func (r RuneDecodingResult) Kind() RuneDecodingResultKind {
+	if r.byteLen == 0 {
+		return RuneDecodingResultKind_Empty
+	}
+	if r.r == stdutf8.RuneError && r.byteLen == 1 {
+		return RuneDecodingResultKind_Invalid
+	}
+	return RuneDecodingResultKind_Valid
+}
+
+// RuneLen returns the number of bytes required to encode r in UTF-8.
+func RuneLen(r rune) int {
+	return stdutf8.RuneLen(r)
+}
+
+// IsPotentialStartOfRune reports whether b could be the first byte of an encoded rune.
+func IsPotentialStartOfRune(b byte) bool {
+	return stdutf8.RuneStart(b)
+}
+
+// firstInvalidSpan returns the first range of bytes in the
+// input text such that the range corresponds to invalid UTF-8.
+//
+// The Length() of the returned span will be within [1, 4].
+func firstInvalidSpan(text string) Option[ranges.Span[int]] {
+	for i := 0; i < len(text); {
+		// 0 <= i < len(text) => len(text[i:]) is non-empty.
+		// So below, we don't need to handle the size == 0 case.
+		r, size := stdutf8.DecodeRuneInString(text[i:])
+		if r == stdutf8.RuneError && size == 1 {
+			return Some(invalidUTF8SpanAt(text, i))
+		}
+		i += size
+	}
+	return None[ranges.Span[int]]()
+}
+
+// Precondition: TryDecodeFirstRune(text[start:]).Kind() == RuneDecodingResultKind_Invalid.
+func invalidUTF8SpanAt(text string, start int) ranges.Span[int] {
+	b0 := text[start]
+	width, secondMin, secondMax, ok := utf8LeadByteInfo(b0)
+	if !ok {
+		return ranges.NewSpan(start, start+1)
+	}
+
+	if len(text) <= start+1 {
+		return ranges.NewSpan(start, len(text))
+	}
+	b1 := text[start+1]
+	if b1 < secondMin || secondMax < b1 {
+		return ranges.NewSpan(start, start+2)
+	}
+	if width == 2 {
+		assert.Invariant(false, "DecodeRuneInString reported invalid UTF-8 for a complete two-byte encoding")
+	}
+
+	if len(text) <= start+2 {
+		return ranges.NewSpan(start, len(text))
+	}
+	if !isContinuationByte(text[start+2]) {
+		return ranges.NewSpan(start, start+3)
+	}
+	if width == 3 {
+		assert.Invariant(false, "DecodeRuneInString reported invalid UTF-8 for a complete three-byte encoding")
+	}
+
+	if len(text) <= start+3 {
+		return ranges.NewSpan(start, len(text))
+	}
+	if !isContinuationByte(text[start+3]) {
+		return ranges.NewSpan(start, start+4)
+	}
+	assert.Invariant(false, "DecodeRuneInString reported invalid UTF-8 for a complete four-byte encoding")
+	return ranges.NewSpan(start, start+4)
+}
+
+// utf8LeadByteInfo returns the UTF-8 width and valid second-byte range for a
+// leading byte, following RFC 3629 §4:
+// https://datatracker.ietf.org/doc/html/rfc3629#section-4
+//
+//	UTF8-octets = *( UTF8-char )
+//	UTF8-char   = UTF8-1 / UTF8-2 / UTF8-3 / UTF8-4
+//	UTF8-1      = %x00-7F
+//	UTF8-2      = %xC2-DF UTF8-tail
+//	UTF8-3      = %xE0 %xA0-BF UTF8-tail / %xE1-EC 2( UTF8-tail ) /
+//	              %xED %x80-9F UTF8-tail / %xEE-EF 2( UTF8-tail )
+//	UTF8-4      = %xF0 %x90-BF 2( UTF8-tail ) / %xF1-F3 3( UTF8-tail ) /
+//	              %xF4 %x80-8F 2( UTF8-tail )
+//	UTF8-tail   = %x80-BF
+//
+// P.S. The ranges are inclusive per https://datatracker.ietf.org/doc/html/rfc2234#section-3.4,
+// which is cited for syntax from RFC 3629.
+func utf8LeadByteInfo(b byte) (width int, secondMin byte, secondMax byte, ok bool) {
+	switch {
+	case 0xc2 <= b && b <= 0xdf:
+		return 2, 0x80, 0xbf, true
+	case b == 0xe0:
+		return 3, 0xa0, 0xbf, true
+	case 0xe1 <= b && b <= 0xec:
+		return 3, 0x80, 0xbf, true
+	case b == 0xed:
+		return 3, 0x80, 0x9f, true
+	case 0xee <= b && b <= 0xef:
+		return 3, 0x80, 0xbf, true
+	case b == 0xf0:
+		return 4, 0x90, 0xbf, true
+	case 0xf1 <= b && b <= 0xf3:
+		return 4, 0x80, 0xbf, true
+	case b == 0xf4:
+		return 4, 0x80, 0x8f, true
+	default:
+		return 0, 0, 0, false
+	}
+}
+
+// isContinuationByte implements the UTF8-tail check described in
+// the doc comment for utf8LeadByteInfo.
+func isContinuationByte(b byte) bool {
+	return 0x80 <= b && b <= 0xbf
+}

--- a/base/utf8/utf8_test.go
+++ b/base/utf8/utf8_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package utf8_test
+
+import (
+	"testing"
+
+	"code.kibou.tools/base/check"
+	. "code.kibou.tools/base/utf8"
+)
+
+func TestTryDecodeFirstRune(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	check.AssertSame(h, '�', ReplacementChar, "ReplacementChar")
+
+	decoded := TryDecodeFirstRune("éx")
+	check.AssertSame(h, RuneDecodingResultKind_Valid, decoded.Kind(), "valid kind")
+	check.AssertSame(h, 'é', decoded.Rune(), "valid rune")
+	check.AssertSame(h, 2, decoded.ByteLen(), "valid size")
+
+	decoded = TryDecodeFirstRune(string([]byte{0xff}))
+	check.AssertSame(h, RuneDecodingResultKind_Invalid, decoded.Kind(), "invalid kind")
+	check.AssertSame(h, 1, decoded.ByteLen(), "invalid size")
+
+	decoded = TryDecodeFirstRune("")
+	check.AssertSame(h, RuneDecodingResultKind_Empty, decoded.Kind(), "empty kind")
+	check.AssertSame(h, 0, decoded.ByteLen(), "empty size")
+
+	decoded = TryDecodeFirstRune("\uFFFD")
+	check.AssertSame(h, RuneDecodingResultKind_Valid, decoded.Kind(), "replacement kind")
+	check.AssertSame(h, ReplacementChar, decoded.Rune(), "replacement rune")
+	check.AssertSame(h, 3, decoded.ByteLen(), "replacement size")
+}
+
+func TestRuneLen(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	check.AssertSame(h, 1, RuneLen('a'), "ASCII")
+	check.AssertSame(h, 2, RuneLen('é'), "two-byte")
+	check.AssertSame(h, 4, RuneLen('😀'), "four-byte")
+}
+
+func TestIsPotentialStartOfRune(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	check.AssertSame(h, true, IsPotentialStartOfRune('a'), "ASCII")
+	check.AssertSame(h, true, IsPotentialStartOfRune(0xc3), "leading byte")
+	check.AssertSame(h, false, IsPotentialStartOfRune(0xa9), "continuation byte")
+}


### PR DESCRIPTION
This introduces some helper functions for UTF-8
validation, as well as wrapper for existing APIs.

We need to handle UTF-8 going from the boundary
of byte slices (`string`) to actually displaying
values (where we ought to be clearer about the
encoding). This package should help with that.
