### PR TITLE
fix(ci): Reduce number of parallel processes for Delve

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -202,8 +202,20 @@ jobs:
             gotip)  export DELVE_TEST_GO="$PWD/gotip/bin/go" ;;
             head)   ;;
           esac
+          # Randomize before grouping so slow tests are less likely to be
+          # clustered in the same subprocess by alphabetical order.
           go test -C delve -list '^(Test|Fuzz|Example)' ./pkg/proc \
             | grep -E '^(Test|Fuzz|Example)' \
-            | xargs -I {} -P 12 go test -C delve ./pkg/proc -run '^{}$'
+            | awk 'BEGIN { srand() } { printf "%.17f\t%s\n", rand(), $0 }' \
+            | sort -n \
+            | cut -f2- \
+            | xargs -n 6 -P 4 sh -c '
+                pattern="$1"
+                shift
+                for test_name do
+                  pattern="$pattern|$test_name"
+                done
+                go test -C delve -v ./pkg/proc -run "^($pattern)$"
+              ' sh
 
-          go test -C delve $(go list -C delve ./... | grep -Ev '/pkg/proc$')
+          go test -C delve -v $(go list -C delve ./... | grep -Ev '/pkg/proc$')


### PR DESCRIPTION
It looks like the test runs didn't see any speed
improvement in the past run, which defeats the
purpose of parallelization.

Hopefully correctly fixes #5 😅