### PR TITLE
refactor(fsx): Replace afero.File with our own fsx.File

### DIFF
--- a/base/fsx/file.go
+++ b/base/fsx/file.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package fsx
+
+import (
+	"github.com/spf13/afero" //nolint:depguard // fsx is the designated wrapper
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/fsx/fsx_name"
+)
+
+type file struct {
+	base afero.File
+}
+
+func wrapFile(base afero.File) File {
+	assert.Invariant(base != nil, "cannot wrap nil file")
+	return file{base: base}
+}
+
+func (f file) Close() error {
+	return f.base.Close()
+}
+
+func (f file) Read(p []byte) (int, error) {
+	return f.base.Read(p)
+}
+
+func (f file) ReadAt(p []byte, off int64) (int, error) {
+	return f.base.ReadAt(p, off)
+}
+
+func (f file) Seek(offset int64, whence int) (int64, error) {
+	return f.base.Seek(offset, whence)
+}
+
+func (f file) Write(p []byte) (int, error) {
+	return f.base.Write(p)
+}
+
+func (f file) WriteAt(p []byte, off int64) (int, error) {
+	return f.base.WriteAt(p, off)
+}
+
+func (f file) Name() Name {
+	baseName := f.base.Name()
+	name, err := fsx_name.ExtractBaseName(baseName)
+	if err != nil {
+		assert.Invariantf(false, "filesystem returned file name without basename: %v", err)
+	}
+	return name
+}
+
+func (f file) Truncate(size int64) error {
+	return f.base.Truncate(size)
+}

--- a/base/fsx/fsx.go
+++ b/base/fsx/fsx.go
@@ -32,8 +32,18 @@ import (
 var ErrNotExist = iofs.ErrNotExist
 
 // File is an open file handle returned by [FS.OpenFile] and similar methods.
-// It is an alias for [afero.File] so callers need not import afero directly.
-type File = afero.File
+type File interface {
+	io.Closer
+	io.Reader
+	io.ReaderAt
+	io.Seeker
+	io.Writer
+	io.WriterAt
+
+	// Name returns the file's basename.
+	Name() Name
+	Truncate(size int64) error
+}
 
 type OpenRW = fsx_opt.OpenRW
 

--- a/base/fsx/open.go
+++ b/base/fsx/open.go
@@ -22,7 +22,11 @@ func OpenReadOnly(fs FS, rel pathx.RelPath) (File, error) {
 
 // OpenFile opens the file at the given root-relative path.
 func (fs rootedFS) OpenFile(rel pathx.RelPath, opts OpenOptions) (File, error) {
-	return fs.base.OpenFile(rel.String(), openFlags(opts), openPerm(opts))
+	f, err := fs.base.OpenFile(rel.String(), openFlags(opts), openPerm(opts))
+	if err != nil {
+		return nil, err
+	}
+	return wrapFile(f), nil
 }
 
 func openFlags(opts OpenOptions) int {

--- a/base/fsx/open_test.go
+++ b/base/fsx/open_test.go
@@ -27,6 +27,7 @@ func TestFSOpenOptions(t *testing.T) {
 		WithMode(fsx.OpenMode_CreateNew).
 		MustBuild()
 	f := Do(repoFS.OpenFile(rel, createNewOpts))(h)
+	check.AssertSame(h, "capture.jsonl", f.Name().String(), "file name")
 	_ = Do(io.WriteString(f, "first\n"))(h)
 	h.Close(f)
 

--- a/docs/external/quirks/README.md
+++ b/docs/external/quirks/README.md
@@ -1,0 +1,33 @@
+# Quirks in third-party dependencies
+
+This folder collects quirks encountered in 
+third-party tools and libraries
+that contributed to or directly caused
+a problem in local development, CI or production.
+
+"Quirks" are interpreted broadly;
+all of the following count:
+
+- Surprising undocumented behavior
+- Surprising documented behavior
+- Unexplained design decisions
+- Bugs
+
+This idea is based on Dan Luu's post
+on the [Normalization of Deviance](https://danluu.com/wat/).
+
+> People don't automatically know what should be normal,
+> and when new people are onboarded,
+> they can just as easily learn deviant processes
+> that have become normalized as reasonable processes.
+>
+> Julia Evans described to me how this happens:
+>
+> new person joins
+> new person: WTF WTF WTF WTF WTF
+> old hands: yeah we know we're concerned about it
+> new person: WTF WTF wTF wtf wtf w...
+> new person gets used to it
+> new person #2 joins
+> new person #2: WTF WTF WTF WTF
+> new person: yeah we know. we're concerned about it.

--- a/docs/external/quirks/afero.md
+++ b/docs/external/quirks/afero.md
@@ -1,0 +1,36 @@
+# Quirks in the Afero library
+
+## `File.Name()` does not return the base name
+
+Afero has a `BasePathFs` which represents the concept of
+a "filesystem rooted at a path R", which has a corresponding
+`BasePathFile` type returned from methods like `Open`.
+
+`BasePathFile` implements the `afero.File.Name() string`
+method which is [implemented like this](https://github.com/spf13/afero/blob/master/basepath.go#L38C1-L41C2):
+
+```go
+type BasePathFs struct {
+	source Fs
+	path   string
+}
+
+type BasePathFile struct {
+	File
+	path string // same as corresponding BasePathFs.path (not documented upstream)
+}
+
+func (f *BasePathFile) Name() string {
+	sourcename := f.File.Name()
+	return strings.TrimPrefix(sourcename, filepath.Clean(f.path))
+}
+```
+
+Despite having the same signature as the stdlib's
+`io/fs.File.Name() string`, which is guaranteed to
+return the _base name_ of the file, here, `Name()`
+tracks the FS-root-relative path. There is zero documentation
+of this behavior in the [afero.File docs](https://pkg.go.dev/github.com/spf13/afero#File)
+
+This led to a confusing CI failure with a `Name()` call
+which returned `\foo.txt` on Windows.


### PR DESCRIPTION
The `Name() string` method on the `afero.File`
interface would return the path relative to
the base, instead of the file's name, which
was error-prone.

Remove the usage of `afero.File` so that we
don't have this problem. Overall, I'm souring
a bit on afero, and considering just replacing
it altogether with our own code.
