### PR TITLE
fix(ci): Fix borked upstream-sync workflow

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
           cache: false
 
       - name: Configure git identity


### PR DESCRIPTION
I forgot to update this workflow when updating the
Go version in the CI workflow to not break when
setup-go was ugpraded.

Fixes #219
