### PR TITLE
feat(base): Introduce a utf8 package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,6 +108,15 @@ linters:
           deny:
             - pkg: "github.com/rivo/uniseg$"
               desc: "use base/internal/uniseg instead of importing rivo/uniseg directly"
+        NoStdlibUTF8:
+          files:
+            - "base/**/*.go"
+            - "misc/**/*.go"
+            - "!**/base/utf8/*.go"
+          list-mode: lax
+          deny:
+            - pkg: "unicode/utf8$"
+              desc: "use base/utf8 instead of unicode/utf8 directly"
     importas:
       no-unaliased: true
       alias:

--- a/base/internal/uniseg/uniseg.go
+++ b/base/internal/uniseg/uniseg.go
@@ -6,7 +6,6 @@ package uniseg
 
 import (
 	"iter"
-	"unicode/utf8"
 
 	"code.kibou.tools/base/assert"
 	rivouniseg "github.com/rivo/uniseg"
@@ -14,6 +13,7 @@ import (
 	"code.kibou.tools/base/collections"
 	"code.kibou.tools/base/core/option"
 	"code.kibou.tools/base/ranges"
+	"code.kibou.tools/base/utf8"
 )
 
 // SegmentedText stores text together with its grapheme cluster boundaries.
@@ -43,10 +43,10 @@ func NewSegmentedText(text string) SegmentedText {
 func (t *SegmentedText) CheckSpan(span ranges.Span[int]) *SpanBoundaryError {
 	start := span.Start()
 	end := span.End()
-	if start != len(t.text) && !utf8.RuneStart(t.text[start]) {
+	if start != len(t.text) && !utf8.IsPotentialStartOfRune(t.text[start]) {
 		return &SpanBoundaryError{SpanBoundaryErrorKind_NotUTF8Boundary, ranges.Bound_Start, span, option.None[ranges.Span[int]]()}
 	}
-	if end != len(t.text) && !utf8.RuneStart(t.text[end]) {
+	if end != len(t.text) && !utf8.IsPotentialStartOfRune(t.text[end]) {
 		return &SpanBoundaryError{SpanBoundaryErrorKind_NotUTF8Boundary, ranges.Bound_End, span, option.None[ranges.Span[int]]()}
 	}
 	if !t.boundaries.Get(start) {

--- a/base/utf8/utf8.go
+++ b/base/utf8/utf8.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package utf8 provides UTF-8 helpers used by Kibou code.
+package utf8
+
+import (
+	stdutf8 "unicode/utf8"
+
+	"code.kibou.tools/base/assert"
+	. "code.kibou.tools/base/core/option"
+	"code.kibou.tools/base/ranges"
+)
+
+// RuneError is the Unicode replacement character.
+const RuneError = stdutf8.RuneError
+
+// TryDecodeFirstRune tries to decode the first rune in s.
+//
+// The result kind is:
+//   - RuneDecodingResultKind_Valid if s starts with a valid UTF-8 encoding.
+//   - RuneDecodingResultKind_Invalid if s starts with invalid UTF-8.
+//   - RuneDecodingResultKind_Empty if s is empty.
+func TryDecodeFirstRune(s string) RuneDecodingResult {
+	r, size := stdutf8.DecodeRuneInString(s)
+	return RuneDecodingResult{r: r, byteLen: uint8(size)}
+}
+
+// RuneDecodingResult is the result of trying to decode a rune.
+type RuneDecodingResult struct {
+	r       rune
+	byteLen uint8
+}
+
+type RuneDecodingResultKind uint8
+
+const (
+	RuneDecodingResultKind_Valid RuneDecodingResultKind = iota + 1
+	RuneDecodingResultKind_Invalid
+	RuneDecodingResultKind_Empty
+)
+
+// Rune returns the decoded rune.
+//
+// Precondition: Kind() == RuneDecodingResultKind_Valid.
+func (r RuneDecodingResult) Rune() rune {
+	if r.Kind() != RuneDecodingResultKind_Valid {
+		assert.Precondition(false, "RuneDecodingResult.Rune requires a valid decoding result")
+	}
+	return r.r
+}
+
+// ByteLen returns the number of bytes read while decoding.
+func (r RuneDecodingResult) ByteLen() int {
+	return int(r.byteLen)
+}
+
+// Kind returns the decoding outcome.
+func (r RuneDecodingResult) Kind() RuneDecodingResultKind {
+	if r.byteLen == 0 {
+		return RuneDecodingResultKind_Empty
+	}
+	if r.r == RuneError && r.byteLen == 1 {
+		return RuneDecodingResultKind_Invalid
+	}
+	return RuneDecodingResultKind_Valid
+}
+
+// PrefixClassification describes how a byte sequence relates to UTF-8 encodings.
+type PrefixClassification uint8
+
+const (
+	// PrefixClassification_Complete means the bytes are exactly one valid UTF-8
+	// encoding.
+	PrefixClassification_Complete PrefixClassification = iota + 1
+	// PrefixClassification_Partial means that the bytes can form an incomplete
+	// prefix of a valid UTF-8 encoded codepoint.
+	PrefixClassification_Partial
+	// PrefixClassification_Malformed means the bytes are neither a complete UTF-8
+	// encoding nor a proper prefix of one.
+	PrefixClassification_Malformed
+)
+
+// ClassifyPrefix classifies bytes as a complete UTF-8 encoding, a proper
+// prefix of one, or malformed bytes.
+//
+// Precondition: len(bytes) ∈ [1, 4].
+func ClassifyPrefix(bytes []byte) PrefixClassification {
+	length := len(bytes)
+	if length < 1 || 4 < length {
+		assert.Preconditionf(false, "UTF-8 prefix length should be in [1, 4] but got %d", length)
+	}
+
+	if !stdutf8.FullRune(bytes) {
+		return PrefixClassification_Partial
+	}
+
+	r, size := stdutf8.DecodeRune(bytes)
+	if r == RuneError && size == 1 {
+		return PrefixClassification_Malformed
+	}
+	if size == length {
+		return PrefixClassification_Complete
+	}
+	return PrefixClassification_Malformed
+}
+
+// RuneLen returns the number of bytes required to encode r in UTF-8.
+func RuneLen(r rune) int {
+	return stdutf8.RuneLen(r)
+}
+
+// IsPotentialStartOfRune reports whether b could be the first byte of an encoded rune.
+func IsPotentialStartOfRune(b byte) bool {
+	return stdutf8.RuneStart(b)
+}
+
+func firstInvalidSpan(text string) Option[ranges.Span[int]] {
+	for i := 0; i < len(text); {
+		r, size := stdutf8.DecodeRuneInString(text[i:])
+		if r != RuneError || size != 1 {
+			i += size
+			continue
+		}
+
+		end, kind := invalidPrefixSpanEnd(text, i)
+		switch kind {
+		case PrefixClassification_Partial, PrefixClassification_Malformed:
+			return Some(ranges.NewSpan(i, end))
+		case PrefixClassification_Complete:
+			assert.Invariant(false, "DecodeRuneInString reported invalid UTF-8 for a complete prefix")
+		default:
+			assert.PanicUnknownCase[any](kind)
+		}
+	}
+	return None[ranges.Span[int]]()
+}
+
+func invalidPrefixSpanEnd(text string, start int) (int, PrefixClassification) {
+	limit := min(len(text), start+4)
+	var prefix [4]byte
+	for end := start + 1; end <= limit; end++ {
+		length := end - start
+		prefix[length-1] = text[end-1]
+		kind := ClassifyPrefix(prefix[:length])
+		if kind != PrefixClassification_Partial {
+			return end, kind
+		}
+	}
+	return len(text), PrefixClassification_Partial
+}

--- a/base/utf8/utf8_test.go
+++ b/base/utf8/utf8_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package utf8_test
+
+import (
+	"strings"
+	"testing"
+	stdutf8 "unicode/utf8"
+
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/check"
+	"code.kibou.tools/base/ranges"
+	. "code.kibou.tools/base/utf8"
+)
+
+func TestUTF8(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("Rune helpers", testRuneHelpers)
+	h.Run("ParseText", func(h check.Harness) {
+		h.Run("unit", testParseTextUnit)
+		h.Run("property", testParseTextProperty)
+	})
+	h.Run("MustParseText", testMustParseText)
+	h.Run("Text.CodePointContaining", func(h check.Harness) {
+		h.Run("unit", testCodePointContainingUnit)
+		h.Run("property", testCodePointContainingProperty)
+	})
+}
+
+func testRuneHelpers(h check.Harness) {
+	h.Parallel()
+
+	check.AssertSame(h, '�', RuneError, "RuneError")
+
+	check.AssertSame(h, 1, RuneLen('a'), "RuneLen ASCII")
+	check.AssertSame(h, 2, RuneLen('é'), "RuneLen two-byte")
+	check.AssertSame(h, 4, RuneLen('😀'), "RuneLen four-byte")
+
+	decoded := TryDecodeFirstRune("éx")
+	check.AssertSame(h, RuneDecodingResultKind_Valid, decoded.Kind(), "TryDecodeFirstRune kind")
+	check.AssertSame(h, 'é', decoded.Rune(), "TryDecodeFirstRune rune")
+	check.AssertSame(h, 2, decoded.ByteLen(), "TryDecodeFirstRune size")
+
+	decoded = TryDecodeFirstRune(string([]byte{0xff}))
+	check.AssertSame(h, RuneDecodingResultKind_Invalid, decoded.Kind(), "TryDecodeFirstRune invalid kind")
+	check.AssertSame(h, 1, decoded.ByteLen(), "TryDecodeFirstRune invalid size")
+
+	decoded = TryDecodeFirstRune("")
+	check.AssertSame(h, RuneDecodingResultKind_Empty, decoded.Kind(), "TryDecodeFirstRune empty kind")
+	check.AssertSame(h, 0, decoded.ByteLen(), "TryDecodeFirstRune empty size")
+
+	decoded = TryDecodeFirstRune("\uFFFD")
+	check.AssertSame(h, RuneDecodingResultKind_Valid, decoded.Kind(), "TryDecodeFirstRune replacement kind")
+	check.AssertSame(h, RuneError, decoded.Rune(), "TryDecodeFirstRune replacement rune")
+	check.AssertSame(h, 3, decoded.ByteLen(), "TryDecodeFirstRune replacement size")
+
+	check.AssertSame(h, true, IsPotentialStartOfRune('a'), "IsPotentialStartOfRune ASCII")
+	check.AssertSame(h, true, IsPotentialStartOfRune(0xc3), "IsPotentialStartOfRune leading byte")
+	check.AssertSame(h, false, IsPotentialStartOfRune(0xa9), "IsPotentialStartOfRune continuation byte")
+}
+
+func testParseTextUnit(h check.Harness) {
+	h.Parallel()
+
+	valid, err := ParseText("aé😀")
+	check.AssertSame(h, (*TextParseError)(nil), err, "valid text error")
+	check.AssertSame(h, "aé😀", valid.String(), "valid text String")
+
+	cases := []struct {
+		name    string
+		text    string
+		want    ranges.Span[int]
+		wantErr string
+	}{
+		{
+			name:    "single invalid byte",
+			text:    string([]byte{'a', 0xff, 'b'}),
+			want:    ranges.NewSpan(1, 2),
+			wantErr: "invalid UTF-8 byte 0xFF at byte offset 1",
+		},
+		{
+			name:    "consecutive invalid bytes",
+			text:    string([]byte{0xff, 0xfe, 'x'}),
+			want:    ranges.NewSpan(0, 1),
+			wantErr: "invalid UTF-8 byte 0xFF at byte offset 0",
+		},
+		{
+			name:    "invalid after multibyte",
+			text:    string([]byte{0xc3, 0xa9, 0xff, 0xfe}),
+			want:    ranges.NewSpan(2, 3),
+			wantErr: "invalid UTF-8 byte 0xFF at byte offset 2",
+		},
+		{
+			name:    "long invalid byte run",
+			text:    string([]byte{0xff, 0xfe, 0xfd, 0xfc, 0xfb}),
+			want:    ranges.NewSpan(0, 1),
+			wantErr: "invalid UTF-8 byte 0xFF at byte offset 0",
+		},
+		{
+			name:    "truncated three-byte sequence",
+			text:    string([]byte{0xe2, 0x82}),
+			want:    ranges.NewSpan(0, 2),
+			wantErr: "invalid UTF-8 bytes 0xE282 at byte span [0, 2)",
+		},
+		{
+			name:    "overlong three-byte sequence",
+			text:    string([]byte{0xe0, 0x80, 0x80}),
+			want:    ranges.NewSpan(0, 2),
+			wantErr: "invalid UTF-8 bytes 0xE080 at byte span [0, 2)",
+		},
+	}
+
+	for _, tc := range cases {
+		_, err := ParseText(tc.text)
+		h.Assertf(err != nil, "%s: expected parse error", tc.name)
+		check.AssertSame(h, 0, err.FirstInvalidSpan().CompareStrict(tc.want), tc.name+" first invalid span")
+		check.AssertSame(h, tc.wantErr, err.Error(), tc.name+" error")
+	}
+}
+
+func testParseTextProperty(h check.Harness) {
+	h.Parallel()
+
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		bytes := rapid.SliceOfN(rapid.Uint8(), 0, 64).Draw(t, "bytes")
+		text := string(bytes)
+
+		parsed, err := ParseText(text)
+		wantValid := stdutf8.ValidString(text)
+		check.AssertSame(h, wantValid, err == nil, "ParseText validity")
+		if wantValid {
+			check.AssertSame(h, text, parsed.String(), "parsed text")
+			return
+		}
+
+		h.Assertf(err != nil, "invalid UTF-8 should return a TextParseError")
+		span := err.FirstInvalidSpan()
+		length := span.Length().Unwrap()
+		h.Assertf(0 <= span.Start(), "span start %d before 0", span.Start())
+		h.Assertf(span.End() <= len(text), "span end %d after text length %d", span.End(), len(text))
+		h.Assertf(1 <= length && length <= 4, "span length %d outside [1, 4]", length)
+		check.AssertSame(h, true, stdutf8.ValidString(text[:span.Start()]), "prefix before invalid span is valid")
+		check.AssertSame(h, false, stdutf8.ValidString(text[:span.End()]), "prefix through invalid span is invalid")
+		h.Assertf(err.Error() != "", "error message should be non-empty")
+	})
+}
+
+func testMustParseText(h check.Harness) {
+	h.Parallel()
+
+	text := MustParseText("aé😀")
+	check.AssertSame(h, "aé😀", text.String(), "MustParseText String")
+}
+
+func testCodePointContainingUnit(h check.Harness) {
+	h.Parallel()
+
+	text := MustParseText("aé😀")
+	cases := []struct {
+		name string
+		off  int
+		want ranges.Span[int]
+		ok   bool
+	}{
+		{name: "start", off: 0, want: ranges.NewSpan(0, 0), ok: false},
+		{name: "between ASCII and two-byte", off: 1, want: ranges.NewSpan(0, 0), ok: false},
+		{name: "inside two-byte", off: 2, want: ranges.NewSpan(1, 3), ok: true},
+		{name: "between two-byte and four-byte", off: 3, want: ranges.NewSpan(0, 0), ok: false},
+		{name: "inside four-byte first continuation", off: 4, want: ranges.NewSpan(3, 7), ok: true},
+		{name: "inside four-byte second continuation", off: 5, want: ranges.NewSpan(3, 7), ok: true},
+		{name: "inside four-byte third continuation", off: 6, want: ranges.NewSpan(3, 7), ok: true},
+		{name: "end", off: 7, want: ranges.NewSpan(0, 0), ok: false},
+	}
+
+	for _, tc := range cases {
+		got, ok := text.CodePointContaining(tc.off).Get()
+		check.AssertSame(h, tc.ok, ok, tc.name+" present")
+		if ok {
+			check.AssertSame(h, 0, got.CompareStrict(tc.want), tc.name+" span")
+		}
+	}
+
+	h.AssertPanicsWith(
+		assert.AssertionError{Fmt: "precondition violation: offset %d outside text bounds [0, %d]", Args: []any{-1, 7}},
+		func() { _ = text.CodePointContaining(-1) },
+	)
+	h.AssertPanicsWith(
+		assert.AssertionError{Fmt: "precondition violation: offset %d outside text bounds [0, %d]", Args: []any{8, 7}},
+		func() { _ = text.CodePointContaining(8) },
+	)
+}
+
+func testCodePointContainingProperty(h check.Harness) {
+	h.Parallel()
+
+	partsGen := rapid.SliceOfN(rapid.SampledFrom([]string{"", "a", "é", "😀", "\u0301", "\uFFFD", "👩‍💻"}), 0, 40)
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		parts := partsGen.Draw(t, "parts")
+		text := strings.Join(parts, "")
+		parsed := MustParseText(text)
+
+		for offset := 0; offset <= len(text); offset++ {
+			want, wantOK := codePointContainingReference(text, offset)
+			got, gotOK := parsed.CodePointContaining(offset).Get()
+			check.AssertSame(h, wantOK, gotOK, "presence")
+			if gotOK {
+				check.AssertSame(h, 0, got.CompareStrict(want), "span")
+			}
+		}
+	})
+}
+
+func codePointContainingReference(text string, offset int) (ranges.Span[int], bool) {
+	for start, r := range text {
+		end := start + stdutf8.RuneLen(r)
+		if start < offset && offset < end {
+			return ranges.NewSpan(start, end), true
+		}
+	}
+	return ranges.NewSpan(0, 0), false
+}


### PR DESCRIPTION
This introduces some helper functions for UTF-8
validation, as well as wrapper for existing APIs.

We need to handle UTF-8 going from the boundary
of byte slices (`string`) to actually displaying
values (where we ought to be clearer about the
encoding). This package should help with that.

Broken out from https://github.com/kibou-tools/kibou/pull/205
