### PR TITLE
feat(fsx): Redefine OpenOptions with more knobs

### DIFF
--- a/base/fsx/fsx.go
+++ b/base/fsx/fsx.go
@@ -16,13 +16,14 @@ import (
 	"iter"
 	"os"
 
-	"code.kibou.tools/base/fsx/fsx_name"
 	"github.com/spf13/afero" //nolint:depguard // fsx is the designated wrapper
 
 	"code.kibou.tools/base/assert"
 	"code.kibou.tools/base/core/pathx"
 	"code.kibou.tools/base/core/result"
 	"code.kibou.tools/base/errorx"
+	"code.kibou.tools/base/fsx/fsx_name"
+	"code.kibou.tools/base/fsx/fsx_opt"
 	"code.kibou.tools/base/internal/constants"
 	"code.kibou.tools/base/iterx"
 )
@@ -30,21 +31,27 @@ import (
 // ErrNotExist is [fs.ErrNotExist], re-exported so callers need not import io/fs.
 var ErrNotExist = iofs.ErrNotExist
 
-// File is an open file handle returned by [FS.Open] and similar methods.
+// File is an open file handle returned by [FS.OpenFile] and similar methods.
 // It is an alias for [afero.File] so callers need not import afero directly.
 type File = afero.File
 
-type OpenMode int
+type OpenRW = fsx_opt.OpenRW
 
 const (
-	OpenMode_ReadOnly OpenMode = iota + 1
-	OpenMode_WriteOnly
-	OpenMode_ReadWrite
+	OpenRW_ReadOnly  = fsx_opt.OpenRW_ReadOnly
+	OpenRW_WriteOnly = fsx_opt.OpenRW_WriteOnly
+	OpenRW_ReadWrite = fsx_opt.OpenRW_ReadWrite
 )
 
-type OpenOptions struct {
-	Mode OpenMode
-}
+type OpenMode = fsx_opt.OpenMode
+
+const (
+	OpenMode_Existing     = fsx_opt.OpenMode_Existing
+	OpenMode_CreateOrKeep = fsx_opt.OpenMode_CreateOrKeep
+	OpenMode_CreateNew    = fsx_opt.OpenMode_CreateNew
+)
+
+type OpenOptions = fsx_opt.OpenOptions
 
 // DirEntry is a single entry returned by [FS.ReadDir].
 type DirEntry interface {
@@ -81,7 +88,7 @@ type BaseFS interface {
 type FS interface {
 	Root() pathx.AbsPath
 	ReadDir(rel pathx.RelPath) iter.Seq[result.Result[DirEntry]]
-	Open(rel pathx.RelPath, opts OpenOptions) (File, error)
+	OpenFile(rel pathx.RelPath, opts OpenOptions) (File, error)
 	ReadFile(rel pathx.RelPath) ([]byte, error)
 	WriteFile(rel pathx.RelPath, data []byte, perm os.FileMode) error
 	MkdirAll(rel pathx.RelPath, perm os.FileMode) error
@@ -182,24 +189,6 @@ func (fs rootedFS) readDirBatches(rel pathx.RelPath) iter.Seq[result.Result[[]io
 				return
 			}
 		}
-	}
-}
-
-// Open opens the file at the given root-relative path.
-func (fs rootedFS) Open(rel pathx.RelPath, opts OpenOptions) (File, error) {
-	return fs.base.OpenFile(rel.String(), openFlags(opts.Mode), 0)
-}
-
-func openFlags(mode OpenMode) int {
-	switch mode {
-	case OpenMode_ReadOnly:
-		return os.O_RDONLY
-	case OpenMode_WriteOnly:
-		return os.O_WRONLY
-	case OpenMode_ReadWrite:
-		return os.O_RDWR
-	default:
-		return assert.PanicUnknownCase[int](mode)
 	}
 }
 

--- a/base/fsx/fsx_opt/open.go
+++ b/base/fsx/fsx_opt/open.go
@@ -1,0 +1,256 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package fsx_opt covers different options used to configure
+// filesystem operations.
+package fsx_opt
+
+import (
+	"fmt"
+
+	"code.kibou.tools/base/assert"
+)
+
+// OpenOptions represents the options for opening a file.
+type OpenOptions struct {
+	rw       OpenRW
+	mode     OpenMode
+	append   bool
+	truncate bool
+}
+
+// RW returns whether the file is meant to be opened as
+// read-only/write-only/read-write.
+func (o OpenOptions) RW() OpenRW { return o.rw }
+
+// Mode returns whether the file should be created and/or
+// if an existing file can be opened as-is.
+func (o OpenOptions) Mode() OpenMode { return o.mode }
+
+// Append returns whether the file will be opened in
+// append-mode.
+func (o OpenOptions) Append() bool {
+	return o.append
+}
+
+func (o OpenOptions) TruncateIfPresent() bool {
+	return o.truncate
+}
+
+// OpenRW represents the read and/or write permissions
+// for a file open operation.
+type OpenRW uint8
+
+const (
+	// OpenRW_ReadOnly is used to open a file in read-only mode.
+	OpenRW_ReadOnly OpenRW = iota + 1
+	// OpenRW_WriteOnly is used to open a file in write-only mode.
+	OpenRW_WriteOnly
+	// OpenRW_ReadWrite is used to open a file in read-write mode.
+	OpenRW_ReadWrite
+)
+
+func (rw OpenRW) String() string {
+	switch rw {
+	case OpenRW_ReadOnly:
+		return "OpenRW_ReadOnly"
+	case OpenRW_WriteOnly:
+		return "OpenRW_WriteOnly"
+	case OpenRW_ReadWrite:
+		return "OpenRW_ReadWrite"
+	default:
+		return assert.PanicUnknownCase[string](rw)
+	}
+}
+
+// Label returns a friendly kebab-case label for OpenRW suitable
+// for user-facing messages in English.
+func (rw OpenRW) Label() string {
+	switch rw {
+	case OpenRW_ReadOnly:
+		return "read-only"
+	case OpenRW_WriteOnly:
+		return "write-only"
+	case OpenRW_ReadWrite:
+		return "read-write"
+	default:
+		return assert.PanicUnknownCase[string](rw)
+	}
+}
+
+// OpenMode represents whether an existing file may be opened
+// and/or whether a new file is created.
+type OpenMode uint8
+
+const (
+	// OpenMode_Existing only opens the file if it exists already.
+	// If the file doesn't exist, [fsx.ErrNotExist] is returned.
+	OpenMode_Existing OpenMode = iota + 1
+	// OpenMode_CreateOrKeep opens the file if it exists already,
+	// or creates a new file and opens it if it doesn't exist.
+	OpenMode_CreateOrKeep
+	// OpenMode_CreateNew creates the file only if it doesn't exist already,
+	// and opens the file.
+	//
+	// If the file already exists, [fsx.ErrExist] is returned.
+	OpenMode_CreateNew
+)
+
+func (mode OpenMode) String() string {
+	switch mode {
+	case OpenMode_Existing:
+		return "OpenMode_Existing"
+	case OpenMode_CreateOrKeep:
+		return "OpenMode_CreateOrKeep"
+	case OpenMode_CreateNew:
+		return "OpenMode_CreateNew"
+	default:
+		return assert.PanicUnknownCase[string](mode)
+	}
+}
+
+// OpenOptionsBuilder is a builder struct used for creating an OpenOptions.
+type OpenOptionsBuilder struct {
+	rw       OpenRW
+	mode     OpenMode
+	append   bool
+	truncate bool
+}
+
+// Open creates a new OpenOptionsBuilder, which can be constructed
+// with [OpenOptionsBuilder.Build] or [OpenOptionsBuilder.MustBuild].
+//
+// For example, if you want to open a log file for appending,
+// you'd typically do:
+//
+//	opts := fsx_opt.Open(fsx_opt.OpenRW_WriteOnly).
+//		WithMode(fsx_opt.OpenMode_CreateOrKeep).
+//		WithAppend(true).
+//		MustBuild()
+func Open(rw OpenRW) OpenOptionsBuilder {
+	switch rw {
+	case OpenRW_ReadOnly, OpenRW_WriteOnly, OpenRW_ReadWrite:
+	default:
+		assert.Preconditionf(false, "unknown value for fsx_opt.OpenRW %d", rw)
+	}
+	return OpenOptionsBuilder{rw: rw, mode: OpenMode_Existing, append: false, truncate: false}
+}
+
+func (b OpenOptionsBuilder) WithMode(mode OpenMode) OpenOptionsBuilder {
+	switch mode {
+	case OpenMode_Existing, OpenMode_CreateOrKeep, OpenMode_CreateNew:
+	default:
+		assert.Preconditionf(false, "unknown value for fsx_opt.OpenMode %d", mode)
+	}
+	b.mode = mode
+	return b
+}
+
+// WithAppend changes whether the file should be opened in append
+// mode or not.
+//
+// NOTE: This is incompatible with OpenRW_ReadOnly, and will lead to
+// an error with Build and a panic with MustBuild.
+func (b OpenOptionsBuilder) WithAppend(append bool) OpenOptionsBuilder {
+	b.append = append
+	return b
+}
+
+// WithTruncateIfPresent changes whether the file should be truncated
+// if it's already present on disk, or not.
+//
+// NOTE: This is incompatible with OpenRW_ReadOnly, and will lead to
+// an error with Build and a panic with MustBuild.
+func (b OpenOptionsBuilder) WithTruncateIfPresent(truncate bool) OpenOptionsBuilder {
+	b.truncate = truncate
+	return b
+}
+
+// Build attempts to Build an OpenOptions, returning an error
+// if some invalid configuration of options was configured.
+//
+// Currently, an error is returned if the following are combined
+// with OpenRW_ReadOnly:
+//
+// - OpenMode_CreateOrKeep
+// - OpenMode_CreateNew
+// - TruncateIfPresent(true)
+// - Append(true)
+//
+// The set of errors may increase over time.
+func (b OpenOptionsBuilder) Build() (OpenOptions, *OpenOptionsBuildError) {
+	switch b.rw {
+	case OpenRW_ReadOnly:
+		if b.mode != OpenMode_Existing {
+			return OpenOptions{}, missingWritePerm(b.mode.String())
+		}
+		if b.truncate {
+			return OpenOptions{}, missingWritePerm("OpenOptions.TruncateIfPresent=true")
+		}
+		if b.append {
+			return OpenOptions{}, missingWritePerm("OpenOptions.Append=true")
+		}
+	case OpenRW_WriteOnly, OpenRW_ReadWrite:
+	default:
+		assert.PanicUnknownCase[struct{}](b.rw)
+	}
+	if b.mode == OpenMode_CreateNew && b.truncate { //nolint:staticcheck
+		// TODO: In this situation, b.truncate will not have
+		// the intended effect; it will just be ignored.
+		// Perhaps we should emit a warning using a separate API.
+	}
+	return OpenOptions(b), nil
+}
+
+// MustBuild asserts that the builder is well-formed and returns
+// the built OpenOptions.
+//
+// See [OpenOptionsBuilder.Build] for the possible error cases.
+func (b OpenOptionsBuilder) MustBuild() OpenOptions {
+	opts, err := b.Build()
+	if err != nil {
+		assert.Preconditionf(false, "invalid OpenOptions: %v", err)
+	}
+	return opts
+}
+
+type OpenOptionsBuildError struct {
+	kind     OpenOptionsBuildErrorKind
+	neededBy string
+}
+
+type OpenOptionsBuildErrorKind uint8
+
+const (
+	OpenOptionsBuildErrorKind_MissingWritePermission OpenOptionsBuildErrorKind = iota + 1
+)
+
+func NewOpenOptionsBuildError(kind OpenOptionsBuildErrorKind, neededBy string) *OpenOptionsBuildError {
+	return &OpenOptionsBuildError{kind: kind, neededBy: neededBy}
+}
+
+func (e *OpenOptionsBuildError) Kind() OpenOptionsBuildErrorKind {
+	return e.kind
+}
+
+// NeededBy returns which setting for OpenOptionsBuilder needed the
+// necessary permission.
+func (e *OpenOptionsBuildError) NeededBy() string {
+	return e.neededBy
+}
+
+func (e *OpenOptionsBuildError) Error() string {
+	switch e.kind {
+	case OpenOptionsBuildErrorKind_MissingWritePermission:
+		return fmt.Sprintf("%s requires OpenRW_WriteOnly or OpenRW_ReadWrite", e.neededBy)
+	default:
+		return assert.PanicUnknownCase[string](e.kind)
+	}
+}
+
+func missingWritePerm(neededBy string) *OpenOptionsBuildError {
+	return NewOpenOptionsBuildError(
+		OpenOptionsBuildErrorKind_MissingWritePermission,
+		neededBy)
+}

--- a/base/fsx/fsx_opt/open_test.go
+++ b/base/fsx/fsx_opt/open_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package fsx_opt_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"code.kibou.tools/base/check"
+	"code.kibou.tools/base/fsx/fsx_opt"
+)
+
+func TestOpenOptionsBuilder(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	_ = fsx_opt.Open(fsx_opt.OpenRW_ReadOnly).MustBuild()
+
+	_ = fsx_opt.Open(fsx_opt.OpenRW_ReadWrite).
+		WithMode(fsx_opt.OpenMode_CreateNew).
+		MustBuild()
+
+	_, err := fsx_opt.Open(fsx_opt.OpenRW_ReadOnly).
+		WithMode(fsx_opt.OpenMode_CreateNew).
+		Build()
+	wantErr := fsx_opt.NewOpenOptionsBuildError(
+		fsx_opt.OpenOptionsBuildErrorKind_MissingWritePermission,
+		fsx_opt.OpenMode_CreateNew.String())
+	check.AssertSame(h, wantErr, err, "OpenOptionsBuildError",
+		cmp.AllowUnexported(fsx_opt.OpenOptionsBuildError{}))
+
+	opts := fsx_opt.Open(fsx_opt.OpenRW_WriteOnly).
+		WithMode(fsx_opt.OpenMode_CreateNew).
+		WithMode(fsx_opt.OpenMode_CreateOrKeep).
+		MustBuild()
+	h.Assertf(opts.Mode() == fsx_opt.OpenMode_CreateOrKeep, "last WithMode call should win")
+}

--- a/base/fsx/fsx_testkit/fsx_testkit.go
+++ b/base/fsx/fsx_testkit/fsx_testkit.go
@@ -103,11 +103,11 @@ func (fs *faultyFS) Stat(rel pathx.RelPath, opts fsx.StatOptions) (os.FileInfo, 
 	return fs.FS.Stat(rel, opts)
 }
 
-func (fs *faultyFS) Open(rel pathx.RelPath, opts fsx.OpenOptions) (fsx.File, error) {
+func (fs *faultyFS) OpenFile(rel pathx.RelPath, opts fsx.OpenOptions) (fsx.File, error) {
 	if fs.hasFault(FaultOp_Open, rel) {
 		return nil, injectedFSError()
 	}
-	return fs.FS.Open(rel, opts)
+	return fs.FS.OpenFile(rel, opts)
 }
 
 func (fs *faultyFS) ReadFile(rel pathx.RelPath) ([]byte, error) {

--- a/base/fsx/open.go
+++ b/base/fsx/open.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package fsx
+
+import (
+	"os"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/core/pathx"
+	"code.kibou.tools/base/fsx/fsx_opt"
+)
+
+func NewOpenOptions(rw OpenRW) fsx_opt.OpenOptionsBuilder {
+	return fsx_opt.Open(rw)
+}
+
+func OpenReadOnly(fs FS, rel pathx.RelPath) (File, error) {
+	return fs.OpenFile(rel, NewOpenOptions(OpenRW_ReadOnly).MustBuild())
+}
+
+// OpenFile opens the file at the given root-relative path.
+func (fs rootedFS) OpenFile(rel pathx.RelPath, opts OpenOptions) (File, error) {
+	return fs.base.OpenFile(rel.String(), openFlags(opts), openPerm(opts))
+}
+
+func openFlags(opts OpenOptions) int {
+	var flags int
+	switch opts.RW() {
+	case OpenRW_ReadOnly:
+		flags = os.O_RDONLY
+	case OpenRW_WriteOnly:
+		flags = os.O_WRONLY
+	case OpenRW_ReadWrite:
+		flags = os.O_RDWR
+	default:
+		return assert.PanicUnknownCase[int](opts.RW())
+	}
+	if opts.Append() {
+		flags |= os.O_APPEND
+	}
+	if opts.TruncateIfPresent() {
+		flags |= os.O_TRUNC
+	}
+	switch opts.Mode() {
+	case OpenMode_Existing:
+	case OpenMode_CreateOrKeep:
+		flags |= os.O_CREATE
+	case OpenMode_CreateNew:
+		flags |= os.O_CREATE | os.O_EXCL
+	default:
+		return assert.PanicUnknownCase[int](opts.Mode())
+	}
+	return flags
+}
+
+func openPerm(opts OpenOptions) os.FileMode {
+	switch opts.Mode() {
+	case OpenMode_Existing:
+		return 0
+	case OpenMode_CreateOrKeep, OpenMode_CreateNew:
+		// FIXME(issue: https://github.com/kibou-tools/kibou/issues/216):
+		// Expose a better way of specifying the permissions here.
+		// This matches the defaults in Rust's cap-std and Java's NIO2.
+		return 0o666
+	default:
+		return assert.PanicUnknownCase[os.FileMode](opts.Mode())
+	}
+}

--- a/base/fsx/open_test.go
+++ b/base/fsx/open_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package fsx_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"code.kibou.tools/base/check"
+	. "code.kibou.tools/base/check/prelude"
+	"code.kibou.tools/base/core/pathx"
+	"code.kibou.tools/base/fsx"
+	"code.kibou.tools/base/fsx/fsx_testkit"
+)
+
+func TestFSOpenOptions(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	repoFS := fsx_testkit.TempDirFS(h)
+	rel := pathx.MustParseRelPath("capture.jsonl")
+
+	createNewOpts := fsx.NewOpenOptions(fsx.OpenRW_WriteOnly).
+		WithMode(fsx.OpenMode_CreateNew).
+		MustBuild()
+	f := Do(repoFS.OpenFile(rel, createNewOpts))(h)
+	_ = Do(io.WriteString(f, "first\n"))(h)
+	h.Close(f)
+
+	_, err := repoFS.OpenFile(rel, createNewOpts)
+	h.Assertf(err != nil, "CreateNew should fail when the file already exists")
+
+	truncateOpts := fsx.NewOpenOptions(fsx.OpenRW_WriteOnly).
+		WithTruncateIfPresent(true).
+		MustBuild()
+	f = Do(repoFS.OpenFile(rel, truncateOpts))(h)
+	h.Close(f)
+	data := Do(repoFS.ReadFile(rel))(h)
+	h.Assertf(len(data) == 0, "TruncateIfPresent should empty the file, got %q", data)
+
+	appendOpts := fsx.NewOpenOptions(fsx.OpenRW_WriteOnly).
+		WithAppend(true).
+		MustBuild()
+	f = Do(repoFS.OpenFile(rel, appendOpts))(h)
+	_ = Do(io.WriteString(f, "appended\n"))(h)
+	h.Close(f)
+	data = Do(repoFS.ReadFile(rel))(h)
+	h.Assertf(strings.HasSuffix(string(data), "appended\n"), "Append should write at the end, got %q", data)
+}

--- a/misc/cmd/kido/list.go
+++ b/misc/cmd/kido/list.go
@@ -19,7 +19,7 @@ import (
 
 func loadWorkspaceConfig(repoFS fsx.FS) (_ config.WorkspaceConfig, retErr error) {
 	path := MustParseRelPath("misc/repo-configuration.json")
-	f, err := repoFS.Open(path, fsx.OpenOptions{Mode: fsx.OpenMode_ReadOnly})
+	f, err := fsx.OpenReadOnly(repoFS, path)
 	if err != nil {
 		return config.WorkspaceConfig{}, errorx.Wrapf("+stacks", err, "open %s", path)
 	}

--- a/misc/internal/licenses/licenses_test.go
+++ b/misc/internal/licenses/licenses_test.go
@@ -83,7 +83,7 @@ func loadWorkspaceConfig(h check.Harness, repoFS fsx.FS) config.WorkspaceConfig 
 	h.T().Helper()
 
 	path := MustParseRelPath("misc/repo-configuration.json")
-	f := DoMsg(repoFS.Open(path, fsx.OpenOptions{Mode: fsx.OpenMode_ReadOnly}))(h, "opening %s", path)
+	f := DoMsg(fsx.OpenReadOnly(repoFS, path))(h, "opening %s", path)
 	defer h.Close(f)
 
 	return DoMsg(config.Load(f))(h, "loading %s", path)
@@ -174,11 +174,11 @@ func visitWalkEntries(
 
 // ensureLicenseHeader reports whether rel has the required header, updating it when -update is set.
 func ensureLicenseHeader(h check.Harness, repoFS fsx.FS, rel RelPath) bool {
-	mode := fsx.OpenMode_ReadOnly
+	mode := fsx.OpenRW_ReadOnly
 	if check.IsUpdateFlagSet() {
-		mode = fsx.OpenMode_ReadWrite
+		mode = fsx.OpenRW_ReadWrite
 	}
-	f := DoMsg(repoFS.Open(rel, fsx.OpenOptions{Mode: mode}))(h, "open %s", rel)
+	f := DoMsg(repoFS.OpenFile(rel, fsx.NewOpenOptions(mode).MustBuild()))(h, "open %s", rel)
 	defer h.Close(f)
 
 	var want bytes.Buffer

--- a/misc/mappings_test.go
+++ b/misc/mappings_test.go
@@ -32,7 +32,7 @@ func TestWorkspaceConfig(t *testing.T) {
 	h.Assertf(ok, "working directory %s must have a parent", workingDir)
 	repoFS := DoMsg(syscaps.FS(repoRoot))(h, "opening repo FS")
 
-	f := DoMsg(repoFS.Open(MustParseRelPath("misc/repo-configuration.json"), fsx.OpenOptions{Mode: fsx.OpenMode_ReadOnly}))(h, "opening repo-configuration.json")
+	f := DoMsg(fsx.OpenReadOnly(repoFS, MustParseRelPath("misc/repo-configuration.json")))(h, "opening repo-configuration.json")
 	t.Cleanup(func() { _ = f.Close() })
 
 	wsConfig := Do(config.Load(f))(h)


### PR DESCRIPTION
Adds a builder-based OpenOptions type with separate
controls for read/write/read-write access,
while separately modeling creation rules,
truncation and appending.

This aligns the API more with cap-std and nio2
in Java. One key difference is that for illegal
combinations, we return an error (or assert
with MustBuild) instead of ignoring some specified
options.

We need this for later work on creating temporary
files, since that needs a way to say "I want to
create this new file, if the file already exists,
please give me an error."
