### PR TITLE
feat(fsx): Add APIs for temp file creation

### DIFF
--- a/base/fsx/fsx.go
+++ b/base/fsx/fsx.go
@@ -28,8 +28,12 @@ import (
 	"code.kibou.tools/base/iterx"
 )
 
-// ErrNotExist is [fs.ErrNotExist], re-exported so callers need not import io/fs.
+// ErrNotExist indicates a "file does not exist" error.
 var ErrNotExist = iofs.ErrNotExist
+
+// ErrExist indicates that a "file already exists" error
+// when trying to create a file with [fsx.OpenMode_CreateNew].
+var ErrExist = iofs.ErrExist
 
 // File is an open file handle returned by [FS.OpenFile] and similar methods.
 type File interface {

--- a/base/fsx/fsx_temp/Design.djot
+++ b/base/fsx/fsx_temp/Design.djot
@@ -1,0 +1,61 @@
+::: metadata
+references:
+  packages:
+    - code.kibou.tools/base/fsx/fsx_temp
+    - code.kibou.tools/base/syscaps
+  declarations:
+    - fsx_temp.CreateFile
+:::
+
+# Design of the `fsx_temp` package
+
+The main API in this package is [CreateFile]{.sym}:
+
+```go
+func CreateFile(
+	fs fsx.FS, dir pathx.RelPath,
+	names iter.Seq[fsx.Name],
+	opts fsx_opt.OpenOptionsBuilder,
+) (fsx.File, *CreateFileError)
+```
+
+This is somewhat unusual as far as
+temporary file creation APIs go.
+There are a few reasons for this choice.
+
+1. Existing APIs in the Go stdlib, in [cap-tempfile][]
+   etc. usually own the control flow, instead of
+   leaving it up to the caller. The main control
+   flow decision here is about how many iterations
+   should be taken.
+
+   - The Go stdlib tries up to 10000 times, for
+     unclear reasons. Afero simply copies this limit.
+   - cap-tempfile retries an unbounded number of times.
+
+   In the Kibou base libraries, we generally try to
+   let callers control the flow. Deciding the limit for
+   how many iterations is appropriate likely depends
+   on the application.
+
+   Instead, we ship with a conservative default of 100
+   which lives at the [syscaps]{.sym} layer.
+
+2. Existing temporary file creation APIs in capability-safe
+   libraries, such as the
+   [Pony standard library](https://stdlib.ponylang.io/files-Path/#random)
+   and [cap-tempfile][] directly access RNGs, process
+   PIDs etc. and mix them into the name, which is
+   annoying for testing. For example, if you're creating a
+   bunch of temporary files for testing, it's nice for
+   you to be able to control the names _if needed_.
+
+   Capabilities in Kibou are primarily focused on enabling
+   determinism for testing, so it makes sense for the
+   most low-level API to be "pure" instead of coming
+   up with names based on global state.
+
+   For convenience, [syscaps]{.sym} exposes APIs which allow
+   easily plugging in a stream of names.
+
+[cap-tempfile]: https://docs.rs/cap-tempfile/latest/cap_tempfile/struct.TempFile.html

--- a/base/fsx/fsx_temp/examples_test.go
+++ b/base/fsx/fsx_temp/examples_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package fsx_temp_test
+
+import (
+	"io"
+
+	"code.kibou.tools/base/core/pathx"
+	"code.kibou.tools/base/fsx"
+	"code.kibou.tools/base/fsx/fsx_temp"
+	"code.kibou.tools/base/syscaps"
+)
+
+func ExampleCreateFile_withSyscapsTempFileNames() {
+	repoFS, _ := fsx.MemMap(pathx.MustParseAbsPath("/repo"))
+
+	file, _ := fsx_temp.CreateFile(
+		repoFS,
+		pathx.Dot(),
+		syscaps.TempFileNames(`capture-*.jsonl`),
+		fsx.NewOpenOptions(fsx.OpenRW_WriteOnly),
+	)
+
+	_, _ = io.WriteString(file, "{}\n")
+	_ = file.Close()
+}

--- a/base/fsx/fsx_temp/temp.go
+++ b/base/fsx/fsx_temp/temp.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package fsx_temp
+
+import (
+	"fmt"
+	"iter"
+	"strings"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/core/pathx"
+	"code.kibou.tools/base/errorx"
+	"code.kibou.tools/base/fsx"
+	"code.kibou.tools/base/fsx/fsx_opt"
+)
+
+// CreateFile creates a temporary file in the directory 'dir' in 'fs'.
+//
+// The candidate file names are returned based on the names iterator.
+//
+// Pre-condition: opts must build successfully after setting
+// [fsx.OpenMode_CreateNew]. In particular, its [fsx.OpenRW] must allow writes.
+func CreateFile(
+	fs fsx.FS, dir pathx.RelPath,
+	names iter.Seq[fsx.Name],
+	opts fsx_opt.OpenOptionsBuilder,
+) (fsx.File, *CreateFileError) {
+	opts_, err := opts.
+		WithMode(fsx.OpenMode_CreateNew).
+		Build()
+	if err != nil {
+		assert.Preconditionf(false, "CreateFile.opts failed to build with OpenMode_CreateNew: %v (input: %+v)", err, opts)
+	}
+
+	for name := range names {
+		rel := dir.JoinOne(name)
+		f, err := fs.OpenFile(rel, opts_)
+		if err == nil {
+			return f, nil
+		}
+		if errorx.GetRootCauseAsValue(err, fsx.ErrExist) {
+			continue
+		}
+		assert.Invariant(err != nil, "nil I/O error")
+		return nil, &CreateFileError{kind: CreateFileErrorKind_IOError, path: rel, err: err}
+	}
+	return nil, &CreateFileError{kind: CreateFileErrorKind_OutOfNames, path: pathx.RelPath{}, err: nil}
+}
+
+// CreateFileErrorKind classifies a [CreateFileError].
+type CreateFileErrorKind uint8
+
+const (
+	// CreateFileErrorKind_IOError indicates a filesystem I/O failure while
+	// trying to create a candidate file.
+	//
+	// Methods returning data:
+	//   - [CreateFileError.Path]: root-relative path of the failing operation.
+	//   - [CreateFileError.Unwrap]: the underlying I/O error.
+	CreateFileErrorKind_IOError CreateFileErrorKind = iota + 1
+	// CreateFileErrorKind_OutOfNames indicates that every candidate name was
+	// already taken.
+	CreateFileErrorKind_OutOfNames
+)
+
+// CreateFileError is the structured error type returned by [CreateFile].
+type CreateFileError struct {
+	kind CreateFileErrorKind
+	path pathx.RelPath
+	err  error
+}
+
+// Kind returns the error kind.
+func (e *CreateFileError) Kind() CreateFileErrorKind {
+	return e.kind
+}
+
+// Path returns the root-relative path associated with the error.
+//
+// Pre-condition: [CreateFileError.Kind] == [CreateFileErrorKind_IOError].
+func (e *CreateFileError) Path() pathx.RelPath {
+	switch e.kind {
+	case CreateFileErrorKind_IOError:
+		return e.path
+	case CreateFileErrorKind_OutOfNames:
+		assert.Preconditionf(false, "Path() called on CreateFileError kind %v", e.kind)
+		return pathx.RelPath{}
+	default:
+		return assert.PanicUnknownCase[pathx.RelPath](e.kind)
+	}
+}
+
+func (e *CreateFileError) Error() string {
+	switch e.kind {
+	case CreateFileErrorKind_IOError:
+		return fmt.Sprintf("create temporary file %s: %v", e.path, e.err)
+	case CreateFileErrorKind_OutOfNames:
+		return "no temporary file candidate name could be created"
+	default:
+		return assert.PanicUnknownCase[string](e.kind)
+	}
+}
+
+func (e *CreateFileError) Unwrap() error {
+	return e.err
+}
+
+func Names(prefix []byte, fragments iter.Seq[[]byte], suffix []byte) iter.Seq[fsx.Name] {
+	return func(yield func(fsx.Name) bool) {
+		var builder strings.Builder
+		for fragment := range fragments {
+			builder.Grow(len(prefix) + len(fragment) + len(suffix))
+			builder.Write(prefix)
+			builder.Write(fragment)
+			builder.Write(suffix)
+			if !yield(fsx.NewName(builder.String())) {
+				return
+			}
+			builder.Reset()
+		}
+	}
+}

--- a/base/fsx/fsx_temp/temp_test.go
+++ b/base/fsx/fsx_temp/temp_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package fsx_temp_test
+
+import (
+	"iter"
+	"testing"
+
+	"code.kibou.tools/base/check"
+	"code.kibou.tools/base/core/pathx"
+	"code.kibou.tools/base/core/pathx/pathx_testkit"
+	"code.kibou.tools/base/fsx"
+	"code.kibou.tools/base/fsx/fsx_temp"
+	"code.kibou.tools/base/fsx/fsx_testkit"
+	"code.kibou.tools/base/iterx"
+)
+
+func TestNames(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("Unit", func(h check.Harness) {
+		h.Parallel()
+
+		nameSeq := fsx_temp.Names([]byte("capture-"), fragments("tmp0001", "tmp0002"), []byte(".jsonl"))
+		names := iterx.Map(nameSeq, fsx.Name.String)
+		check.AssertSame(h,
+			[]string{"capture-tmp0001.jsonl", "capture-tmp0002.jsonl"},
+			iterx.Collect(names),
+			"names")
+	})
+}
+
+func TestCreateFile(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("Unit", func(h check.Harness) {
+		h.Parallel()
+
+		h.Run("creates first available candidate", func(h check.Harness) {
+			h.Parallel()
+
+			repoFS := fsx_testkit.TempDirFS(h)
+			fsx_testkit.WriteFile(h, repoFS, pathx.MustParseRelPath("capture-tmp0001.jsonl"), "taken")
+
+			nameSeq := fsx_temp.Names(
+				[]byte("capture-"),
+				fragments("tmp0001", "tmp0002"),
+				[]byte(".jsonl"))
+			opts := fsx.NewOpenOptions(fsx.OpenRW_WriteOnly)
+			f, err := fsx_temp.CreateFile(repoFS, pathx.Dot(), nameSeq, opts)
+			h.Assertf(err == nil, "CreateFile returned error: %v", err)
+			defer h.Close(f)
+
+			check.AssertSame(h, "capture-tmp0002.jsonl", f.Name().String(), "created name")
+		})
+
+		h.Run("out of names", func(h check.Harness) {
+			h.Parallel()
+
+			repoFS := fsx_testkit.TempDirFS(h)
+			fsx_testkit.WriteFile(h, repoFS, pathx.MustParseRelPath("capture-tmp0001.jsonl"), "taken")
+
+			nameSeq := fsx_temp.Names([]byte("capture-"), fragments("tmp0001"), []byte(".jsonl"))
+			opts := fsx.NewOpenOptions(fsx.OpenRW_WriteOnly)
+			_, err := fsx_temp.CreateFile(repoFS, pathx.Dot(), nameSeq, opts)
+			h.Assertf(err != nil, "CreateFile should fail when all candidates exist")
+			check.AssertSame(h, fsx_temp.CreateFileErrorKind_OutOfNames, err.Kind(), "error kind")
+		})
+
+		h.Run("I/O error", func(h check.Harness) {
+			h.Parallel()
+
+			repoFS := fsx_testkit.TempDirFS(h)
+			dir := pathx.MustParseRelPath("missing")
+
+			nameSeq := fsx_temp.Names([]byte("capture-"), fragments("tmp0001"), []byte(".jsonl"))
+			opts := fsx.NewOpenOptions(fsx.OpenRW_WriteOnly)
+			_, err := fsx_temp.CreateFile(repoFS, dir, nameSeq, opts)
+			h.Assertf(err != nil, "CreateFile should fail when parent directory is missing")
+			check.AssertSame(h, fsx_temp.CreateFileErrorKind_IOError, err.Kind(), "error kind")
+			check.AssertSame(h, dir.JoinOne(fsx.NewName("capture-tmp0001.jsonl")), err.Path(), "error path", pathx_testkit.CompareOptions()...)
+			h.Assertf(err.Unwrap() != nil, "IOError should wrap the underlying error")
+		})
+	})
+}
+
+func fragments(values ...string) iter.Seq[[]byte] {
+	return func(yield func([]byte) bool) {
+		for _, value := range values {
+			if !yield([]byte(value)) {
+				return
+			}
+		}
+	}
+}

--- a/base/syscaps/syscaps_test.go
+++ b/base/syscaps/syscaps_test.go
@@ -6,6 +6,7 @@ package syscaps_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"pgregory.net/rapid"
@@ -17,7 +18,80 @@ import (
 	"code.kibou.tools/base/core/pathx"
 	"code.kibou.tools/base/fsx/fsx_testkit"
 	"code.kibou.tools/base/internal/constants"
+	"code.kibou.tools/base/syscaps"
 )
+
+func TestTempFileNames(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("valid pattern", func(h check.Harness) {
+		h.Parallel()
+
+		var got string
+		for name := range syscaps.TempFileNames(`foo\*bar-*.txt`) {
+			got = name.String()
+			break
+		}
+		h.Assertf(strings.HasPrefix(got, "foo*bar-tmp"), "name %q does not have expected prefix", got)
+		h.Assertf(strings.HasSuffix(got, ".txt"), "name %q does not have expected suffix", got)
+	})
+
+	h.Run("preconditions", func(h check.Harness) {
+		h.Parallel()
+
+		type testCase struct {
+			name    string
+			pattern string
+			want    assert.AssertionError
+		}
+
+		testCases := []testCase{
+			{
+				name:    "no wildcard",
+				pattern: "foo.txt",
+				want: assert.AssertionError{
+					Fmt:  "precondition violation: temp file pattern %q does not contain a wildcard",
+					Args: []any{"foo.txt"},
+				},
+			},
+			{
+				name:    "multiple wildcards",
+				pattern: "***",
+				want: assert.AssertionError{
+					Fmt:  "precondition violation: temp file pattern %q contains more than one wildcard",
+					Args: []any{"***"},
+				},
+			},
+			{
+				name:    "trailing escape",
+				pattern: `foo-\`,
+				want: assert.AssertionError{
+					Fmt:  "precondition violation: temp file pattern %q has a trailing escape",
+					Args: []any{`foo-\`},
+				},
+			},
+			{
+				name:    "invalid escape sequence",
+				pattern: `foo-\x*`,
+				want: assert.AssertionError{
+					Fmt:  "precondition violation: temp file pattern %q contains invalid escape sequence",
+					Args: []any{`foo-\x*`},
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			h.Run(tc.name, func(h check.Harness) {
+				h.Parallel()
+
+				h.AssertPanicsWith(tc.want, func() {
+					_ = syscaps.TempFileNames(tc.pattern)
+				})
+			})
+		}
+	})
+}
 
 func TestFSReadDirBatched(t *testing.T) {
 	h := check.New(t)

--- a/base/syscaps/temp_file.go
+++ b/base/syscaps/temp_file.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package syscaps
+
+import (
+	"iter"
+	"math/rand"
+	"os"
+	"strconv"
+	"unsafe"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/fsx"
+	"code.kibou.tools/base/fsx/fsx_temp"
+)
+
+// TempFileNames returns temporary file names generated from pattern.
+//
+// Pattern must have exactly one unescaped '*' pattern, which will be
+// replaced by values from [TempFileFragments].
+//
+// - `abc-*.txt` -> will generate names like foo-tmp9239.txt, etc.
+// - `abc.txt.*` -> will generate names like foo.txt.tmp1035
+//
+// Use `\*` for a literal '*' and `\\` for a literal '\'.
+//
+// Preconditions:
+// - pattern contains exactly one unescaped '*' wildcard.
+// - '\' must be followed by '\' or '*'.
+func TempFileNames(pattern string) iter.Seq[fsx.Name] {
+	prefix, suffix := splitTempFileNamePattern(pattern)
+	return fsx_temp.Names(prefix, TempFileFragments(), suffix)
+}
+
+const TempFileFragments_MaxIters = 100
+
+// TempFileFragments returns a series of fragments of the form tmpNNNN based on
+// ambient system capabilities such as process metadata.
+//
+// The slices in the returned iterator must not be retained.
+//
+// The returned sequence has length TempFileFragments_MaxIters.
+func TempFileFragments() iter.Seq[[]byte] {
+	return func(yield func([]byte) bool) {
+		pid := int64(os.Getpid())
+		addr := int64(uintptr(unsafe.Pointer(&yield)))
+		source := rand.NewSource((addr << 32) & pid)
+		rng := rand.New(source)
+		out := [3 + 10]byte{'t', 'm', 'p', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0'}
+		for range TempFileFragments_MaxIters {
+			val := rng.Uint32()
+			digits := strconv.AppendUint(out[:3], uint64(val), 10)
+			// AFAICT, there's no API to right-align the write directly
+			// (we'd have to precompute the number of digits ourselves,
+			// and then update the index), so we copy the digits from
+			// the left to the right, and zero out earlier digits.
+			n := len(digits) - 3
+			copy(out[len(out)-n:], out[3:3+n])
+			for i := 3; i < len(out)-n; i++ {
+				out[i] = '0'
+			}
+			if !yield(out[:]) {
+				return
+			}
+		}
+	}
+}
+
+func splitTempFileNamePattern(pattern string) ([]byte, []byte) {
+	var prefix []byte
+	var suffix []byte
+	current := &prefix
+	wildcards := 0
+	for i := 0; i < len(pattern); {
+		switch pattern[i] {
+		case '\\':
+			if i+1 == len(pattern) {
+				assert.Preconditionf(false, "temp file pattern %q has a trailing escape", pattern)
+			}
+			escaped := pattern[i+1]
+			if escaped != '*' && escaped != '\\' {
+				assert.Preconditionf(false, "temp file pattern %q contains invalid escape sequence", pattern)
+			}
+			*current = append(*current, escaped)
+			i += 2
+		case '*':
+			wildcards++
+			if wildcards > 1 {
+				assert.Preconditionf(false, "temp file pattern %q contains more than one wildcard", pattern)
+			}
+			current = &suffix
+			i++
+		default:
+			*current = append(*current, pattern[i])
+			i++
+		}
+	}
+	if wildcards == 0 {
+		assert.Preconditionf(false, "temp file pattern %q does not contain a wildcard", pattern)
+	}
+	return prefix, suffix
+}


### PR DESCRIPTION
This adds a few different things:

1. A stream-based API for creating temporary files,
   so that you can control how many files are
   tried at most before failing, as well as what
   those names look like in case you don't like
   my choices.
2. Some APIs in syscaps to provide some convenient
   ways of generating the stream of names based on
   OS-based entropy sources.
