### PR TITLE
feat(collections): Add OrderedMap type

### DIFF
--- a/base/collections/ordered_map.go
+++ b/base/collections/ordered_map.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package collections
+
+import (
+	"iter"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/core/op"
+	"code.kibou.tools/base/core/option"
+)
+
+// OrderedMap is a mutable map that preserves insertion order of live keys,
+// allowing deterministic iteration and in-place deletion.
+//
+// Implementation: Currently based on chunks of fixed-sized arrays
+// of keys, values and some storage bits. Deletion leaves tombstones,
+// and the map compacts itself once live entries are no more than
+// 25% of the used slots.
+//
+// A single OrderedMap is limited to at most 2^48 live entries
+// on 64-bit platforms.
+type OrderedMap[K comparable, V any] struct {
+	// May be nil when the map is empty.
+	chunks []orderedMapChunk[K, V]
+	// May be nil when the map is empty.
+	positions map[K]position
+	// Zero when chunks is nil; otherwise the next insertion offset in the last chunk.
+	nextOffset int
+}
+
+type orderedMapChunk[K comparable, V any] struct {
+	keys    [orderedMapChunkSize]K
+	values  [orderedMapChunkSize]V
+	present uint8
+}
+
+const (
+	// Chosen somewhat arbitrarily: small enough to keep iteration
+	// cache-friendly, but large enough to amortize the per-chunk
+	// presence bitmap. It may make sense to tune this later.
+	orderedMapChunkSize = 4
+	// Conservative limit so we can repurpose bits in packed positions
+	// later without making the position type bigger.
+	orderedMapMaxEntries = uint64(1) << 48
+	orderedMapMaxChunks  = orderedMapMaxEntries / orderedMapChunkSize
+)
+
+// NewOrderedMap returns an empty ordered map.
+func NewOrderedMap[K comparable, V any]() OrderedMap[K, V] {
+	return OrderedMap[K, V]{
+		chunks:     nil,
+		positions:  nil,
+		nextOffset: 0,
+	}
+}
+
+// Lookup returns the value for key, if present.
+//
+// Expected time: Θ(1).
+func (m *OrderedMap[K, V]) Lookup(key K) option.Option[V] {
+	pos, ok := m.positions[key]
+	if !ok {
+		return option.None[V]()
+	}
+	chunkIndex, offset := pos.split()
+	return option.Some(m.chunks[chunkIndex].values[offset])
+}
+
+// Len returns the number of live entries.
+func (m *OrderedMap[K, V]) Len() int {
+	return len(m.positions)
+}
+
+// Keys returns the live keys in insertion order.
+//
+// Creating the iterator is Θ(1). Exhausting it is Θ(|m|).
+func (m *OrderedMap[K, V]) Keys() iter.Seq[K] {
+	return func(yield func(K) bool) {
+		for _, chunk := range m.chunks {
+			for offset := range orderedMapChunkSize {
+				if chunk.present&orderedMapBit(offset) == 0 {
+					continue
+				}
+				if !yield(chunk.keys[offset]) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// InsertOrKeep inserts the value if the key is absent.
+//
+// Expected time: Θ(1).
+func (m *OrderedMap[K, V]) InsertOrKeep(key K, value V) op.InsertResult {
+	if _, ok := m.positions[key]; ok {
+		return op.KeptOld
+	}
+	m.insertNew(key, value)
+	return op.InsertedNew
+}
+
+// InsertOrReplace inserts or replaces the value, returning the old value if
+// one existed.
+//
+// Expected time: Θ(1).
+func (m *OrderedMap[K, V]) InsertOrReplace(key K, value V) option.Option[V] {
+	pos, ok := m.positions[key]
+	if !ok {
+		m.insertNew(key, value)
+		return option.None[V]()
+	}
+	chunkIndex, offset := pos.split()
+	old := m.chunks[chunkIndex].values[offset]
+	m.chunks[chunkIndex].values[offset] = value
+	return option.Some(old)
+}
+
+// Delete removes key from the map and returns its old value, if present.
+//
+// Expected amortized time: Θ(1).
+func (m *OrderedMap[K, V]) Delete(key K) option.Option[V] {
+	pos, ok := m.positions[key]
+	if !ok {
+		return option.None[V]()
+	}
+	chunkIndex, offset := pos.split()
+	chunk := &m.chunks[chunkIndex]
+	old := chunk.values[offset]
+	delete(m.positions, key)
+	var zeroKey K
+	var zeroValue V
+	chunk.keys[offset] = zeroKey
+	chunk.values[offset] = zeroValue
+	chunk.present &^= orderedMapBit(offset)
+	m.compactIfNeeded()
+	return option.Some(old)
+}
+
+func (m *OrderedMap[K, V]) insertNew(key K, value V) {
+	if m.positions == nil {
+		m.positions = map[K]position{}
+	}
+	if len(m.chunks) == 0 || m.nextOffset == orderedMapChunkSize {
+		m.chunks = append(m.chunks, orderedMapChunk[K, V]{
+			keys:    [orderedMapChunkSize]K{},
+			values:  [orderedMapChunkSize]V{},
+			present: 0,
+		})
+		m.nextOffset = 0
+	}
+	chunkIndex := len(m.chunks) - 1
+	offset := m.nextOffset
+	m.chunks[chunkIndex].keys[offset] = key
+	m.chunks[chunkIndex].values[offset] = value
+	m.chunks[chunkIndex].present |= orderedMapBit(offset)
+	m.positions[key] = newPosition(chunkIndex, offset)
+	m.nextOffset++
+}
+
+func (m *OrderedMap[K, V]) compactIfNeeded() {
+	usedSlots := m.usedSlots()
+	if usedSlots == 0 || 4*m.Len() > usedSlots {
+		return
+	}
+	compacted := NewOrderedMap[K, V]()
+	for _, chunk := range m.chunks {
+		for offset := range orderedMapChunkSize {
+			if chunk.present&orderedMapBit(offset) == 0 {
+				continue
+			}
+			compacted.insertNew(chunk.keys[offset], chunk.values[offset])
+		}
+	}
+	*m = compacted
+}
+
+func (m *OrderedMap[K, V]) usedSlots() int {
+	if len(m.chunks) == 0 {
+		return 0
+	}
+	return (len(m.chunks)-1)*orderedMapChunkSize + m.nextOffset
+}
+
+type position int
+
+func newPosition(chunk int, offset int) position {
+	if chunk < 0 || orderedMapMaxChunks <= uint64(chunk) || offset < 0 || orderedMapChunkSize <= offset {
+		assert.Invariantf(false, "ordered map position outside supported range: chunk=%d offset=%d max_entries=%d",
+			chunk, offset, orderedMapMaxEntries)
+	}
+	return position(chunk<<2 | offset)
+}
+
+func (idx position) split() (chunk int, offset int) {
+	pos := int(idx)
+	return pos >> 2, pos & (orderedMapChunkSize - 1)
+}
+
+func orderedMapBit(offset int) uint8 {
+	return 1 << uint(offset)
+}

--- a/base/collections/ordered_map_test.go
+++ b/base/collections/ordered_map_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package collections_test
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/base/check"
+	"code.kibou.tools/base/collections"
+	"code.kibou.tools/base/core/op"
+	"code.kibou.tools/base/iterx"
+)
+
+func TestOrderedMap(t *testing.T) {
+	h := check.New(t)
+
+	h.Run("Unit", func(h check.Harness) {
+		h.Parallel()
+
+		m := collections.NewOrderedMap[string, int]()
+		h.Assertf(!m.Lookup("missing").IsSome(), "missing key unexpectedly present")
+		h.Assertf(m.InsertOrKeep("a", 1) == op.InsertedNew, "first insert should report InsertedNew")
+		h.Assertf(m.InsertOrKeep("a", 2) == op.KeptOld, "duplicate insert should report KeptOld")
+
+		old, ok := m.InsertOrReplace("a", 3).Get()
+		h.Assertf(ok, "InsertOrReplace should return the old value")
+		h.Assertf(old == 1, "InsertOrReplace returned old value %d, want 1", old)
+
+		h.Assertf(m.InsertOrKeep("b", 4) == op.InsertedNew, "insert of b should report InsertedNew")
+		check.AssertSame(h, []string{"a", "b"}, iterx.Collect(m.Keys()), "Keys()")
+
+		deleted, ok := m.Delete("a").Get()
+		h.Assertf(ok, "Delete should return the old value")
+		h.Assertf(deleted == 3, "Delete returned %d, want 3", deleted)
+		h.Assertf(!m.Lookup("a").IsSome(), "deleted key unexpectedly present")
+		check.AssertSame(h, []string{"b"}, iterx.Collect(m.Keys()), "Keys() after delete")
+
+		h.Assertf(m.InsertOrKeep("a", 5) == op.InsertedNew, "reinsert of deleted key should report InsertedNew")
+		check.AssertSame(h, []string{"b", "a"}, iterx.Collect(m.Keys()), "Keys() after reinsert")
+
+		compacted := collections.NewOrderedMap[int, int]()
+		for i := range 200 {
+			compacted.InsertOrReplace(i, i*10)
+		}
+		for i := range 150 {
+			_, ok := compacted.Delete(i).Get()
+			h.Assertf(ok, "Delete(%d) should find inserted key", i)
+		}
+
+		wantCompacted := make([]int, 0, 50)
+		for i := 150; i < 200; i++ {
+			wantCompacted = append(wantCompacted, i)
+		}
+		check.AssertSame(h, wantCompacted, iterx.Collect(compacted.Keys()), "Keys() after compaction")
+		h.Assertf(compacted.Len() == len(wantCompacted), "Len() = %d, want %d", compacted.Len(), len(wantCompacted))
+
+		compacted.InsertOrReplace(200, 2000)
+		wantCompacted = append(wantCompacted, 200)
+		check.AssertSame(h, wantCompacted, iterx.Collect(compacted.Keys()), "Keys() after post-compaction insert")
+	})
+
+	h.Run("Properties", func(h check.Harness) {
+		h.Parallel()
+
+		opsGen := rapid.SliceOfN(rapid.Custom(func(t *rapid.T) orderedMapOp {
+			return orderedMapOp{
+				kind:  orderedMapOpKind(rapid.IntRange(0, 2).Draw(t, "kind")),
+				key:   rapid.IntRange(-20, 20).Draw(t, "key"),
+				value: rapid.Int().Draw(t, "value"),
+			}
+		}), 0, 200)
+		rapid.Check(h.T(), func(t *rapid.T) {
+			h := check.NewBasic(t)
+			ops := opsGen.Draw(t, "ops")
+			checkKeyRolls := rapid.SliceOfN(rapid.IntRange(0, 15), len(ops), len(ops)).Draw(t, "check_key_rolls")
+
+			impl := collections.NewOrderedMap[int, int]()
+			model := collections.NewMonotoneMap[int, int]()
+			for step, op := range ops {
+				op.Apply(h, step, &impl, &model)
+
+				if checkKeyRolls[step] == 0 {
+					check.AssertSame(h, iterx.Collect(model.Keys()), iterx.Collect(impl.Keys()),
+						"Keys() during model run")
+				}
+				h.Assertf(impl.Len() == model.Len(), "step %d: Len() = %d, want %d", step, impl.Len(), model.Len())
+				modelValue, modelHasValue := model.Lookup(op.key).Get()
+				implValue, implHasValue := impl.Lookup(op.key).Get()
+				h.Assertf(implHasValue == modelHasValue,
+					"step %d: Lookup(%d) presence = %v, want %v", step, op.key, implHasValue, modelHasValue)
+				if modelHasValue {
+					h.Assertf(implValue == modelValue,
+						"step %d: Lookup(%d) = %d, want %d", step, op.key, implValue, modelValue)
+				}
+			}
+			check.AssertSame(h, iterx.Collect(model.Keys()), iterx.Collect(impl.Keys()), "final Keys()")
+		})
+	})
+}
+
+type orderedMapOp struct {
+	kind  orderedMapOpKind
+	key   int
+	value int
+}
+
+type orderedMapOpKind int
+
+const (
+	orderedMapOp_InsertOrKeep orderedMapOpKind = iota
+	orderedMapOp_InsertOrReplace
+	orderedMapOp_Delete
+)
+
+func (op orderedMapOp) Apply(
+	h check.BasicHarness,
+	step int,
+	impl *collections.OrderedMap[int, int],
+	model *collections.MonotoneMap[int, int],
+) {
+	switch op.kind {
+	case orderedMapOp_InsertOrKeep:
+		implResult := impl.InsertOrKeep(op.key, op.value)
+		modelResult := model.InsertOrKeep(op.key, op.value)
+		h.Assertf(implResult == modelResult,
+			"step %d: InsertOrKeep(%d, %d) = %v, want %v", step, op.key, op.value, implResult, modelResult)
+	case orderedMapOp_InsertOrReplace:
+		implOld, implHadOld := impl.InsertOrReplace(op.key, op.value).Get()
+		modelOld, modelHadOld := model.InsertOrReplace(op.key, op.value).Get()
+		h.Assertf(implHadOld == modelHadOld,
+			"step %d: InsertOrReplace(%d, %d) old presence = %v, want %v",
+			step, op.key, op.value, implHadOld, modelHadOld)
+		if modelHadOld {
+			h.Assertf(implOld == modelOld,
+				"step %d: InsertOrReplace(%d, %d) old = %d, want %d",
+				step, op.key, op.value, implOld, modelOld)
+		}
+	case orderedMapOp_Delete:
+		implOld, implHadOld := impl.Delete(op.key).Get()
+		modelOld, modelHadOld := model.Lookup(op.key).Get()
+		omit := collections.NewSet[int]()
+		omit.Insert(op.key)
+		*model = model.CloneWithout(omit)
+		h.Assertf(implHadOld == modelHadOld,
+			"step %d: Delete(%d) old presence = %v, want %v", step, op.key, implHadOld, modelHadOld)
+		if modelHadOld {
+			h.Assertf(implOld == modelOld,
+				"step %d: Delete(%d) old = %d, want %d", step, op.key, implOld, modelOld)
+		}
+	default:
+		h.Assertf(false, "step %d: unknown op kind %d", step, op.kind)
+	}
+}

--- a/base/collections/ordered_map_whitebox_test.go
+++ b/base/collections/ordered_map_whitebox_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package collections
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/base/check"
+)
+
+func TestOrderedMapWhitebox(t *testing.T) {
+	h := check.New(t)
+
+	h.Run("Properties", func(h check.Harness) {
+		h.Parallel()
+
+		deletionCountGen := rapid.IntRange(0, 300)
+		rapid.Check(h.T(), func(t *rapid.T) {
+			h := check.NewBasic(t)
+			count := deletionCountGen.Draw(t, "count")
+			checkRolls := rapid.SliceOfN(rapid.IntRange(0, 15), count, count).Draw(t, "check_rolls")
+
+			m := NewOrderedMap[int, int]()
+			assertOrderedMapWhitebox(h, &m, "empty map")
+			for i := range count {
+				m.InsertOrReplace(i, i*10)
+			}
+			assertOrderedMapWhitebox(h, &m, "after inserts")
+
+			for i := range count {
+				beforeUsedSlots := m.usedSlots()
+				beforeChunkCount := len(m.chunks)
+				beforeChunkCap := cap(m.chunks)
+				old, ok := m.Delete(i).Get()
+				h.Assertf(ok, "Delete(%d) should find inserted key", i)
+				h.Assertf(old == i*10, "Delete(%d) = %d, want %d", i, old, i*10)
+				h.Assertf(m.usedSlots() <= beforeUsedSlots,
+					"usedSlots increased after deletion: %d -> %d", beforeUsedSlots, m.usedSlots())
+				h.Assertf(len(m.chunks) <= beforeChunkCount,
+					"chunk count increased after deletion: %d -> %d", beforeChunkCount, len(m.chunks))
+				h.Assertf(cap(m.chunks) <= beforeChunkCap,
+					"chunk capacity increased after deletion: %d -> %d", beforeChunkCap, cap(m.chunks))
+				if checkRolls[i] == 0 {
+					assertOrderedMapWhitebox(h, &m, "after delete")
+				}
+			}
+			assertOrderedMapWhitebox(h, &m, "after all deletes")
+			assertOrderedMapHasEmptyShape(h, &m)
+		})
+	})
+}
+
+func assertOrderedMapHasEmptyShape(h check.BasicHarness, m *OrderedMap[int, int]) {
+	empty := NewOrderedMap[int, int]()
+	h.Assertf(len(m.chunks) == len(empty.chunks), "final chunk count = %d, want %d", len(m.chunks), len(empty.chunks))
+	h.Assertf(cap(m.chunks) == cap(empty.chunks), "final chunk capacity = %d, want %d", cap(m.chunks), cap(empty.chunks))
+	h.Assertf(m.positions == nil, "final positions should be nil")
+	h.Assertf(m.nextOffset == empty.nextOffset, "final nextOffset = %d, want %d", m.nextOffset, empty.nextOffset)
+}
+
+func assertOrderedMapWhitebox(h check.BasicHarness, m *OrderedMap[int, int], what string) {
+	usedSlots := m.usedSlots()
+	h.Assertf(usedSlots == 0 || 4*m.Len() > usedSlots,
+		"%s: live count = %d, usedSlots = %d", what, m.Len(), usedSlots)
+	h.Assertf(0 <= m.nextOffset && m.nextOffset <= orderedMapChunkSize,
+		"%s: nextOffset = %d, want in [0, %d]", what, m.nextOffset, orderedMapChunkSize)
+	h.Assertf(m.Len() <= m.usedSlots(), "%s: live count %d exceeds usedSlots %d", what, m.Len(), m.usedSlots())
+	h.Assertf(m.usedSlots() <= len(m.chunks)*orderedMapChunkSize,
+		"%s: usedSlots %d exceeds chunk capacity %d", what, m.usedSlots(), len(m.chunks)*orderedMapChunkSize)
+	for key, pos := range m.positions {
+		chunkIndex, offset := pos.split()
+		h.Assertf(0 <= chunkIndex && chunkIndex < len(m.chunks),
+			"%s: position for key %d has chunk %d outside [0, %d)", what, key, chunkIndex, len(m.chunks))
+		h.Assertf(0 <= offset && offset < orderedMapChunkSize,
+			"%s: position for key %d has offset %d outside [0, %d)", what, key, offset, orderedMapChunkSize)
+		chunk := m.chunks[chunkIndex]
+		h.Assertf(chunk.present&orderedMapBit(offset) != 0,
+			"%s: position for key %d points at absent slot", what, key)
+		h.Assertf(chunk.keys[offset] == key,
+			"%s: position for key %d points at key %d", what, key, chunk.keys[offset])
+	}
+}


### PR DESCRIPTION
Currently implemented as a storage slice +
integer indexes, with occasional compaction
when the map is <25% full.

A linked map would likely be much worse
for iteration by being less cache-friendly.
