### PR TITLE
feat(uniseg): Add bounded API for finding surrounding grapheme cluster

### DIFF
--- a/base/check/pbt/text/text.go
+++ b/base/check/pbt/text/text.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package text provides property-test generators for interesting text.
+package text
+
+import (
+	"strconv"
+	"strings"
+
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/base/assert"
+)
+
+// GraphemeCluster generates valid UTF-8 strings that are intended to form a
+// single extended grapheme cluster.
+func GraphemeCluster() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		kind := rapid.SampledFrom([]string{"single", "multi"}).Draw(t, "clusterKind")
+		switch kind {
+		case "single":
+			return rapid.SampledFrom([]string{
+				"\u0000",     // NUL
+				"\u0061",     // a
+				"\u00E9",     // é
+				"\u754C",     // 界
+				"\U0001F642", // 🙂
+				"\U0001F684", // 🚄
+			}).Draw(t, "normalCluster")
+		case "multi":
+			return MultiCodePointGraphemeCluster().Draw(t, "multiCluster")
+		default:
+			assert.Invariant(false, "unknown cluster kind")
+			return ""
+		}
+	})
+}
+
+// MultiCodePointGraphemeCluster generates single grapheme clusters containing
+// multiple code points, including long combining-mark and ZWJ cases.
+func MultiCodePointGraphemeCluster() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		kind := rapid.SampledFrom([]string{"knownEmoji", "combiningMarks", "zwjEmoji", "zwjEmojiWithSkinTones"}).Draw(t, "clusterKind")
+		switch kind {
+		case "knownEmoji":
+			return rapid.SampledFrom([]string{
+				"\U0001F469\u200D\U0001F4BB",                                                       // 👩‍💻
+				"\U0001F468\u200D\U0001F469\u200D\U0001F467\u200D\U0001F466",                       // 👨‍👩‍👧‍👦
+				"\U0001F469\U0001F3FD\u200D\U0001F4BB",                                             // 👩🏽‍💻
+				"\U0001F3F3\uFE0F\u200D\U0001F308",                                                 // 🏳️‍🌈
+				"\u2764\uFE0F\u200D\U0001F525",                                                     // ❤️‍🔥
+				"\U0001F468\u200D\u2764\uFE0F\u200D\U0001F48B\u200D\U0001F468",                     // 👨‍❤️‍💋‍👨
+				"\U0001F469\U0001F3FD\u200D\u2764\uFE0F\u200D\U0001F48B\u200D\U0001F468\U0001F3FF", // 👩🏽‍❤️‍💋‍👨🏿
+			}).Draw(t, "knownEmojiCluster")
+		case "combiningMarks":
+			base := rapid.SampledFrom([]string{"a", "क", "م"}).Draw(t, "base")
+			combiningMarkCount := rapid.IntRange(1, 128).Draw(t, "combiningMarkCount")
+			marks := rapid.SliceOfN(rapid.SampledFrom([]string{"\u0301", "\u0308", "\u0327", "\u20dd"}), combiningMarkCount, combiningMarkCount).Draw(t, "combiningMarks")
+			return base + strings.Join(marks, "")
+		case "zwjEmoji":
+			componentCount := rapid.IntRange(2, 64).Draw(t, "zwjComponentCount")
+			components := rapid.SliceOfN(rapid.SampledFrom([]string{"👩", "👨", "👧", "👦", "💻", "🚄", "🔬"}), componentCount, componentCount).Draw(t, "zwjComponents")
+			return strings.Join(components, "\u200d")
+		case "zwjEmojiWithSkinTones":
+			componentCount := rapid.IntRange(2, 32).Draw(t, "zwjSkinToneComponentCount")
+			components := make([]string, 0, componentCount)
+			for i := 0; i < componentCount; i++ {
+				person := rapid.SampledFrom([]string{"👩", "👨", "🧑"}).Draw(t, "person"+strconv.Itoa(i))
+				tone := rapid.SampledFrom([]string{"🏻", "🏼", "🏽", "🏾", "🏿"}).Draw(t, "skinTone"+strconv.Itoa(i))
+				components = append(components, person+tone)
+			}
+			return strings.Join(components, "\u200d")
+		default:
+			assert.Invariant(false, "unknown cluster kind")
+			return ""
+		}
+	})
+}

