### PR TITLE
feat(fsx_name): Add API for extracting basename as Name

### DIFF
--- a/base/assert/assert.go
+++ b/base/assert/assert.go
@@ -14,6 +14,10 @@ type AssertionError struct {
 	Args []any
 }
 
+func NewError(format string, args ...any) AssertionError {
+	return AssertionError{Fmt: format, Args: args}
+}
+
 func (e AssertionError) String() string {
 	return fmt.Sprintf(e.Fmt, e.Args...)
 }

--- a/base/fsx/fsx_name/base_name.go
+++ b/base/fsx/fsx_name/base_name.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package fsx_name
+
+import (
+	"fmt"
+
+	"code.kibou.tools/base/assert"
+	internal_pathx "code.kibou.tools/base/internal/pathx"
+)
+
+// ExtractBaseName extracts the final concrete path component as a [Name].
+func ExtractBaseName(path string) (Name, *BaseNameError) {
+	if path == "" {
+		return Name{}, &BaseNameError{kind: BaseNameErrorKind_EmptyString, path: path}
+	}
+	if internal_pathx.IsPathSeparator(path[len(path)-1]) {
+		return Name{}, &BaseNameError{kind: BaseNameErrorKind_EndsWithPathSeparator, path: path}
+	}
+
+	var base string
+	for component := range internal_pathx.Components(path).Components() {
+		base = component
+	}
+	if base == "." || base == ".." || base == "" {
+		return Name{}, &BaseNameError{kind: BaseNameErrorKind_NoBaseName, path: path}
+	}
+
+	return Name{base}, nil
+}
+
+// MustExtractBaseName extracts the final concrete path component from path as a
+// [Name].
+//
+// Pre-condition: path has a final concrete path component.
+func MustExtractBaseName(path string) Name {
+	name, err := ExtractBaseName(path)
+	if err != nil {
+		assert.Precondition(false, err.Error())
+	}
+	return name
+}
+
+// BaseNameErrorKind classifies a [BaseNameError].
+type BaseNameErrorKind uint8
+
+const (
+	// BaseNameErrorKind_EmptyString indicates that the input path was empty.
+	BaseNameErrorKind_EmptyString BaseNameErrorKind = iota + 1
+	// BaseNameErrorKind_EndsWithPathSeparator indicates that the input path ends
+	// with a path separator.
+	BaseNameErrorKind_EndsWithPathSeparator
+	// BaseNameErrorKind_NoBaseName indicates that the input path does not have a
+	// concrete final path component, such as "." or "..".
+	BaseNameErrorKind_NoBaseName
+)
+
+// BaseNameError is returned by [ExtractBaseName].
+type BaseNameError struct {
+	kind BaseNameErrorKind
+	// path is the input path passed to [ExtractBaseName]. It is empty for
+	// [BaseNameErrorKind_EmptyString].
+	path string
+}
+
+// Kind returns the error kind.
+func (e *BaseNameError) Kind() BaseNameErrorKind {
+	return e.kind
+}
+
+// Path returns the input path passed to [ExtractBaseName]. It is empty for
+// [BaseNameErrorKind_EmptyString].
+func (e *BaseNameError) Path() string {
+	return e.path
+}
+
+func (e *BaseNameError) Error() string {
+	switch e.kind {
+	case BaseNameErrorKind_EmptyString:
+		return "cannot extract base name from empty path string"
+	case BaseNameErrorKind_EndsWithPathSeparator:
+		return fmt.Sprintf("path %q ends with a path separator; cannot extract base name", e.path)
+	case BaseNameErrorKind_NoBaseName:
+		return fmt.Sprintf("path %q has no concrete base name", e.path)
+	default:
+		return assert.PanicUnknownCase[string](e.kind)
+	}
+}

