### PR TITLE
ci(delve): Parallelize proc tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -202,4 +202,8 @@ jobs:
             gotip)  export DELVE_TEST_GO="$PWD/gotip/bin/go" ;;
             head)   ;;
           esac
-          go test -C delve ./...
+          go test -C delve -list '^(Test|Fuzz|Example)' ./pkg/proc \
+            | grep -E '^(Test|Fuzz|Example)' \
+            | xargs -I {} -P 12 go test -C delve ./pkg/proc -run '^{}$'
+
+          go test -C delve $(go list -C delve ./... | grep -Ev '/pkg/proc$')


### PR DESCRIPTION
`./pkg/proc` runs a bunch of tests serially, which seems
to be linked to the issue we've been seeing with
flakiness/timeouts in #5.

Let's try running more tests in parallel
processes. Intra-process parallelism is not
easily doable because how `sys.Wait4` is used
on Linux.

I tried to fix this upstream, but that runs into
problems on Linux in stress tests:

```
go test ./pkg/proc \
  -run 'TestNext|TestStep|TestEvalExpression|TestVariableEvaluation|TestCallFunction' \
  -count=4 -parallel=24 -timeout 600s
```

This triggered a few different errors:

1. A fixture's Go runtime aborted with `SIGTRAP`
2. `panic: panicking` printed from `_fixtures/defercall.go`
   outside the debugger.
3. Error compiling ../../_fixtures/defercall.go:
   `waitid: no child processes`

Tentatively fixes https://github.com/kibou-tools/kibou/issues/5