--- a/base/internal/uniseg/uniseg.go
+++ b/base/internal/uniseg/uniseg.go
@@ -18,17 +18,16 @@ import (
 
 // SegmentedText stores text together with its grapheme cluster boundaries.
 type SegmentedText struct {
-	text string
-	// boundaries[i] is true iff i == len(text) or if
-	// text[i] is the start byte of a grapheme cluster.
+	text utf8.Text
+	// boundaries[i] is true iff i == text.Len() or if
+	// text.GetByte(i) is the start byte of a grapheme cluster.
 	//
-	// boundaries.Len() == len(text) + 1
+	// boundaries.Len() == text.Len() + 1
 	boundaries collections.BitVec
 }
 
-// Pre-condition: text is valid UTF-8.
-func NewSegmentedText(text string) SegmentedText {
-	boundaries := collections.NewBitVec(len(text) + 1)
+func NewSegmentedText(text utf8.Text) SegmentedText {
+	boundaries := collections.NewBitVec(text.Len() + 1)
 	boundaries.Set(0)
 	for cluster := range GraphemeClusters(text) {
 		boundaries.Set(cluster.Span().End())
@@ -39,38 +38,134 @@ func NewSegmentedText(text string) SegmentedText {
 // CheckSpan checks that the bounds of the span line up with
 // UTF-8 codepoint boundaries and grapheme cluster boundaries.
 //
-// Pre-condition: span ⊆ [0, len(t.text)).
+// Pre-condition: span ⊆ [0, t.text.Len()].
+//
+// Post-condition: If the returned error has kind
+// [SpanBoundaryErrorKind_NotGraphemeBoundary], then ByteOffset() is a UTF-8
+// boundary strictly inside a grapheme cluster.
 func (t *SegmentedText) CheckSpan(span ranges.Span[int]) *SpanBoundaryError {
 	start := span.Start()
 	end := span.End()
-	if start != len(t.text) && !utf8.IsPotentialStartOfRune(t.text[start]) {
-		return &SpanBoundaryError{SpanBoundaryErrorKind_NotUTF8Boundary, ranges.Bound_Start, span, option.None[ranges.Span[int]]()}
+	if start != t.text.Len() && !utf8.IsPotentialStartOfRune(t.text.GetByte(start)) {
+		return &SpanBoundaryError{SpanBoundaryErrorKind_NotUTF8Boundary, ranges.Bound_Start, span}
 	}
-	if end != len(t.text) && !utf8.IsPotentialStartOfRune(t.text[end]) {
-		return &SpanBoundaryError{SpanBoundaryErrorKind_NotUTF8Boundary, ranges.Bound_End, span, option.None[ranges.Span[int]]()}
+	if end != t.text.Len() && !utf8.IsPotentialStartOfRune(t.text.GetByte(end)) {
+		return &SpanBoundaryError{SpanBoundaryErrorKind_NotUTF8Boundary, ranges.Bound_End, span}
 	}
 	if !t.boundaries.Get(start) {
-		return &SpanBoundaryError{SpanBoundaryErrorKind_NotGraphemeBoundary, ranges.Bound_Start, span, t.findContainingGraphemeCluster(start)}
+		return &SpanBoundaryError{SpanBoundaryErrorKind_NotGraphemeBoundary, ranges.Bound_Start, span}
 	}
 	if !t.boundaries.Get(end) {
-		return &SpanBoundaryError{SpanBoundaryErrorKind_NotGraphemeBoundary, ranges.Bound_End, span, t.findContainingGraphemeCluster(end)}
+		return &SpanBoundaryError{SpanBoundaryErrorKind_NotGraphemeBoundary, ranges.Bound_End, span}
 	}
 	return nil
 }
 
-func (t *SegmentedText) findContainingGraphemeCluster(offset int) option.Option[ranges.Span[int]] {
-	if offset < 0 || t.boundaries.Len() <= offset || t.boundaries.Get(offset) {
-		return option.None[ranges.Span[int]]()
+// GraphemeClusterWindow is a possibly truncated grapheme-cluster byte span.
+type GraphemeClusterWindow struct {
+	span          ranges.Span[int]
+	isFullCluster bool
+}
+
+func (w GraphemeClusterWindow) Span() ranges.Span[int] { return w.span }
+
+func (w GraphemeClusterWindow) IsFullCluster() bool { return w.isFullCluster }
+
+// FindGraphemeClusterContaining returns a codepoint-aligned window around an
+// offset strictly inside a grapheme cluster.
+//
+// If the containing grapheme cluster has at most maxCodePoints codepoints,
+// the returned window is the full cluster. Otherwise, the window contains
+// maxCodePoints / 2 codepoints before offset, and the rest after offset.
+//
+// Preconditions:
+//   - offset ∈ [0, t.text.Len()].
+//   - offset == t.text.Len() or offset points to the first byte of
+//     a UTF-8 code point.
+//   - maxCodePoints >= 1.
+//
+// Postconditions: If Some(window) is returned:
+//   - window.Span() contains offset
+//   - window.Span() will be codepoint aligned
+func (t *SegmentedText) FindGraphemeClusterContaining(offset int, maxCodePoints int) option.Option[GraphemeClusterWindow] {
+	if offset < 0 || t.text.Len() < offset {
+		assert.Preconditionf(false, "offset %d outside text bounds [0, %d]", offset, t.text.Len())
 	}
-	start, ok := t.boundaries.FindAtOrBefore(offset).Get()
-	if !ok {
-		return option.None[ranges.Span[int]]()
+	if maxCodePoints < 1 {
+		assert.Preconditionf(false, "maxCodePoints %d below 1", maxCodePoints)
 	}
-	end, ok := t.boundaries.FindAtOrAfter(offset).Get()
-	if !ok {
-		return option.None[ranges.Span[int]]()
+	if offset != t.text.Len() && !utf8.IsPotentialStartOfRune(t.text.GetByte(offset)) {
+		assert.Preconditionf(false, "offset %d is not a UTF-8 boundary", offset)
 	}
-	return option.Some(ranges.NewSpan(start, end))
+	if offset == 0 || offset == t.text.Len() || t.boundaries.Get(offset) {
+		return option.None[GraphemeClusterWindow]()
+	}
+
+	// Optimistic loop: try to include the entire grapheme cluster when it fits
+	// within maxCodePoints, even if offset is unbalanced within the cluster.
+	start, end := offset, offset
+	codePoints := 0
+	for codePoints < maxCodePoints && !t.boundaries.Get(start) {
+		start = t.previousCodePointStart(start)
+		codePoints++
+	}
+	for codePoints < maxCodePoints && !t.boundaries.Get(end) {
+		end = t.nextCodePointEnd(end)
+		codePoints++
+	}
+	if t.boundaries.Get(start) && t.boundaries.Get(end) {
+		return option.Some(GraphemeClusterWindow{
+			span:          ranges.NewSpan(start, end),
+			isFullCluster: true,
+		})
+	}
+
+	leftBudget := maxCodePoints / 2
+	rightBudget := maxCodePoints - leftBudget
+
+	// Fallback loop: return a balanced, bounded window around offset.
+	// Invariant: start and end always point to valid codepoint boundaries
+	// (including t.text.Len() for end)
+	start, end = offset, offset
+	for i := 0; i < rightBudget; i++ {
+		if i < leftBudget && !t.boundaries.Get(start) {
+			// start is not a grapheme cluster boundary, so try
+			// to walk back by 1 codepoint.
+			start = t.previousCodePointStart(start)
+		}
+		if !t.boundaries.Get(end) {
+			// i < rightBudget means we can potentially look at one more
+			// codepoint on the right side.
+			end = t.nextCodePointEnd(end)
+		}
+		if t.boundaries.Get(start) && t.boundaries.Get(end) {
+			// We found a full grapheme cluster within the budget!
+			// We know this is exactly 1 grapheme cluster because we checked
+			// t.boundaries.Get(offset) earlier, and grapheme clusters are
+			// composed of 1 or more codepoints.
+			break
+		}
+	}
+
+	return option.Some(GraphemeClusterWindow{
+		span:          ranges.NewSpan(start, end),
+		isFullCluster: t.boundaries.Get(start) && t.boundaries.Get(end),
+	})
+}
+
+// Pre-condition: t.text[i] is the first byte of a codepoint.
+func (t *SegmentedText) nextCodePointEnd(i int) int {
+	decoded := utf8.TryDecodeFirstRune(t.text.String()[i:])
+	assert.Invariant(decoded.Kind() == utf8.RuneDecodingResultKind_Valid, "segmented text should contain valid UTF-8")
+	return i + decoded.ByteLen()
+}
+
+func (t *SegmentedText) previousCodePointStart(before int) int {
+	start := before - 1
+	for 0 < start && !utf8.IsPotentialStartOfRune(t.text.GetByte(start)) {
+		start--
+	}
+	return start
 }
 
 // GraphemeCluster is one user-perceived character within a string.
@@ -79,9 +174,9 @@ type GraphemeCluster struct {
 }
 
 // GraphemeClusters iterates over the grapheme clusters in s.
-func GraphemeClusters(s string) iter.Seq[GraphemeCluster] {
+func GraphemeClusters(text utf8.Text) iter.Seq[GraphemeCluster] {
 	return func(yield func(GraphemeCluster) bool) {
-		graphemes := rivouniseg.NewGraphemes(s)
+		graphemes := rivouniseg.NewGraphemes(text.String())
 		cluster := GraphemeCluster{graphemes}
 		for graphemes.Next() {
 			if !yield(cluster) {
@@ -104,10 +199,9 @@ func (c GraphemeCluster) Span() ranges.Span[int] {
 func ComputeWidth(s string) int { return rivouniseg.StringWidth(s) }
 
 type SpanBoundaryError struct {
-	kind                      SpanBoundaryErrorKind
-	bound                     ranges.Bound
-	span                      ranges.Span[int]
-	containingGraphemeCluster option.Option[ranges.Span[int]]
+	kind  SpanBoundaryErrorKind
+	bound ranges.Bound
+	span  ranges.Span[int]
 }
 
 type SpanBoundaryErrorKind uint8
@@ -138,10 +232,4 @@ func (e *SpanBoundaryError) ByteOffset() int {
 	default:
 		return assert.PanicUnknownCase[int](e.bound)
 	}
-}
-
-// ContainingGraphemeCluster returns the span corresponding to
-// the grapheme cluster which contains the ByteOffset.
-func (e *SpanBoundaryError) ContainingGraphemeCluster() option.Option[ranges.Span[int]] {
-	return e.containingGraphemeCluster
 }

--- a/base/internal/uniseg/uniseg_test.go
+++ b/base/internal/uniseg/uniseg_test.go
@@ -5,11 +5,115 @@
 package uniseg_test
 
 import (
+	"math"
 	"strings"
 	"testing"
 
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/check"
+	pbt_text "code.kibou.tools/base/check/pbt/text"
 	"code.kibou.tools/base/internal/uniseg"
+	"code.kibou.tools/base/ranges"
+	"code.kibou.tools/base/utf8"
 )
+
+func TestContainingGraphemeCluster_CanExceedMaxInt16(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	text := utf8.MustParseText("a" + strings.Repeat("\u0301", 1<<14))
+	segmented := uniseg.NewSegmentedText(text)
+
+	err := segmented.CheckSpan(ranges.NewSpan(1, 1))
+	h.Assertf(err != nil, "span inside grapheme cluster should fail boundary check")
+	check.AssertSame(h, uniseg.SpanBoundaryErrorKind_NotGraphemeBoundary, err.Kind(), "error kind")
+
+	window, ok := segmented.FindGraphemeClusterContaining(err.ByteOffset(), math.MaxInt16).Get()
+	h.Assertf(ok, "expected containing grapheme cluster")
+	check.AssertSame(h, true, window.IsFullCluster(), "full cluster")
+	length := window.Span().Length().Unwrap()
+	h.Assertf(length > math.MaxInt16, "containing grapheme cluster length %d <= MaxInt16", length)
+}
+
+func TestFindGraphemeClusterContaining(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	clusterCountGen := rapid.IntRange(1, 20)
+	maxCodePointsGen := rapid.IntRange(1, 32)
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		clusterCount := clusterCountGen.Draw(t, "clusterCount")                 // make N grapheme clusters
+		targetIndex := rapid.IntRange(0, clusterCount-1).Draw(t, "targetIndex") // pick one of them
+		clusters := make([]string, 0, clusterCount)
+		targetStart := 0
+		var target string
+		for i := 0; i < clusterCount; i++ {
+			cluster := pbt_text.GraphemeCluster().Draw(t, "cluster"+itoa(i))
+			if i == targetIndex {
+				// FindGraphemeClusterContaining is meant to test the situation where you're
+				// pointing to a code point in the middle of a multi-codepoint grapheme cluster,
+				// so force the use of a multi-codepoint generator here.
+				cluster = pbt_text.MultiCodePointGraphemeCluster().Draw(t, "target")
+				target = cluster
+			}
+			if i < targetIndex {
+				targetStart += len(cluster)
+			}
+			clusters = append(clusters, cluster)
+		}
+		maxCodePoints := maxCodePointsGen.Draw(t, "maxCodePoints")
+		targetCodePointStarts := codePointStartOffsets(target)
+		targetCodePointCount := len(targetCodePointStarts)
+		assert.Invariantf(targetCodePointCount >= 2,
+			"used pbt_text.MultiCodePointGraphemeCluster earlier, but got grapheme cluster %q with %d codepoints",
+			target, targetCodePointCount)
+
+		offsetCodePointIndex := rapid.IntRange(1, targetCodePointCount-1).Draw(t, "offsetCodePointIndex")
+
+		text := utf8.MustParseText(strings.Join(clusters, ""))
+		segmented := uniseg.NewSegmentedText(text)
+		targetSpan := ranges.NewSpan(targetStart, targetStart+len(target))
+		offset := targetStart + targetCodePointStarts[offsetCodePointIndex]
+
+		window, ok := segmented.FindGraphemeClusterContaining(offset, maxCodePoints).Get()
+		h.Assertf(ok, "expected grapheme cluster containing offset %d", offset)
+		span := window.Span()
+		h.Assertf(targetSpan.Start() <= span.Start(), "window start %d before cluster start %d", span.Start(), targetSpan.Start())
+		h.Assertf(span.Start() <= offset, "window start %d after offset %d", span.Start(), offset)
+		h.Assertf(offset < span.End(), "window end %d not after offset %d", span.End(), offset)
+		h.Assertf(span.End() <= targetSpan.End(), "window end %d after cluster end %d", span.End(), targetSpan.End())
+		assertCodePointBoundary(h, text, span.Start(), "window start")
+		assertCodePointBoundary(h, text, span.End(), "window end")
+
+		windowCodePoints := len(codePointStartOffsets(text.String()[span.Start():span.End()]))
+		h.Assertf(windowCodePoints <= maxCodePoints, "window has %d codepoints, max %d", windowCodePoints, maxCodePoints)
+
+		if targetCodePointCount <= maxCodePoints {
+			check.AssertSame(h, true, window.IsFullCluster(), "full cluster")
+			check.AssertSame(h, 0, span.CompareStrict(targetSpan), "full cluster span")
+		} else {
+			check.AssertSame(h, false, window.IsFullCluster(), "truncated cluster")
+		}
+	})
+}
+
+func codePointStartOffsets(text string) []int {
+	starts := make([]int, 0, len(text))
+	// This may be a bit confusing, but it actually does return byte offsets
+	// for codepoints, not a uniformly increasing sequence [0, 1, 2, ...].
+	for i := range text {
+		starts = append(starts, i)
+	}
+	return starts
+}
+
+func assertCodePointBoundary(h check.BasicHarness, text utf8.Text, offset int, name string) {
+	h.Assertf(offset == text.Len() || utf8.IsPotentialStartOfRune(text.GetByte(offset)),
+		"%s is not a codepoint boundary: %d", name, offset)
+}
 
 func BenchmarkNewSegmentedText(b *testing.B) {
 	for _, tc := range []struct {
@@ -22,10 +126,10 @@ func BenchmarkNewSegmentedText(b *testing.B) {
 		{name: "ComplexEmoji", unit: "👩‍💻"},
 	} {
 		for _, count := range []int{10, 100, 1000} {
-			text := strings.Repeat(tc.unit, count)
+			text := utf8.MustParseText(strings.Repeat(tc.unit, count))
 			b.Run(tc.name+"/count="+itoa(count), func(b *testing.B) {
 				b.ReportAllocs()
-				b.SetBytes(int64(len(text)))
+				b.SetBytes(int64(text.Len()))
 				for b.Loop() {
 					_ = uniseg.NewSegmentedText(text)
 				}

--- a/base/ranges/ranges.go
+++ b/base/ranges/ranges.go
@@ -38,6 +38,9 @@ func (s Span[T]) Start() T      { return s.start }
 func (s Span[T]) End() T        { return s.end }
 func (s Span[T]) IsEmpty() bool { return s.start == s.end }
 
+// Contains reports whether v is in this half-open span.
+func (s Span[T]) Contains(v T) bool { return s.start <= v && v < s.end }
+
 // Length attempts to compute the length of this span using the
 // span's numeric type.
 //

--- a/base/ranges/ranges_test.go
+++ b/base/ranges/ranges_test.go
@@ -23,6 +23,7 @@ func TestSpan(t *testing.T) {
 
 	h.Run("NewSpan", testNewSpan)
 	h.Run("Length", testLength)
+	h.Run("Contains", testContains)
 	h.Run("CompareStrict", testCompareStrict)
 	h.Run("Overlaps", func(h check.Harness) {
 		h.Run("unit", testOverlapsUnit)
@@ -62,6 +63,19 @@ func testLength(h check.Harness) {
 				start, end, length)
 		}
 	}
+}
+
+func testContains(h check.Harness) {
+	h.Parallel()
+
+	span := ranges.NewSpan(3, 7)
+	check.AssertSame(h, false, span.Contains(2), "before start")
+	check.AssertSame(h, true, span.Contains(3), "at start")
+	check.AssertSame(h, true, span.Contains(6), "before end")
+	check.AssertSame(h, false, span.Contains(7), "at end")
+
+	empty := ranges.NewSpan(3, 3)
+	check.AssertSame(h, false, empty.Contains(3), "empty span")
 }
 
 func testCompareStrict(h check.Harness) {

--- a/base/utf8/text.go
+++ b/base/utf8/text.go
@@ -19,6 +19,18 @@ type Text struct {
 	text string
 }
 
+// Len returns the byte length of t.
+func (t Text) Len() int {
+	return len(t.text)
+}
+
+// GetByte gets the i-th byte for this Text value.
+//
+// Precondition: 0 <= i < t.Len().
+func (t Text) GetByte(i int) byte {
+	return t.text[i]
+}
+
 // ParseText validates s as UTF-8 text.
 func ParseText(s string) (Text, *TextParseError) {
 	if span, ok := firstInvalidSpan(s).Get(); ok {
@@ -48,7 +60,7 @@ func (t Text) String() string {
 //
 // If offset already lies on a codepoint boundary, the result is None.
 //
-// Precondition: offset ∈ [0, len(t.String())].
+// Precondition: offset ∈ [0, t.Len()].
 func (t Text) CodePointContaining(offset int) Option[ranges.Span[int]] {
 	text := t.text
 	if offset < 0 || len(text) < offset {


### PR DESCRIPTION
In theory, grapheme clusters can be arbitrarily long.
In most cases, we don't want to look at an arbitrarily
long "window" around an offset in the middle of a grapheme
cluster. This patch adds an API to do a bounded lookup
backward and forward to locate the containing grapheme
cluster, which returns a range of codepoints in the case
of very large grapheme clusters.