--- a/base/fsx/fsx_name/base_name_test.go
+++ b/base/fsx/fsx_name/base_name_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package fsx_name_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/check"
+	"code.kibou.tools/base/core/pathx/pathx_testkit"
+	"code.kibou.tools/base/fsx/fsx_name"
+	internal_pathx "code.kibou.tools/base/internal/pathx"
+)
+
+func TestExtractBaseName(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("Unit", testExtractBaseNameUnit)
+	h.Run("Properties", testExtractBaseNameProperties)
+}
+
+func testExtractBaseNameUnit(h check.Harness) {
+	h.Parallel()
+
+	type testCase struct {
+		name        string
+		path        string
+		wantName    string
+		wantKind    fsx_name.BaseNameErrorKind
+		wantMessage string
+	}
+
+	trailingSeparatorPath := "parent" + string(filepath.Separator)
+	testCases := []testCase{
+		{
+			name:        "valid",
+			path:        filepath.Join("parent", "child.txt"),
+			wantName:    "child.txt",
+			wantKind:    0,
+			wantMessage: "",
+		},
+		{
+			name:        "empty string",
+			path:        "",
+			wantName:    "",
+			wantKind:    fsx_name.BaseNameErrorKind_EmptyString,
+			wantMessage: "cannot extract base name from empty path string",
+		},
+		{
+			name:     "trailing separator",
+			path:     trailingSeparatorPath,
+			wantName: "",
+			wantKind: fsx_name.BaseNameErrorKind_EndsWithPathSeparator,
+			wantMessage: fmt.Sprintf(
+				"path %q ends with a path separator; cannot extract base name",
+				trailingSeparatorPath,
+			),
+		},
+		{
+			name:        "current directory",
+			path:        ".",
+			wantName:    "",
+			wantKind:    fsx_name.BaseNameErrorKind_NoBaseName,
+			wantMessage: `path "." has no concrete base name`,
+		},
+		{
+			name:        "parent directory",
+			path:        "..",
+			wantName:    "",
+			wantKind:    fsx_name.BaseNameErrorKind_NoBaseName,
+			wantMessage: `path ".." has no concrete base name`,
+		},
+	}
+
+	for _, tc := range testCases {
+		h.Run(tc.name, func(h check.Harness) {
+			h.Parallel()
+
+			name, err := fsx_name.ExtractBaseName(tc.path)
+			if tc.wantMessage == "" {
+				h.Assertf(err == nil, "ExtractBaseName returned error: %v", err)
+				check.AssertSame(h, tc.wantName, name.String(), "ExtractBaseName base name")
+				mustName := fsx_name.MustExtractBaseName(tc.path)
+				check.AssertSame(h, tc.wantName, mustName.String(), "MustExtractBaseName base name")
+				return
+			}
+
+			h.Assertf(err != nil, "ExtractBaseName(%q) succeeded unexpectedly", tc.path)
+			check.AssertSame(h, tc.wantKind, err.Kind(), "error kind")
+			check.AssertSame(h, tc.path, err.Path(), "error path")
+			check.AssertSame(h, tc.wantMessage, err.Error(), "error message")
+			h.AssertPanicsWith(
+				assert.NewError("precondition violation: %s", tc.wantMessage),
+				func() {
+					_ = fsx_name.MustExtractBaseName(tc.path)
+				},
+			)
+		})
+	}
+}
+
+func testExtractBaseNameProperties(h check.Harness) {
+	h.Parallel()
+
+	componentsGen := rapid.SliceOfN(baseNamePathComponentGen(), 0, 8)
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		components := componentsGen.Draw(t, "components")
+		path := strings.Join(components, string(filepath.Separator))
+		wantBase := filepath.Base(path)
+
+		name, err := fsx_name.ExtractBaseName(path)
+		checkErr := func(wantKind fsx_name.BaseNameErrorKind) {
+			h.Assertf(err != nil, "ExtractBaseName(%q) succeeded unexpectedly", path)
+			check.AssertSame(h, wantKind, err.Kind(), "error kind")
+			h.AssertPanicsWith(
+				assert.NewError("precondition violation: %s", err.Error()),
+				func() {
+					_ = fsx_name.MustExtractBaseName(path)
+				},
+			)
+		}
+		switch {
+		case path == "":
+			checkErr(fsx_name.BaseNameErrorKind_EmptyString)
+		case strings.HasSuffix(path, string(filepath.Separator)):
+			checkErr(fsx_name.BaseNameErrorKind_EndsWithPathSeparator)
+		case wantBase == "." || wantBase == ".." || hasPathSeparator(wantBase):
+			checkErr(fsx_name.BaseNameErrorKind_NoBaseName)
+		default:
+			h.Assertf(err == nil, "ExtractBaseName(%q) returned error: %v", path, err)
+			check.AssertSame(h, wantBase, name.String(), "ExtractBaseName vs filepath.Base")
+
+			mustName := fsx_name.MustExtractBaseName(path)
+			check.AssertSame(h, wantBase, mustName.String(), "MustExtractBaseName vs filepath.Base")
+		}
+	})
+}
+
+func hasPathSeparator(s string) bool {
+	for i := range len(s) {
+		if internal_pathx.IsPathSeparator(s[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func baseNamePathComponentGen() *rapid.Generator[string] {
+	return rapid.OneOf(
+		rapid.Just(""),
+		rapid.Just("."),
+		rapid.Just(".."),
+		pathx_testkit.ComponentGen(),
+	)
+}


### PR DESCRIPTION
It's a bit silly that we didn't have this API,
which makes it trickier to bridge to third-party
code which is stringly-typed.
