### PR TITLE
chore(ci): Upgrade setup-go to v6.4.0

### DIFF
--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.25.x
         # setup-go does caching by default, and issues a warning due to being

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.25.x
           # setup-go cache warns when GOCACHE is customized; we manage caching explicitly.
@@ -152,7 +152,7 @@ jobs:
         with:
           persist-credentials: false
       # Stable Go is used only for fixture builds; capture its GOROOT before PATH changes.
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         if: matrix.go-toolchain == 'stable'
         with:
           go-version: 1.25.x

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -69,7 +69,7 @@ jobs:
           # Use app token so that pushes and PRs trigger downstream workflows.
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.24.x
           cache: false


### PR DESCRIPTION
Older versions are triggering a deprecation warning

> Node.js 20 actions are deprecated.
>
> The following actions are running on Node.js 20
> and may not work as expected:
> actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff.
> Actions will be forced to run with Node.js 24
> by default starting June 16th, 2026.
>
> Node.js 20 will be removed from the runner
> on September 16th, 2026
