### PR TITLE
feat(jsonl): Add tool for handling go test JSON output

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,6 +67,9 @@ linters:
             - $all
             - "!**/base/timex/*.go"
             - "!**/base/syscaps/*.go"
+            # FIXME: Remove the line below after adding the necessary
+            # functionality in timex
+            - "!**/misc/cmd/jsonl/*_test.go"
           list-mode: lax
           deny:
             - pkg: "time"

--- a/base/core/pathx/pathx.go
+++ b/base/core/pathx/pathx.go
@@ -222,6 +222,11 @@ func MustParseRelPath(path string) RelPath {
 	return relPath
 }
 
+// NewRelPathFromName returns name as a single-component relative path.
+func NewRelPathFromName(name fsx_name.Name) RelPath {
+	return RelPath{name.String()}
+}
+
 // String is guaranteed to be "." if a relative path for the current directory.
 func (p RelPath) String() string {
 	return p.value
@@ -264,6 +269,11 @@ func (p RelPath) RelativeTo(base RelPath) RelPath {
 func (p RelPath) JoinOne(name fsx_name.Name) RelPath {
 	// TODO: Use an unchecked code path here, because we know the invariant can't be violated.
 	return MustParseRelPath(filepath.Join(p.value, name.String()))
+}
+
+// BaseName returns the final path component of p.
+func (p RelPath) BaseName() fsx_name.Name {
+	return fsx_name.New(filepath.Base(p.value))
 }
 
 // JoinComponents joins individual path components onto p.

--- a/base/core/result/result.go
+++ b/base/core/result/result.go
@@ -52,3 +52,22 @@ func (r Result[T]) Get() (T, error) {
 func (r Result[T]) ErrOrNil() error {
 	return r.err
 }
+
+// Status is the outcome of an operation, without an associated value or error.
+//
+// Use it where a caller must tell a callee whether the surrounding work
+// succeeded so the callee can finalize accordingly (for example, committing
+// versus discarding a partially written file).
+type Status uint8
+
+const (
+	Status_Success Status = iota + 1
+	Status_Failure
+)
+
+func NewStatusFromError(err error) Status {
+	if err != nil {
+		return Status_Failure
+	}
+	return Status_Success
+}

--- a/base/fsx/fsx.go
+++ b/base/fsx/fsx.go
@@ -108,6 +108,7 @@ type FS interface {
 	MkdirAll(rel pathx.RelPath, perm os.FileMode) error
 	MkdirTemp(dir pathx.RelPath, pattern string) (pathx.RelPath, error)
 	RemoveAll(rel pathx.RelPath) error
+	Rename(oldRel, newRel pathx.RelPath) error
 	Stat(rel pathx.RelPath, opts StatOptions) (os.FileInfo, error)
 }
 
@@ -242,4 +243,10 @@ func (fs rootedFS) MkdirTemp(dir pathx.RelPath, pattern string) (pathx.RelPath, 
 // along with any children it contains.
 func (fs rootedFS) RemoveAll(rel pathx.RelPath) error {
 	return fs.base.RemoveAll(rel.String())
+}
+
+// Rename moves the file or directory at oldRel to newRel, replacing newRel if
+// it already exists. Both paths are interpreted relative to Root().
+func (fs rootedFS) Rename(oldRel, newRel pathx.RelPath) error {
+	return fs.base.Rename(oldRel.String(), newRel.String())
 }

--- a/base/fsx/fsx_temp/temp.go
+++ b/base/fsx/fsx_temp/temp.go
@@ -107,6 +107,10 @@ func (e *CreateFileError) Unwrap() error {
 	return e.err
 }
 
+// Preconditions:
+//
+// 1. prefix and suffix do not contain [filepath.Separator].
+// 2. fragments does not yield []byte which contain [filepath.Separator].
 func Names(prefix []byte, fragments iter.Seq[[]byte], suffix []byte) iter.Seq[fsx.Name] {
 	return func(yield func(fsx.Name) bool) {
 		var builder strings.Builder

--- a/base/syscaps/syscaps.go
+++ b/base/syscaps/syscaps.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	stdlib_time "time"
 
@@ -46,6 +47,21 @@ func WorkingDirectory() (pathx.AbsPath, error) {
 		return pathx.AbsPath{}, err
 	}
 	return pathx.MustParseAbsPath(wd), nil
+}
+
+// ResolvePath returns the absolute form of path.
+//
+//   - A relative path is resolved against the process working directory
+//   - On Windows a drive-relative path (such as "C:abc") is resolved
+//     against that drive's current directory.
+//
+// Does not evaluate symlinks or require the path to exist/be accessible.
+func ResolvePath(path string) (pathx.AbsPath, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return pathx.AbsPath{}, err
+	}
+	return pathx.MustParseAbsPath(abs), nil
 }
 
 // FS returns a rooted filesystem backed by the host operating system.

--- a/misc/cmd/jsonl/arg_parse.go
+++ b/misc/cmd/jsonl/arg_parse.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package main
+
+import (
+	"strings"
+
+	"code.kibou.tools/base/errorx"
+)
+
+// InputPath is a parsed input path or input special form.
+type InputPath struct {
+	kind InputPathKind
+	// path is set only when kind is InputPath_FilePath.
+	path string
+}
+
+type InputPathKind uint8
+
+const (
+	InputPath_FilePath InputPathKind = iota + 1
+	InputPath_Stdin
+)
+
+func parseInputPathOrSpecial(value string) (InputPath, error) {
+	if value == "" {
+		return InputPath{}, errorx.Newf("nostack", "input path must be non-empty")
+	}
+	if value == ":stdin" {
+		return InputPath{kind: InputPath_Stdin, path: ""}, nil
+	}
+	if strings.HasPrefix(value, "::") {
+		return InputPath{kind: InputPath_FilePath, path: value[1:]}, nil
+	}
+	if strings.HasPrefix(value, ":") {
+		return InputPath{}, errorx.Newf("nostack", "unsupported input special path %q, want :stdin", value)
+	}
+	return InputPath{kind: InputPath_FilePath, path: value}, nil
+}
+
+// OutputPath is a parsed output path or output special form.
+type OutputPath struct {
+	kind OutputPathKind
+	// path is set only when kind is OutputPath_FilePath.
+	path string
+}
+
+type OutputPathKind uint8
+
+const (
+	OutputPath_FilePath OutputPathKind = iota + 1
+	OutputPath_Stdout
+	OutputPath_Discard
+)
+
+func parseOutputPathOrSpecial(value string) (OutputPath, error) {
+	if value == "" {
+		return OutputPath{}, errorx.Newf("nostack", "output path must be non-empty")
+	}
+	switch value {
+	case ":stdout":
+		return OutputPath{kind: OutputPath_Stdout, path: ""}, nil
+	case ":discard":
+		return OutputPath{kind: OutputPath_Discard, path: ""}, nil
+	}
+	if strings.HasPrefix(value, "::") {
+		return OutputPath{kind: OutputPath_FilePath, path: value[1:]}, nil
+	}
+	if strings.HasPrefix(value, ":") {
+		return OutputPath{}, errorx.Newf("nostack", "unsupported output special path %q, want :stdout or :discard", value)
+	}
+	return OutputPath{kind: OutputPath_FilePath, path: value}, nil
+}

--- a/misc/cmd/jsonl/errors.go
+++ b/misc/cmd/jsonl/errors.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package main
+
+import (
+	"fmt"
+	"io"
+
+	. "code.kibou.tools/base/core"
+	"code.kibou.tools/base/core/limited"
+	"code.kibou.tools/base/core/op"
+	"code.kibou.tools/base/logx"
+	"code.kibou.tools/misc/internal/go_test"
+)
+
+type renderWarnings [3]Warning
+
+type Warning struct {
+	kind WarningKind
+	limited.Counter[uint32]
+}
+
+type WarningKind int
+
+// These values are used directly as indexes into renderWarnings, so they
+// deliberately start at iota (0) rather than iota+1.
+const (
+	Warn_NotJSON WarningKind = iota
+	Warn_UnknownAction
+	Warn_UnknownOutputType
+)
+
+const renderWarningLimit uint32 = 3
+
+func newRenderWarnings() renderWarnings {
+	var warnings renderWarnings
+	for i := range len(warnings) {
+		warnings[i] = Warning{kind: WarningKind(i), Counter: limited.NewCounter(renderWarningLimit)}
+	}
+	return warnings
+}
+
+func (kind WarningKind) logMessage() string {
+	switch kind {
+	case Warn_NotJSON:
+		return "passing through non-JSON go test line"
+	case Warn_UnknownAction:
+		return "unknown go test JSON action"
+	case Warn_UnknownOutputType:
+		return "unknown go test JSON output type"
+	default:
+		return "unknown jsonl warning"
+	}
+}
+
+func (kind WarningKind) summaryLabel() string {
+	switch kind {
+	case Warn_NotJSON:
+		return "Non-JSON lines"
+	case Warn_UnknownAction:
+		return "Unknown go test JSON actions"
+	case Warn_UnknownOutputType:
+		return "Unknown go test JSON output types"
+	default:
+		return "Unknown jsonl warnings"
+	}
+}
+
+func (warning Warning) summaryStats() string {
+	total := warning.Hits()
+	omitted := warning.Dropped()
+	logged := total - omitted
+	if omitted == 0 {
+		return fmt.Sprintf("(logged: %d/%d)", logged, total)
+	}
+	return fmt.Sprintf("(logged: %d/%d, omitted: %d/%d for brevity)", logged, total, omitted, total)
+}
+
+func (warnings *renderWarnings) warnNotJSON(logger logx.Logger, lineNumber int, err error) {
+	if warnings[Warn_NotJSON].Inc() == op.KeepGoing {
+		logger.Warn(Warn_NotJSON.logMessage(), "line", lineNumber, "err", err.Error())
+	}
+}
+
+func (warnings *renderWarnings) warnUnknownEnums(logger logx.Logger, event go_test.Event) {
+	if !event.Action.Known() {
+		if warnings[Warn_UnknownAction].Inc() == op.KeepGoing {
+			logger.Warn(Warn_UnknownAction.logMessage(), "action", string(event.Action))
+		}
+	}
+	if !event.OutputType.Known() {
+		if warnings[Warn_UnknownOutputType].Inc() == op.KeepGoing {
+			logger.Warn(Warn_UnknownOutputType.logMessage(), "output_type", string(event.OutputType))
+		}
+	}
+}
+
+func (warnings *renderWarnings) writeSummary(w io.Writer, z go_test.Colorizer) error {
+	wroteHeader := false
+	for _, warning := range warnings {
+		if warning.Hits() == 0 {
+			continue
+		}
+		if !wroteHeader {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintln(w, "jsonl warnings:"); err != nil {
+				return err
+			}
+			wroteHeader = true
+		}
+		if _, err := fmt.Fprint(w, "- "); err != nil {
+			return err
+		}
+		if err := z.Write(w, warning.kind.summaryLabel(), Some(go_test.ColorYellow)); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, " %s\n", warning.summaryStats()); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/misc/cmd/jsonl/main.go
+++ b/misc/cmd/jsonl/main.go
@@ -1,0 +1,326 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package main
+
+import (
+	"context" //nolint:depguard // cli main is the program boundary.
+	"io"
+	"os"
+
+	"github.com/urfave/cli/v3"
+	"golang.org/x/term"
+
+	"code.kibou.tools/base/assert"
+	. "code.kibou.tools/base/core"
+	"code.kibou.tools/base/core/pathx"
+	"code.kibou.tools/base/core/result"
+	"code.kibou.tools/base/errorx"
+	"code.kibou.tools/base/fsx"
+	"code.kibou.tools/base/fsx/fsx_temp"
+	"code.kibou.tools/base/logx"
+	"code.kibou.tools/base/syscaps"
+	"code.kibou.tools/misc/internal/go_test"
+)
+
+func main() {
+	logger := logx.NewLogger(os.Stderr, logx.ColorSupport_AutoDetect)
+	app := &cli.Command{
+		Name:  "jsonl",
+		Usage: "Operate on JSON Lines streams",
+		Description: `The jsonl tool is used to operate on a closed set
+of JSONL formats, to massage them into a uniform shape.
+
+The problem with consuming 'go test -json' and
+'go tool dist test -json' output directly is that these streams
+are not always strictly JSONL, and can have other output in-between.
+This makes it trickier to ingest the data elsewhere when edge cases
+come up.
+
+Additionally, there doesn't seem to be any existing tool
+which converts these JSON streams to the default 'go test'
+human-readable output (no -v). The jsonl tool can write both
+normalized JSONL and human-readable output.
+
+In the future, we may extend this to JSONL output from
+other tools that we rely on.
+
+This tool is only meant for use within the Kibou monorepo.
+`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:      "format",
+				Usage:     "input format to render: go-test",
+				TakesFile: true,
+				OnlyOnce:  true,
+				Value:     "go-test",
+			},
+			&cli.StringFlag{
+				Name:      "input",
+				Usage:     "input path, or :stdin for standard input",
+				OnlyOnce:  true,
+				TakesFile: true,
+				Value:     ":stdin",
+			},
+			&cli.StringFlag{
+				Name:  "color",
+				Usage: "color output: auto, always, never",
+				Value: string(ColorMode_Auto),
+			},
+			&cli.StringFlag{
+				Name:      "pretty-output",
+				Usage:     "human-readable render output path, or :stdout/:discard",
+				OnlyOnce:  true,
+				TakesFile: true,
+				Value:     ":discard",
+			},
+			&cli.StringFlag{
+				Name:      "jsonl-output",
+				Usage:     "normalized JSONL output path, or :stdout/:discard",
+				OnlyOnce:  true,
+				TakesFile: true,
+				Value:     ":stdout",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) (retErr error) {
+			if cmd.String("format") != "go-test" {
+				return errorx.Newf("nostack", "unsupported --format %q, want go-test", cmd.String("format"))
+			}
+
+			mode, err := parseColorMode(cmd.String("color"))
+			if err != nil {
+				return err
+			}
+
+			inputPath, err := parseInputPathOrSpecial(cmd.String("input"))
+			if err != nil {
+				return err
+			}
+			prettyPath, err := parseOutputPathOrSpecial(cmd.String("pretty-output"))
+			if err != nil {
+				return err
+			}
+			jsonlPath, err := parseOutputPathOrSpecial(cmd.String("jsonl-output"))
+			if err != nil {
+				return err
+			}
+			if err := validateOutputPaths(prettyPath, jsonlPath); err != nil {
+				return err
+			}
+
+			input, err := openInput(inputPath)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if closeErr := input.Close(); closeErr != nil {
+					logger.Warn("close --input", "path", cmd.String("input"), "err", closeErr.Error())
+				}
+			}()
+
+			prettyOutput, err := openOutput(prettyPath, "pretty-output")
+			if err != nil {
+				return err
+			}
+			defer func() {
+				status := result.NewStatusFromError(retErr)
+				if closeErr := prettyOutput.Close(status); closeErr != nil {
+					retErr = errorx.Join(retErr, closeErr)
+				}
+			}()
+			jsonlOutput, err := openOutput(jsonlPath, "jsonl-output")
+			if err != nil {
+				return err
+			}
+			defer func() {
+				status := result.NewStatusFromError(retErr)
+				if closeErr := jsonlOutput.Close(status); closeErr != nil {
+					retErr = errorx.Join(retErr, closeErr)
+				}
+			}()
+
+			return renderGoTest(logger, colorizerForMode(mode, prettyPath), input, prettyOutput.writer, jsonlOutput.writer)
+		},
+	}
+
+	if err := app.Run(context.Background(), os.Args); err != nil {
+		logger.Error(err.Error())
+		os.Exit(1)
+	}
+}
+
+type ColorMode string
+
+const (
+	ColorMode_Auto   ColorMode = "auto"
+	ColorMode_Always ColorMode = "always"
+	ColorMode_Never  ColorMode = "never"
+)
+
+func parseColorMode(value string) (ColorMode, error) {
+	mode := ColorMode(value)
+	switch mode {
+	case ColorMode_Auto, ColorMode_Always, ColorMode_Never:
+		return mode, nil
+	default:
+		return "", errorx.Newf("nostack", "unsupported --color %q, want auto, always, never", value)
+	}
+}
+
+func colorizerForMode(mode ColorMode, out OutputPath) go_test.Colorizer {
+	return go_test.NewColorizer(mode == ColorMode_Always ||
+		(mode == ColorMode_Auto && out.kind == OutputPath_Stdout && term.IsTerminal(int(os.Stdout.Fd()))))
+}
+
+func validateOutputPaths(pretty OutputPath, jsonl OutputPath) error {
+	if pretty.kind == OutputPath_Stdout && jsonl.kind == OutputPath_Stdout {
+		return errorx.Newf("nostack", "--pretty-output and --jsonl-output cannot both be :stdout")
+	}
+	return nil
+}
+
+func openInput(input InputPath) (io.ReadCloser, error) {
+	switch input.kind {
+	case InputPath_Stdin:
+		return io.NopCloser(os.Stdin), nil
+	case InputPath_FilePath:
+		fs, rel, err := fsForPath(input.path)
+		if err != nil {
+			return nil, err
+		}
+		f, err := fsx.OpenReadOnly(fs, rel)
+		if err != nil {
+			return nil, errorx.Wrapf("nostack", err, "open --input %q", input.path)
+		}
+		return f, nil
+	default:
+		return nil, assert.PanicUnknownCase[error](input.kind)
+	}
+}
+
+// outputTarget is an opened output destination.
+type outputTarget struct {
+	// writer is always non-nil.
+	writer io.Writer
+	// fs is set only for filesystem path outputs.
+	fs fsx.FS
+	// file is set only for filesystem path outputs.
+	file *OutputFile
+}
+
+func openOutput(path OutputPath, flag string) (outputTarget, error) {
+	switch path.kind {
+	case OutputPath_Stdout:
+		return outputTarget{writer: os.Stdout, fs: nil, file: nil}, nil
+	case OutputPath_Discard:
+		return outputTarget{writer: io.Discard, fs: nil, file: nil}, nil
+	case OutputPath_FilePath:
+	default:
+		return outputTarget{}, assert.PanicUnknownCase[error](path.kind)
+	}
+
+	fs, rel, err := fsForPath(path.path)
+	if err != nil {
+		return outputTarget{}, errorx.Wrapf("nostack", err, "open --%s %q", flag, path.path)
+	}
+
+	info, err := fs.Stat(rel, fsx.StatOptions{FollowFinalSymlink: true, OnErrorTraverseParents: false})
+	if err == nil {
+		if info.IsDir() {
+			return outputTarget{}, errorx.Newf("nostack", "open --%s %q: is a directory", flag, path.path)
+		}
+		base := rel.BaseName()
+		f, createErr := fsx_temp.CreateFile(fs, pathx.Dot(),
+			fsx_temp.Names([]byte("."+base.String()+".tmp."), syscaps.TempFileFragments(), nil),
+			fsx.NewOpenOptions(fsx.OpenRW_WriteOnly))
+		if createErr != nil {
+			return outputTarget{}, errorx.Wrapf("nostack", createErr, "open --%s %q: create temporary output file", flag, path.path)
+		}
+		out := &OutputFile{file: f, target: rel, temp: Some(pathx.Dot().JoinOne(f.Name()))}
+		return outputTarget{writer: out, fs: fs, file: out}, nil
+	}
+	if !errorx.GetRootCauseAsValue(err, fsx.ErrNotExist) {
+		return outputTarget{}, errorx.Wrapf("nostack", err, "open --%s %q: stat output path", flag, path.path)
+	}
+
+	f, err := fs.OpenFile(rel, fsx.NewOpenOptions(fsx.OpenRW_WriteOnly).
+		WithMode(fsx.OpenMode_CreateNew).
+		MustBuild())
+	if err != nil {
+		return outputTarget{}, errorx.Wrapf("nostack", err, "open --%s %q: create output file", flag, path.path)
+	}
+	out := &OutputFile{file: f, target: rel, temp: None[pathx.RelPath]()}
+	return outputTarget{writer: out, fs: fs, file: out}, nil
+}
+
+func (out outputTarget) Close(status result.Status) error {
+	if out.file == nil {
+		return nil
+	}
+	return out.file.Close(out.fs, status)
+}
+
+// OutputFile is a file being written, optionally via a temporary that replaces
+// an existing target atomically on success. See [OutputFile.Close].
+type OutputFile struct {
+	// The open file where writes are directed.
+	//
+	// This is a temporary file when temp is Some, otherwise,
+	// this corresponds to target.
+	file fsx.File
+	// target is the final destination path, relative to the output FS root.
+	target pathx.RelPath
+	// temp, when set, is the temporary file to rename onto target at a
+	// successful Close. It is None when file already is the target.
+	temp Option[pathx.RelPath]
+}
+
+func (o *OutputFile) Write(p []byte) (int, error) {
+	return o.file.Write(p)
+}
+
+// Close closes the file and finalizes it based on status.
+//
+// If status is result.Status_Success, then the temporary output file
+// is moved to the destination. Otherwise, the temporary file is
+// deleted.
+func (o *OutputFile) Close(fs fsx.FS, status result.Status) error {
+	closeErr := o.file.Close()
+	switch status {
+	case result.Status_Success:
+		if closeErr != nil {
+			return errorx.Join(closeErr, o.delete(fs))
+		}
+		if temp, ok := o.temp.Get(); ok {
+			if err := fs.Rename(temp, o.target); err != nil {
+				return errorx.Join(errorx.Wrapf("nostack", err, "replace output file"), o.delete(fs))
+			}
+		}
+		return nil
+	case result.Status_Failure:
+		return errorx.Join(closeErr, o.delete(fs))
+	default:
+		return assert.PanicUnknownCase[error](status)
+	}
+}
+
+func (o *OutputFile) delete(fs fsx.FS) error {
+	return fs.RemoveAll(o.temp.ValueOr(o.target))
+}
+
+// fsForPath creates a scoped fsx.FS for accessing this file,
+// and creates a basename-only RelPath for the file.
+func fsForPath(path string) (fsx.FS, pathx.RelPath, error) {
+	abs, err := syscaps.ResolvePath(path)
+	if err != nil {
+		return nil, pathx.RelPath{}, err
+	}
+
+	dir, name := abs.Split()
+	fs, err := syscaps.FS(dir)
+	if err != nil {
+		return nil, pathx.RelPath{}, err
+	}
+	return fs, pathx.NewRelPathFromName(name), nil
+}

--- a/misc/cmd/jsonl/main_test.go
+++ b/misc/cmd/jsonl/main_test.go
@@ -1,0 +1,650 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"code.kibou.tools/base/cancel"
+	"code.kibou.tools/base/check"
+	"code.kibou.tools/base/check/golden"
+	"code.kibou.tools/base/cmdx"
+	"code.kibou.tools/base/core/pathx"
+	"code.kibou.tools/base/core/result"
+	"code.kibou.tools/base/envx"
+	"code.kibou.tools/base/logx"
+	"code.kibou.tools/base/syscaps"
+	"code.kibou.tools/misc/internal/go_test"
+)
+
+var snapshots = golden.NewSnapshotDirSet("testdata/snapshots")
+
+func TestMain(m *testing.M) {
+	os.Exit(snapshots.Run(m))
+}
+
+func TestRenderGoTest(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("SyntheticSchema", testRenderGoTestSyntheticSchema)
+	h.Run("PassesThroughDistIssue76024", testRenderGoTestPassesThroughDistIssue76024)
+	h.Run("PassesThroughNonJSON", testRenderGoTestPassesThroughNonJSON)
+	h.Run("PackageResults", testRenderGoTestPackageResults)
+	h.Run("WarnsUnknownEnums", testRenderGoTestWarnsUnknownEnums)
+}
+
+func testRenderGoTestSyntheticSchema(h check.Harness) {
+	h.Parallel()
+	input := strings.Join([]string{
+		`{"Action":"start","Package":"example.test/pkg"}`,
+		`{"Action":"run","Package":"example.test/pkg","Test":"TestPanic"}`,
+		`{"Action":"output","Package":"example.test/pkg","Test":"TestPanic","Output":"=== RUN   TestPanic\n","OutputType":"frame"}`,
+		`{"Action":"output","Package":"example.test/pkg","Test":"TestPanic","Output":"panic: boom\n","OutputType":"error"}`,
+		`{"Action":"fail","Package":"example.test/pkg","Test":"TestPanic","Elapsed":0.01}`,
+		`{"Action":"fail","Package":"example.test/pkg","Elapsed":0.02}`,
+		`{"Action":"fail","Package":"example.test/dep","Elapsed":0,"FailedBuild":"example.test/dep"}`,
+	}, "\n") + "\n"
+
+	got := renderString(h, input)
+	golden.SnapshotAt(snapshots.FS(h, "testdata/snapshots"), pathx.MustParseRelPath("synthetic-schema.txt")).AssertMatch(h, got)
+}
+
+// TestGoTestJSONSamples drives the renderer end-to-end against real `go test
+// -json` output from fixture packages. Each subtest snapshots the rendered
+// (human-readable) output, which is what the tool actually produces. Only
+// lifecycle additionally snapshots the normalized JSONL shape, as a single
+// representative; snapshotting it per fixture mostly re-tests `go test` and the
+// normalizer, not our code, and is brittle across Go versions.
+func TestGoTestJSONSamples(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("Lifecycle", testGoTestJSONLifecycleSample)
+	h.Run("StdoutStderr", testGoTestJSONStdoutStderrSample)
+	h.Run("Panic", testGoTestJSONPanicSample)
+	h.Run("Segfault", testGoTestJSONSegfaultSample)
+	h.Run("Timeout", testGoTestJSONTimeoutSample)
+	h.Run("BuildFail", testGoTestJSONBuildFailSample)
+}
+
+func testGoTestJSONLifecycleSample(h check.Harness) {
+	h.Parallel()
+	normalized := sampleJSONL(h, "lifecycle", "TestLifecycle", true)
+	snapshotFS := snapshots.FS(h, "testdata/snapshots")
+	golden.SnapshotAt(snapshotFS, pathx.MustParseRelPath("lifecycle.jsonl")).AssertMatch(h, normalized)
+	golden.SnapshotAt(snapshotFS, pathx.MustParseRelPath("lifecycle-rendered.txt")).AssertMatch(h, renderString(h, normalized))
+	golden.SnapshotAt(snapshotFS, pathx.MustParseRelPath("lifecycle-actions.txt")).AssertMatch(h, actionTrace(h, normalized))
+}
+
+func testGoTestJSONStdoutStderrSample(h check.Harness) {
+	h.Parallel()
+	assertRenderedSnapshot(h, "stdio", "TestStdoutStderr", false, "stdio-rendered.txt")
+}
+
+func testGoTestJSONPanicSample(h check.Harness) {
+	h.Parallel()
+	assertRenderedSnapshot(h, "panic", "TestPanic", true, "panic-rendered.txt")
+}
+
+func testGoTestJSONSegfaultSample(h check.Harness) {
+	h.Parallel()
+	// A segfault drives the same crash-render path as a panic; rather than
+	// snapshot a second near-identical goroutine dump, assert only the
+	// SIGSEGV-specific detail that sets it apart.
+	rendered := renderString(h, sampleJSONL(h, "segfault", "TestSegfault", true))
+	h.Assertf(strings.Contains(rendered, "SIGSEGV"), "segfault render should surface the SIGSEGV signal line")
+	h.Assertf(strings.Contains(rendered, "FAIL\texample.test/jsonlfixture/segfault"),
+		"segfault package should fail")
+}
+
+func testGoTestJSONTimeoutSample(h check.Harness) {
+	h.Parallel()
+	// A timeout's goroutine dump is inherently non-deterministic — it depends on
+	// what every goroutine is doing when the alarm fires — so we assert the
+	// stable, meaningful behavior instead of snapshotting the dump: the renderer
+	// surfaces the timeout, the package fails, and because a timed-out binary
+	// emits no per-test result, the failing test's name is lost (only a
+	// package-level failure reaches the summary). With the dump no longer
+	// snapshotted, the timeout can be tiny again.
+	rendered := renderString(h, runSamplePackage(h, "timeout", "TestTimeout", true, "-timeout=10ms"))
+
+	h.Assertf(strings.Contains(rendered, "test timed out"), "render should surface the timeout panic")
+	h.Assertf(strings.Contains(rendered, "FAIL\texample.test/jsonlfixture/timeout"),
+		"render should show the package failing")
+
+	idx := strings.Index(rendered, "# go test summary")
+	h.Assertf(idx >= 0, "render should include a summary")
+	summary := rendered[idx:]
+	h.Assertf(strings.Contains(summary, "FAIL example.test/jsonlfixture/timeout ("),
+		"summary should list the package-level failure")
+	h.Assertf(!strings.Contains(summary, "TestTimeout"),
+		"a timed-out test produces no per-test result, so its name is absent from the summary")
+}
+
+func testGoTestJSONBuildFailSample(h check.Harness) {
+	h.Parallel()
+	normalized := sampleJSONL(h, "buildfail", "TestBuildFail", true)
+	snapshotFS := snapshots.FS(h, "testdata/snapshots")
+	golden.SnapshotAt(snapshotFS, pathx.MustParseRelPath("buildfail.jsonl")).AssertMatch(h, normalized)
+	// The rendered snapshot must contain the compiler diagnostic (from
+	// build-output), not just a "[build failed]" summary line.
+	rendered := renderString(h, normalized)
+	h.Assertf(strings.Contains(rendered, "undefined: thisSymbolDoesNotExist"),
+		"build-output diagnostics should be rendered, not dropped")
+	golden.SnapshotAt(snapshotFS, pathx.MustParseRelPath("buildfail-rendered.txt")).AssertMatch(h, rendered)
+}
+
+func testRenderGoTestPassesThroughDistIssue76024(h check.Harness) {
+	h.Parallel()
+	input := readSnapshotText(h, "dist-issue-76024-input.txt")
+	snapshotFS := snapshots.FS(h, "testdata/snapshots")
+	golden.SnapshotAt(snapshotFS, pathx.MustParseRelPath("dist-issue-76024-input.txt")).AssertMatch(h, input)
+
+	var out, logBuf bytes.Buffer
+	logger := logx.NewLogger(&logBuf, logx.ColorSupport_Disable)
+	h.NoErrorf(renderGoTest(logger, go_test.NewColorizer(false), strings.NewReader(input), &out, io.Discard),
+		"renderGoTest")
+	golden.SnapshotAt(snapshotFS, pathx.MustParseRelPath("dist-issue-76024-rendered.txt")).AssertMatch(h, out.String())
+	h.Assertf(strings.Contains(logBuf.String(), "passing through non-JSON"), "the raw dist lines should be warned about")
+
+	captured, err := captureStream(h, input)
+	h.NoErrorf(err, "captureStream")
+	golden.SnapshotAt(snapshotFS, pathx.MustParseRelPath("dist-issue-76024-captured.jsonl")).AssertMatch(h, captured)
+}
+
+func testRenderGoTestPassesThroughNonJSON(h check.Harness) {
+	h.Parallel()
+	input := strings.Join([]string{
+		`{"Action":"output","Package":"example.test/pkg","Output":"before\n"}`,
+		`not json at all`,
+		`{"Action":"fail","Package":"example.test/pkg","Elapsed":0.01}`,
+	}, "\n") + "\n"
+
+	var out, logBuf bytes.Buffer
+	logger := logx.NewLogger(&logBuf, logx.ColorSupport_Disable)
+	h.NoErrorf(renderGoTest(logger, go_test.NewColorizer(false), strings.NewReader(input), &out, io.Discard),
+		"renderGoTest should not abort on a non-JSON line")
+	h.Assertf(strings.Contains(out.String(), "not json at all"), "non-JSON line should be echoed verbatim")
+	h.Assertf(strings.Contains(out.String(), "before"), "valid output before the bad line should still render")
+	h.Assertf(strings.Contains(out.String(), "FAIL example.test/pkg"), "summary should still render after the bad line")
+	h.Assertf(strings.Contains(logBuf.String(), "passing through non-JSON"), "the bad line should be warned about")
+}
+
+func TestCapture(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("WrapsNonJSONWithCarriedTime", testCaptureWrapsNonJSONWithCarriedTime)
+	h.Run("BuffersLeadingNonJSONUntilFirstEvent", testCaptureBuffersLeadingNonJSONUntilFirstEvent)
+	h.Run("ErrorsWithoutTimestampedEvent", testCaptureErrorsWithoutTimestampedEvent)
+}
+
+func testCaptureWrapsNonJSONWithCarriedTime(h check.Harness) {
+	h.Parallel()
+	input := strings.Join([]string{
+		`{"Action":"start","Package":"p","Time":"2026-01-02T03:04:05Z"}`,
+		`stray non-json line`,
+		`{"Action":"fail","Package":"p","Elapsed":0.01,"Time":"2026-01-02T03:04:07Z"}`,
+	}, "\n") + "\n"
+
+	captured, err := captureStream(h, input)
+	h.NoErrorf(err, "captureStream")
+
+	lines := nonEmptyLines(captured)
+	h.Assertf(len(lines) == 3, "capture should have 3 lines, got %d", len(lines))
+	// Valid lines pass through byte-for-byte.
+	h.Assertf(lines[0] == `{"Action":"start","Package":"p","Time":"2026-01-02T03:04:05Z"}`, "first line verbatim")
+	h.Assertf(lines[2] == `{"Action":"fail","Package":"p","Elapsed":0.01,"Time":"2026-01-02T03:04:07Z"}`, "third line verbatim")
+	// The stray line is wrapped as an output event carrying the previous event's Time.
+	wrapped := decodeJSONObject(h, lines[1])
+	h.Assertf(wrapped["Action"] == "output", "wrapped Action is output")
+	h.Assertf(wrapped["Time"] == "2026-01-02T03:04:05Z", "wrapped carries the previous event's Time")
+	h.Assertf(wrapped["Output"] == "stray non-json line\n", "wrapped preserves the raw line")
+	h.Assertf(wrapped[go_test.RawOutputMarker] == true, "wrapped is marked as injected raw output")
+}
+
+func testCaptureBuffersLeadingNonJSONUntilFirstEvent(h check.Harness) {
+	h.Parallel()
+	// build-output is valid JSON but carries no Time, so a stray line among the
+	// leading build events has nothing to anchor to until the start event.
+	input := strings.Join([]string{
+		`{"ImportPath":"p","Action":"build-output","Output":"# p\n"}`,
+		`stray before any timestamp`,
+		`{"Action":"start","Package":"p","Time":"2026-01-02T03:04:05Z"}`,
+	}, "\n") + "\n"
+
+	captured, err := captureStream(h, input)
+	h.NoErrorf(err, "captureStream")
+
+	lines := nonEmptyLines(captured)
+	h.Assertf(len(lines) == 3, "capture should have 3 lines, got %d", len(lines))
+	h.Assertf(strings.Contains(lines[0], `"Action":"build-output"`), "build-output passes through first")
+	// The buffered raw line is flushed before the start event, back-filled with
+	// the first timestamped event's Time.
+	wrapped := decodeJSONObject(h, lines[1])
+	h.Assertf(wrapped[go_test.RawOutputMarker] == true, "buffered line is wrapped")
+	h.Assertf(wrapped["Time"] == "2026-01-02T03:04:05Z", "buffered line back-filled with the first event's Time")
+	h.Assertf(wrapped["Output"] == "stray before any timestamp\n", "buffered raw line preserved")
+	h.Assertf(strings.Contains(lines[2], `"Action":"start"`), "start event follows the flushed buffer")
+}
+
+func testCaptureErrorsWithoutTimestampedEvent(h check.Harness) {
+	h.Parallel()
+
+	// A stray line among Timeless build events, with the stream ending before
+	// any timestamped event: nothing can anchor the buffered line.
+	noAnchor := strings.Join([]string{
+		`{"ImportPath":"p","Action":"build-output","Output":"# p\n"}`,
+		`stray with no anchor`,
+		`{"ImportPath":"p","Action":"build-fail"}`,
+	}, "\n") + "\n"
+	_, err := captureStream(h, noAnchor)
+	h.Assertf(err != nil, "capture should fail when no timestamped event anchors a buffered line")
+
+	// Not even one JSON line.
+	_, err = captureStream(h, "not json at all\nstill not json\n")
+	h.Assertf(err != nil, "capture should fail on a stream with no JSON events")
+}
+
+func testRenderGoTestPackageResults(h check.Harness) {
+	h.Parallel()
+	input := strings.Join([]string{
+		`{"Action":"pass","Package":"example.test/pkg","Test":"TestPass","Elapsed":0.01}`,
+		`{"Action":"pass","Package":"example.test/pkg","Elapsed":0.02}`,
+		`{"Action":"skip","Package":"example.test/pkg","Test":"TestSkip","Elapsed":0.03}`,
+		`{"Action":"skip","Package":"example.test/no-tests","Elapsed":0}`,
+	}, "\n") + "\n"
+
+	rendered := renderString(h, input)
+	h.Assertf(strings.Contains(rendered, "(1 passed)"), "test-level pass should be counted")
+	h.Assertf(!strings.Contains(rendered, "(2 passed)"), "package-level pass should not be counted")
+	h.Assertf(strings.Contains(rendered, "(1 skipped)"), "test-level skip should be counted")
+	h.Assertf(!strings.Contains(rendered, "(2 skipped)"), "package-level skip should not be counted")
+}
+
+func testRenderGoTestWarnsUnknownEnums(h check.Harness) {
+	h.Parallel()
+	input := strings.Join([]string{
+		`{"Action":"teleport","Package":"example.test/pkg"}`,
+		`{"Action":"teleport","Package":"example.test/pkg"}`,
+		`{"Action":"teleport","Package":"example.test/pkg"}`,
+		`{"Action":"teleport","Package":"example.test/pkg"}`,
+		`{"Action":"teleport","Package":"example.test/pkg"}`,
+		`{"Action":"output","Package":"example.test/pkg","Output":"x\n","OutputType":"hologram"}`,
+		`{"Action":"output","Package":"example.test/pkg","Output":"x\n","OutputType":"hologram"}`,
+		`{"Action":"output","Package":"example.test/pkg","Output":"x\n","OutputType":"hologram"}`,
+		`{"Action":"output","Package":"example.test/pkg","Output":"x\n","OutputType":"hologram"}`,
+		`{"Action":"output","Package":"example.test/pkg","Output":"x\n","OutputType":"hologram"}`,
+	}, "\n") + "\n"
+
+	var out, logBuf bytes.Buffer
+	logger := logx.NewLogger(&logBuf, logx.ColorSupport_Disable)
+	h.NoErrorf(renderGoTest(logger, go_test.NewColorizer(false), strings.NewReader(input), &out, io.Discard),
+		"renderGoTest")
+	logs := logBuf.String()
+	h.Assertf(strings.Count(logs, "unknown go test JSON action") == 3, "should limit unknown action warnings")
+	h.Assertf(strings.Count(logs, "unknown go test JSON output type") == 3, "should limit unknown output type warnings")
+	h.Assertf(strings.Contains(out.String(), "- Unknown go test JSON actions (logged: 3/5, omitted: 2/5 for brevity)"),
+		"human-readable output should summarize unknown action warnings")
+	h.Assertf(strings.Contains(out.String(), "- Unknown go test JSON output types (logged: 3/5, omitted: 2/5 for brevity)"),
+		"human-readable output should summarize unknown output type warnings")
+}
+
+func TestColorModes(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	for _, name := range []string{"auto", "always", "never"} {
+		mode, err := parseColorMode(name)
+		h.NoErrorf(err, "parseColorMode(%q)", name)
+		h.Assertf(string(mode) == name, "parseColorMode(%q) round-trips", name)
+	}
+	_, err := parseColorMode("rainbow")
+	h.Assertf(err != nil, "parseColorMode should reject unknown modes")
+
+	// A failing stream exercises both red (error output and failure lines) and
+	// yellow (the passed/skipped counts). Snapshot the colorized render so the
+	// exact ANSI is reviewable in a .ansi file.
+	input := strings.Join([]string{
+		`{"Action":"output","Package":"example.test/pkg","Test":"TestFoo","Output":"    foo_test.go:10: boom\n","OutputType":"error"}`,
+		`{"Action":"output","Package":"example.test/pkg","Test":"TestFoo","Output":"--- FAIL: TestFoo (0.00s)\n","OutputType":"frame"}`,
+		`{"Action":"fail","Package":"example.test/pkg","Test":"TestFoo","Elapsed":0.01}`,
+		`{"Action":"pass","Package":"example.test/pkg","Test":"TestBar","Elapsed":0.02}`,
+		`{"Action":"skip","Package":"example.test/pkg","Test":"TestBaz","Elapsed":0.03}`,
+		`{"Action":"fail","Package":"example.test/pkg","Elapsed":0.04}`,
+	}, "\n") + "\n"
+
+	var out bytes.Buffer
+	h.NoErrorf(renderGoTest(logx.NewLogger(io.Discard, logx.ColorSupport_Disable),
+		go_test.NewColorizer(true), strings.NewReader(input), &out, io.Discard),
+		"renderGoTest")
+	golden.SnapshotAt(snapshots.FS(h, "testdata/snapshots"), pathx.MustParseRelPath("color-modes.ansi")).AssertMatch(h, out.String())
+}
+
+func TestPathSpecialForms(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	input, err := parseInputPathOrSpecial("plain.jsonl")
+	h.NoErrorf(err, "plain input path")
+	h.Assertf(input.kind == InputPath_FilePath && input.path == "plain.jsonl", "plain input path should pass through")
+
+	input, err = parseInputPathOrSpecial(":stdin")
+	h.NoErrorf(err, "stdin input special path")
+	h.Assertf(input.kind == InputPath_Stdin, ":stdin should parse as stdin")
+
+	input, err = parseInputPathOrSpecial("::leading-colon.jsonl")
+	h.NoErrorf(err, "escaped input path")
+	h.Assertf(input.kind == InputPath_FilePath && input.path == ":leading-colon.jsonl",
+		"escaped input path should lose one colon")
+
+	_, err = parseInputPathOrSpecial(":future-special")
+	h.Assertf(err != nil, "unknown input special form should be rejected")
+
+	output, err := parseOutputPathOrSpecial("plain.jsonl")
+	h.NoErrorf(err, "plain output path")
+	h.Assertf(output.kind == OutputPath_FilePath && output.path == "plain.jsonl", "plain output path should pass through")
+
+	output, err = parseOutputPathOrSpecial(":stdout")
+	h.NoErrorf(err, "stdout output special path")
+	h.Assertf(output.kind == OutputPath_Stdout, ":stdout should parse as stdout")
+
+	output, err = parseOutputPathOrSpecial(":discard")
+	h.NoErrorf(err, "discard output special path")
+	h.Assertf(output.kind == OutputPath_Discard, ":discard should parse as discard")
+
+	output, err = parseOutputPathOrSpecial("::leading-colon.jsonl")
+	h.NoErrorf(err, "escaped output path")
+	h.Assertf(output.kind == OutputPath_FilePath && output.path == ":leading-colon.jsonl",
+		"escaped output path should lose one colon")
+
+	_, err = parseOutputPathOrSpecial(":future-special")
+	h.Assertf(err != nil, "unknown output special form should be rejected")
+
+	stdout := OutputPath{kind: OutputPath_Stdout, path: ""}
+	discard := OutputPath{kind: OutputPath_Discard, path: ""}
+	h.NoErrorf(validateOutputPaths(stdout, discard), "stdout may be used by one output")
+	h.Assertf(validateOutputPaths(stdout, stdout) != nil, "both outputs must not write to stdout")
+}
+
+func TestOpenInput(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	stdin, err := parseInputPathOrSpecial(":stdin")
+	h.NoErrorf(err, "parse :stdin")
+	r, err := openInput(stdin)
+	h.NoErrorf(err, "openInput(:stdin)")
+	h.Assertf(r != nil, "openInput(:stdin) returns a reader")
+	h.NoErrorf(r.Close(), "close openInput(:stdin)")
+
+	fileInput, err := parseInputPathOrSpecial("testdata/snapshots/lifecycle.jsonl")
+	h.NoErrorf(err, "parse input file")
+	r, err = openInput(fileInput)
+	h.NoErrorf(err, "openInput on an existing file")
+	h.NoErrorf(r.Close(), "close input file")
+	h.Assertf(r != nil, "openInput returns a reader for an existing file")
+
+	missingInput, err := parseInputPathOrSpecial("testdata/snapshots/does-not-exist.jsonl")
+	h.NoErrorf(err, "parse missing input file")
+	_, err = openInput(missingInput)
+	h.Assertf(err != nil, "openInput reports an error for a missing file")
+}
+
+func TestOpenOutput(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	newPath, err := parseOutputPathOrSpecial(filepath.Join(h.T().TempDir(), "output.jsonl"))
+	h.NoErrorf(err, "parse new output path")
+	out, err := openOutput(newPath, "jsonl-output")
+	h.NoErrorf(err, "openOutput on a new file")
+	h.Assertf(out.writer != nil, "openOutput returns a writer")
+	h.NoErrorf(out.Close(result.Status_Success), "close output file")
+
+	existingPath := filepath.Join(h.T().TempDir(), "existing.jsonl")
+	h.NoErrorf(os.WriteFile(existingPath, []byte("old\n"), 0o644), "write existing output file")
+	existingOutput, err := parseOutputPathOrSpecial(existingPath)
+	h.NoErrorf(err, "parse existing output path")
+	out, err = openOutput(existingOutput, "jsonl-output")
+	h.NoErrorf(err, "openOutput on an existing file")
+	_, err = io.WriteString(out.writer, "new\n")
+	h.NoErrorf(err, "write temporary output file")
+	data, err := os.ReadFile(existingPath)
+	h.NoErrorf(err, "read existing output before commit")
+	h.Assertf(string(data) == "old\n", "existing output should not be overwritten before commit, got %q", data)
+	h.NoErrorf(out.Close(result.Status_Success), "commit output")
+	data, err = os.ReadFile(existingPath)
+	h.NoErrorf(err, "read existing output after commit")
+	h.Assertf(string(data) == "new\n", "existing output should be overwritten at commit, got %q", data)
+
+	// When jsonl's own processing fails partway (Status_Failure, not a test
+	// failure in the stream), the temporary is discarded and the prior output
+	// is left intact.
+	out, err = openOutput(existingOutput, "jsonl-output")
+	h.NoErrorf(err, "reopen existing output")
+	_, err = io.WriteString(out.writer, "partial")
+	h.NoErrorf(err, "write partial output")
+	h.NoErrorf(out.Close(result.Status_Failure), "discard output when processing failed")
+	data, err = os.ReadFile(existingPath)
+	h.NoErrorf(err, "read existing output after failed processing")
+	h.Assertf(string(data) == "new\n", "failed processing must not overwrite the existing output, got %q", data)
+
+	discard, err := parseOutputPathOrSpecial(":discard")
+	h.NoErrorf(err, "parse discard output")
+	out, err = openOutput(discard, "jsonl-output")
+	h.NoErrorf(err, "openOutput(:discard)")
+	h.Assertf(out.writer == io.Discard, ":discard should use io.Discard")
+	h.NoErrorf(out.Close(result.Status_Success), "close discard output")
+}
+
+func runSamplePackage(h check.Harness, name string, run string, wantFail bool, extraArgs ...string) string {
+	h.T().Helper()
+	cwd, err := syscaps.WorkingDirectory()
+	h.NoErrorf(err, "determine package directory")
+	sampleDir := cwd.Join(pathx.MustParseRelPath("testdata/packages")).JoinComponents(name)
+
+	ctx := logx.NewLogCtx(cancel.Never(), logx.NewLogger(io.Discard, logx.ColorSupport_Disable))
+	options := cmdx.RunOptionsDefault().WithCaptureStdout().WithCaptureStderr()
+	options.TransformEnv = func(env envx.Env) envx.Env {
+		env, _ = env.InsertOrReplace("GOWORK", "off")
+		// Fixtures that panic, crash, or hang are gated behind this variable so
+		// they only misbehave when this harness drives them, never under an
+		// ordinary `go test ./...`.
+		env, _ = env.InsertOrReplace("JSONL_FIXTURE", name)
+		return env
+	}
+	argv := append([]string{"go", "test", "-json", "-count=1", "-run", run}, extraArgs...)
+	argv = append(argv, ".")
+	output, err := (syscaps.CmdRunner{Env: syscaps.Env()}).Run(ctx,
+		cmdx.New(argv...).In(sampleDir), options)
+	if wantFail {
+		h.Assertf(err != nil, "go test sample package %q should fail", name)
+	} else {
+		h.NoErrorf(err, "go test sample package %q", name)
+	}
+	h.Assertf(output.Stdout != "", "go test sample package %q should produce JSON output", name)
+	return output.Stdout
+}
+
+// sampleJSONL runs the named fixture package and returns its normalized go test
+// JSONL stream.
+func sampleJSONL(h check.Harness, pkg, run string, wantFail bool) string {
+	h.T().Helper()
+	return goTestNormalizer.NormalizeJSONL(h, runSamplePackage(h, pkg, run, wantFail))
+}
+
+// assertRenderedSnapshot runs the fixture and asserts its rendered output
+// matches the named snapshot.
+func assertRenderedSnapshot(h check.Harness, pkg, run string, wantFail bool, snapshot string) {
+	h.T().Helper()
+	rendered := renderString(h, sampleJSONL(h, pkg, run, wantFail))
+	golden.SnapshotAt(snapshots.FS(h, "testdata/snapshots"), pathx.MustParseRelPath(snapshot)).AssertMatch(h, rendered)
+}
+
+func readSnapshotText(h check.Harness, name string) string {
+	h.T().Helper()
+	data, err := os.ReadFile("testdata/snapshots/" + name)
+	h.NoErrorf(err, "read snapshot input %q", name)
+	return string(data)
+}
+
+func renderString(h check.Harness, input string) string {
+	h.T().Helper()
+	var out bytes.Buffer
+	logger := logx.NewLogger(io.Discard, logx.ColorSupport_Disable)
+	h.NoErrorf(renderGoTest(logger, go_test.NewColorizer(false), strings.NewReader(input), &out, io.Discard),
+		"renderGoTest")
+	return out.String()
+}
+
+// captureStream runs the renderer with a capture sink and returns the sanitized
+// JSONL it wrote, along with any error from the capture (e.g. an unanchored
+// stream). The human-readable render is discarded.
+func captureStream(h check.Harness, input string) (string, error) {
+	h.T().Helper()
+	var render, captured bytes.Buffer
+	logger := logx.NewLogger(io.Discard, logx.ColorSupport_Disable)
+	err := renderGoTest(logger, go_test.NewColorizer(false), strings.NewReader(input), &render, &captured)
+	return captured.String(), err
+}
+
+func nonEmptyLines(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func decodeJSONObject(h check.Harness, line string) map[string]any {
+	h.T().Helper()
+	var obj map[string]any
+	h.NoErrorf(json.Unmarshal([]byte(line), &obj), "decode captured line %q", line)
+	return obj
+}
+
+// goTestNormalizer is the shared, compiled-once instance. Construct one and
+// reuse it rather than building a normalizer inside a per-line loop.
+var goTestNormalizer = newGoTestJSONNormalizer()
+
+// goTestJSONNormalizer rewrites a go test -json stream into a deterministic
+// form for golden snapshots: fixed timestamps, a constant non-zero elapsed
+// time, and output text scrubbed of pointer addresses, goroutine ids, absolute
+// source paths, and line numbers. Its regexps are compiled once by
+// newGoTestJSONNormalizer, never per line.
+type goTestJSONNormalizer struct {
+	elapsedParen *regexp.Regexp
+	elapsedTab   *regexp.Regexp
+	timedOut     *regexp.Regexp
+	hexAddr      *regexp.Regexp
+	goroutineID  *regexp.Regexp
+	pathLine     *regexp.Regexp
+	goLine       *regexp.Regexp
+}
+
+func newGoTestJSONNormalizer() goTestJSONNormalizer {
+	return goTestJSONNormalizer{
+		elapsedParen: regexp.MustCompile(`\([0-9]+(?:\.[0-9]+)?s\)`),
+		elapsedTab:   regexp.MustCompile(`\t[0-9]+(?:\.[0-9]+)?s`),
+		timedOut:     regexp.MustCompile(`timed out after [0-9.]+(?:ns|µs|us|ms|s|m|h)+`),
+		// The trailing "?" is Go's marker for a traceback argument whose value
+		// may be inaccurate; whether it appears depends on the calling
+		// convention, so dropping it keeps snapshots portable across GOARCH.
+		hexAddr:     regexp.MustCompile(`0x[0-9a-fA-F]+\??`),
+		goroutineID: regexp.MustCompile(`goroutine [0-9]+`),
+		// pathLine strips the directory from an absolute "<dir>/<file>.go:<n>"
+		// reference, keeping just "<file>.go:N"; goLine handles any remaining
+		// relative reference such as "_testmain.go:46". The optional ":<col>"
+		// collapses compiler diagnostics like "foo.go:3:11: undefined: y".
+		pathLine: regexp.MustCompile(`\S*/([\w.@~+-]+\.go):[0-9]+(?::[0-9]+)?`),
+		goLine:   regexp.MustCompile(`([\w.@~+-]+\.go):[0-9]+(?::[0-9]+)?`),
+	}
+}
+
+// NormalizeJSONL rewrites a full go test JSONL stream line by line.
+func (n goTestJSONNormalizer) NormalizeJSONL(h check.Harness, input string) string {
+	h.T().Helper()
+	var out strings.Builder
+	lineNumber := 0
+	for _, line := range strings.Split(input, "\n") {
+		if line == "" {
+			continue
+		}
+		lineNumber++
+		var event map[string]any
+		h.NoErrorf(json.Unmarshal([]byte(line), &event), "decode go test JSONL line %d", lineNumber)
+		if _, ok := event["Time"].(string); ok {
+			event["Time"] = fixedTimestamp(lineNumber)
+		}
+		if _, ok := event["Elapsed"].(float64); ok {
+			// Collapse every elapsed value, including an exact 0: whether a
+			// sub-millisecond span rounds to 0.00 or to a tiny non-zero value is
+			// itself timing-dependent (and differs on a slow or emulated
+			// runner), so it must not leak into snapshots.
+			event["Elapsed"] = 0.69
+		}
+		if output, ok := event["Output"].(string); ok {
+			event["Output"] = n.normalizeOutput(output)
+		}
+		encoded, err := json.Marshal(event)
+		h.NoErrorf(err, "encode normalized go test JSONL line %d", lineNumber)
+		out.Write(encoded)
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+func (n goTestJSONNormalizer) normalizeOutput(output string) string {
+	output = n.elapsedParen.ReplaceAllString(output, "(Xs)")
+	output = n.elapsedTab.ReplaceAllString(output, "\tXs")
+	output = n.timedOut.ReplaceAllString(output, "timed out after Xs")
+	output = n.hexAddr.ReplaceAllString(output, "0xADDR")
+	output = n.goroutineID.ReplaceAllString(output, "goroutine N")
+	output = n.pathLine.ReplaceAllString(output, "$1:N")
+	output = n.goLine.ReplaceAllString(output, "$1:N")
+	return output
+}
+
+func fixedTimestamp(index int) string {
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	return base.Add(time.Duration(index-1) * time.Second).Format(time.RFC3339)
+}
+
+func actionTrace(h check.Harness, input string) string {
+	h.T().Helper()
+	var out strings.Builder
+	for _, line := range strings.Split(input, "\n") {
+		if line == "" {
+			continue
+		}
+		var event map[string]any
+		h.NoErrorf(json.Unmarshal([]byte(line), &event), "decode normalized go test JSONL")
+		action, _ := event["Action"].(string)
+		test, _ := event["Test"].(string)
+		if test == "" {
+			pkg, _ := event["Package"].(string)
+			test = pkg
+		}
+		if action != "output" {
+			out.WriteString(action)
+			out.WriteByte('\t')
+			out.WriteString(test)
+			out.WriteByte('\n')
+		}
+	}
+	return out.String()
+}

--- a/misc/cmd/jsonl/render.go
+++ b/misc/cmd/jsonl/render.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package main
+
+import (
+	"io"
+
+	"code.kibou.tools/base/logx"
+	"code.kibou.tools/misc/internal/go_test"
+)
+
+// renderGoTest renders a go test -json stream to out, wiring this command's
+// warning accounting and normalized JSONL sink into [go_test.Render] as hooks.
+func renderGoTest(logger logx.Logger, z go_test.Colorizer, r io.Reader, pretty io.Writer, jsonl io.Writer) error {
+	warnings := newRenderWarnings()
+	return go_test.Render(r, go_test.RenderOutputs{Pretty: pretty, JSONL: jsonl}, z, go_test.Hooks{
+		OnNonJSONLine: func(lineNumber int, _ []byte, err error) error {
+			warnings.warnNotJSON(logger, lineNumber, err)
+			return nil
+		},
+		OnEvent: func(_ []byte, event go_test.Event) error {
+			warnings.warnUnknownEnums(logger, event)
+			return nil
+		},
+		BeforeSummary: func(w io.Writer) error {
+			return warnings.writeSummary(w, z)
+		},
+		OnFinish: nil,
+	})
+}

--- a/misc/cmd/jsonl/testdata/packages/buildfail/fixture_test.go
+++ b/misc/cmd/jsonl/testdata/packages/buildfail/fixture_test.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package buildfail
+
+import "testing"
+
+// TestBuildFail intentionally references an undefined symbol so the package
+// fails to compile. This exercises the renderer's build-output / build-fail
+// handling: go test -json emits the compiler diagnostics on build-output
+// events keyed by ImportPath. The package builds nowhere else (it is its own
+// module, outside the workspace) so it only fails when this harness drives it.
+func TestBuildFail(t *testing.T) {
+	thisSymbolDoesNotExist(t)
+}

--- a/misc/cmd/jsonl/testdata/packages/buildfail/go.mod
+++ b/misc/cmd/jsonl/testdata/packages/buildfail/go.mod
@@ -1,0 +1,3 @@
+module example.test/jsonlfixture/buildfail
+
+go 1.24.0

--- a/misc/cmd/jsonl/testdata/packages/lifecycle/fixture_test.go
+++ b/misc/cmd/jsonl/testdata/packages/lifecycle/fixture_test.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package lifecycle
+
+import "testing"
+
+func TestLifecycle(t *testing.T) {
+	t.Run("pass", func(t *testing.T) {
+		t.Log("pass log")
+	})
+	t.Run("skip", func(t *testing.T) {
+		t.Skip("skip log")
+	})
+	t.Run("fail", func(t *testing.T) {
+		t.Error("fail log")
+	})
+}

--- a/misc/cmd/jsonl/testdata/packages/lifecycle/go.mod
+++ b/misc/cmd/jsonl/testdata/packages/lifecycle/go.mod
@@ -1,0 +1,3 @@
+module example.test/jsonlfixture/lifecycle
+
+go 1.24.0

--- a/misc/cmd/jsonl/testdata/packages/panic/fixture_test.go
+++ b/misc/cmd/jsonl/testdata/packages/panic/fixture_test.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package panicfix
+
+import (
+	"os"
+	"testing"
+)
+
+// TestPanic panics so the renderer harness can capture how an uncaught panic
+// appears in go test -json. It is gated on JSONL_FIXTURE so it stays inert
+// under an ordinary `go test ./...`.
+func TestPanic(t *testing.T) {
+	if os.Getenv("JSONL_FIXTURE") != "panic" {
+		t.Skip("set JSONL_FIXTURE=panic to exercise the panic path")
+	}
+	panic("boom")
+}

--- a/misc/cmd/jsonl/testdata/packages/panic/go.mod
+++ b/misc/cmd/jsonl/testdata/packages/panic/go.mod
@@ -1,0 +1,3 @@
+module example.test/jsonlfixture/panic
+
+go 1.24.0

--- a/misc/cmd/jsonl/testdata/packages/segfault/fixture_test.go
+++ b/misc/cmd/jsonl/testdata/packages/segfault/fixture_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package segfault
+
+import (
+	"os"
+	"testing"
+)
+
+// sink keeps the nil dereference observable so the compiler cannot elide it.
+var sink int
+
+// TestSegfault dereferences a nil pointer, which the runtime delivers as
+// SIGSEGV and prints as a crash traceback in go test -json. It is gated on
+// JSONL_FIXTURE so it stays inert under an ordinary `go test ./...`.
+func TestSegfault(t *testing.T) {
+	if os.Getenv("JSONL_FIXTURE") != "segfault" {
+		t.Skip("set JSONL_FIXTURE=segfault to exercise the crash path")
+	}
+	var p *int
+	sink = *p
+}

--- a/misc/cmd/jsonl/testdata/packages/segfault/go.mod
+++ b/misc/cmd/jsonl/testdata/packages/segfault/go.mod
@@ -1,0 +1,3 @@
+module example.test/jsonlfixture/segfault
+
+go 1.24.0

--- a/misc/cmd/jsonl/testdata/packages/stdio/fixture_test.go
+++ b/misc/cmd/jsonl/testdata/packages/stdio/fixture_test.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package stdio
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestStdoutStderr(t *testing.T) {
+	fmt.Fprintln(os.Stdout, "stdout line")
+	fmt.Fprintln(os.Stderr, "stderr line")
+}

--- a/misc/cmd/jsonl/testdata/packages/stdio/go.mod
+++ b/misc/cmd/jsonl/testdata/packages/stdio/go.mod
@@ -1,0 +1,3 @@
+module example.test/jsonlfixture/stdio
+
+go 1.24.0

--- a/misc/cmd/jsonl/testdata/packages/timeout/fixture_test.go
+++ b/misc/cmd/jsonl/testdata/packages/timeout/fixture_test.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package timeout
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestTimeout sleeps far longer than the harness's -timeout, so go test kills
+// the binary and emits its "test timed out" panic. It is gated on
+// JSONL_FIXTURE so it stays inert under an ordinary `go test ./...`.
+func TestTimeout(t *testing.T) {
+	if os.Getenv("JSONL_FIXTURE") != "timeout" {
+		t.Skip("set JSONL_FIXTURE=timeout to exercise the timeout path")
+	}
+	time.Sleep(time.Hour)
+}

--- a/misc/cmd/jsonl/testdata/packages/timeout/go.mod
+++ b/misc/cmd/jsonl/testdata/packages/timeout/go.mod
@@ -1,0 +1,3 @@
+module example.test/jsonlfixture/timeout
+
+go 1.24.0

--- a/misc/cmd/jsonl/testdata/snapshots/buildfail-rendered.txt
+++ b/misc/cmd/jsonl/testdata/snapshots/buildfail-rendered.txt
@@ -1,0 +1,6 @@
+# example.test/jsonlfixture/buildfail [example.test/jsonlfixture/buildfail.test]
+fixture_test.go:N: undefined: thisSymbolDoesNotExist
+FAIL	example.test/jsonlfixture/buildfail [build failed]
+
+# go test summary
+FAIL example.test/jsonlfixture/buildfail (0.690s) [build failed: example.test/jsonlfixture/buildfail [example.test/jsonlfixture/buildfail.test]]

--- a/misc/cmd/jsonl/testdata/snapshots/buildfail.jsonl
+++ b/misc/cmd/jsonl/testdata/snapshots/buildfail.jsonl
@@ -1,0 +1,6 @@
+{"Action":"build-output","ImportPath":"example.test/jsonlfixture/buildfail [example.test/jsonlfixture/buildfail.test]","Output":"# example.test/jsonlfixture/buildfail [example.test/jsonlfixture/buildfail.test]\n"}
+{"Action":"build-output","ImportPath":"example.test/jsonlfixture/buildfail [example.test/jsonlfixture/buildfail.test]","Output":"fixture_test.go:N: undefined: thisSymbolDoesNotExist\n"}
+{"Action":"build-fail","ImportPath":"example.test/jsonlfixture/buildfail [example.test/jsonlfixture/buildfail.test]"}
+{"Action":"start","Package":"example.test/jsonlfixture/buildfail","Time":"2026-01-02T03:04:08Z"}
+{"Action":"output","Output":"FAIL\texample.test/jsonlfixture/buildfail [build failed]\n","Package":"example.test/jsonlfixture/buildfail","Time":"2026-01-02T03:04:09Z"}
+{"Action":"fail","Elapsed":0.69,"FailedBuild":"example.test/jsonlfixture/buildfail [example.test/jsonlfixture/buildfail.test]","Package":"example.test/jsonlfixture/buildfail","Time":"2026-01-02T03:04:10Z"}

--- a/misc/cmd/jsonl/testdata/snapshots/color-modes.ansi
+++ b/misc/cmd/jsonl/testdata/snapshots/color-modes.ansi
@@ -1,0 +1,8 @@
+[31m    foo_test.go:10: boom
+[0m--- FAIL: TestFoo (0.00s)
+
+# go test summary
+[31mFAIL example.test/pkg TestFoo (0.01s)[0m
+[31mFAIL example.test/pkg (0.040s)[0m
+[32m(1 passed)[0m
+[33m(1 skipped)[0m

--- a/misc/cmd/jsonl/testdata/snapshots/dist-issue-76024-captured.jsonl
+++ b/misc/cmd/jsonl/testdata/snapshots/dist-issue-76024-captured.jsonl
@@ -1,0 +1,6 @@
+{"Time":"2025-10-23T12:36:35.439236-04:00","Action":"start","Package":"crypto:gofips140"}
+{"Time":"2025-10-23T12:36:35.443492-04:00","Action":"start","Package":"crypto/aes:gofips140"}
+{"Time":"2025-10-23T12:36:35.445535-04:00","Action":"start","Package":"crypto/cipher:gofips140"}
+{"Action":"output","Output":"?   \tcrypto/internal/boring/bbig\t[no test files]\n","Time":"2025-10-23T12:36:35.445535-04:00","_raw_output":true}
+{"Action":"output","Output":"?   \tcrypto/internal/boring/sig\t[no test files]\n","Time":"2025-10-23T12:36:35.445535-04:00","_raw_output":true}
+{"Action":"output","Output":"?   \tcrypto/internal/cryptotest\t[no test files]\n","Time":"2025-10-23T12:36:35.445535-04:00","_raw_output":true}

--- a/misc/cmd/jsonl/testdata/snapshots/dist-issue-76024-input.txt
+++ b/misc/cmd/jsonl/testdata/snapshots/dist-issue-76024-input.txt
@@ -1,0 +1,6 @@
+{"Time":"2025-10-23T12:36:35.439236-04:00","Action":"start","Package":"crypto:gofips140"}
+{"Time":"2025-10-23T12:36:35.443492-04:00","Action":"start","Package":"crypto/aes:gofips140"}
+{"Time":"2025-10-23T12:36:35.445535-04:00","Action":"start","Package":"crypto/cipher:gofips140"}
+?   	crypto/internal/boring/bbig	[no test files]
+?   	crypto/internal/boring/sig	[no test files]
+?   	crypto/internal/cryptotest	[no test files]

--- a/misc/cmd/jsonl/testdata/snapshots/dist-issue-76024-rendered.txt
+++ b/misc/cmd/jsonl/testdata/snapshots/dist-issue-76024-rendered.txt
@@ -1,0 +1,6 @@
+?   	crypto/internal/boring/bbig	[no test files]
+?   	crypto/internal/boring/sig	[no test files]
+?   	crypto/internal/cryptotest	[no test files]
+
+jsonl warnings:
+- Non-JSON lines (logged: 3/3)

--- a/misc/cmd/jsonl/testdata/snapshots/lifecycle-actions.txt
+++ b/misc/cmd/jsonl/testdata/snapshots/lifecycle-actions.txt
@@ -1,0 +1,10 @@
+start	example.test/jsonlfixture/lifecycle
+run	TestLifecycle
+run	TestLifecycle/pass
+pass	TestLifecycle/pass
+run	TestLifecycle/skip
+skip	TestLifecycle/skip
+run	TestLifecycle/fail
+fail	TestLifecycle/fail
+fail	TestLifecycle
+fail	example.test/jsonlfixture/lifecycle

--- a/misc/cmd/jsonl/testdata/snapshots/lifecycle-rendered.txt
+++ b/misc/cmd/jsonl/testdata/snapshots/lifecycle-rendered.txt
@@ -1,0 +1,12 @@
+    fixture_test.go:N: fail log
+--- FAIL: TestLifecycle/fail (Xs)
+--- FAIL: TestLifecycle (Xs)
+FAIL
+FAIL	example.test/jsonlfixture/lifecycle	Xs
+
+# go test summary
+FAIL example.test/jsonlfixture/lifecycle TestLifecycle/fail (0.69s)
+FAIL example.test/jsonlfixture/lifecycle TestLifecycle (0.69s)
+FAIL example.test/jsonlfixture/lifecycle (0.690s)
+(1 passed)
+(1 skipped)

--- a/misc/cmd/jsonl/testdata/snapshots/lifecycle.jsonl
+++ b/misc/cmd/jsonl/testdata/snapshots/lifecycle.jsonl
@@ -1,0 +1,23 @@
+{"Action":"start","Package":"example.test/jsonlfixture/lifecycle","Time":"2026-01-02T03:04:05Z"}
+{"Action":"run","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle","Time":"2026-01-02T03:04:06Z"}
+{"Action":"output","Output":"=== RUN   TestLifecycle\n","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle","Time":"2026-01-02T03:04:07Z"}
+{"Action":"run","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/pass","Time":"2026-01-02T03:04:08Z"}
+{"Action":"output","Output":"=== RUN   TestLifecycle/pass\n","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/pass","Time":"2026-01-02T03:04:09Z"}
+{"Action":"output","Output":"    fixture_test.go:N: pass log\n","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/pass","Time":"2026-01-02T03:04:10Z"}
+{"Action":"output","Output":"--- PASS: TestLifecycle/pass (Xs)\n","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/pass","Time":"2026-01-02T03:04:11Z"}
+{"Action":"pass","Elapsed":0.69,"Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/pass","Time":"2026-01-02T03:04:12Z"}
+{"Action":"run","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/skip","Time":"2026-01-02T03:04:13Z"}
+{"Action":"output","Output":"=== RUN   TestLifecycle/skip\n","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/skip","Time":"2026-01-02T03:04:14Z"}
+{"Action":"output","Output":"    fixture_test.go:N: skip log\n","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/skip","Time":"2026-01-02T03:04:15Z"}
+{"Action":"output","Output":"--- SKIP: TestLifecycle/skip (Xs)\n","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/skip","Time":"2026-01-02T03:04:16Z"}
+{"Action":"skip","Elapsed":0.69,"Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/skip","Time":"2026-01-02T03:04:17Z"}
+{"Action":"run","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/fail","Time":"2026-01-02T03:04:18Z"}
+{"Action":"output","Output":"=== RUN   TestLifecycle/fail\n","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/fail","Time":"2026-01-02T03:04:19Z"}
+{"Action":"output","Output":"    fixture_test.go:N: fail log\n","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/fail","Time":"2026-01-02T03:04:20Z"}
+{"Action":"output","Output":"--- FAIL: TestLifecycle/fail (Xs)\n","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/fail","Time":"2026-01-02T03:04:21Z"}
+{"Action":"fail","Elapsed":0.69,"Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle/fail","Time":"2026-01-02T03:04:22Z"}
+{"Action":"output","Output":"--- FAIL: TestLifecycle (Xs)\n","Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle","Time":"2026-01-02T03:04:23Z"}
+{"Action":"fail","Elapsed":0.69,"Package":"example.test/jsonlfixture/lifecycle","Test":"TestLifecycle","Time":"2026-01-02T03:04:24Z"}
+{"Action":"output","Output":"FAIL\n","Package":"example.test/jsonlfixture/lifecycle","Time":"2026-01-02T03:04:25Z"}
+{"Action":"output","Output":"FAIL\texample.test/jsonlfixture/lifecycle\tXs\n","Package":"example.test/jsonlfixture/lifecycle","Time":"2026-01-02T03:04:26Z"}
+{"Action":"fail","Elapsed":0.69,"Package":"example.test/jsonlfixture/lifecycle","Time":"2026-01-02T03:04:27Z"}

--- a/misc/cmd/jsonl/testdata/snapshots/panic-rendered.txt
+++ b/misc/cmd/jsonl/testdata/snapshots/panic-rendered.txt
@@ -1,0 +1,21 @@
+--- FAIL: TestPanic (Xs)
+panic: boom [recovered, repanicked]
+
+goroutine N [running]:
+testing.tRunner.func1.2({0xADDR, 0xADDR})
+	testing.go:N +0xADDR
+testing.tRunner.func1()
+	testing.go:N +0xADDR
+panic({0xADDR, 0xADDR})
+	panic.go:N +0xADDR
+example.test/jsonlfixture/panic.TestPanic(0xADDR)
+	fixture_test.go:N +0xADDR
+testing.tRunner(0xADDR, 0xADDR)
+	testing.go:N +0xADDR
+created by testing.(*T).Run in goroutine N
+	testing.go:N +0xADDR
+FAIL	example.test/jsonlfixture/panic	Xs
+
+# go test summary
+FAIL example.test/jsonlfixture/panic TestPanic (0.69s)
+FAIL example.test/jsonlfixture/panic (0.690s)

--- a/misc/cmd/jsonl/testdata/snapshots/stdio-rendered.txt
+++ b/misc/cmd/jsonl/testdata/snapshots/stdio-rendered.txt
@@ -1,0 +1,4 @@
+ok  	example.test/jsonlfixture/stdio	Xs
+
+# go test summary
+(1 passed)

--- a/misc/cmd/jsonl/testdata/snapshots/synthetic-schema.txt
+++ b/misc/cmd/jsonl/testdata/snapshots/synthetic-schema.txt
@@ -1,0 +1,6 @@
+panic: boom
+
+# go test summary
+FAIL example.test/pkg TestPanic (0.01s)
+FAIL example.test/pkg (0.020s)
+FAIL example.test/dep (0.000s) [build failed: example.test/dep]

--- a/misc/internal/go_test/color.go
+++ b/misc/internal/go_test/color.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package go_test
+
+import (
+	"fmt"
+	"io"
+
+	. "code.kibou.tools/base/core"
+)
+
+// Color is an ANSI text color the renderer can apply to a line.
+type Color int
+
+const (
+	ColorRed Color = iota
+	ColorYellow
+	ColorGreen
+)
+
+const colorReset = "\x1b[0m"
+
+func (c Color) ansi() string {
+	switch c {
+	case ColorRed:
+		return "\x1b[31m"
+	case ColorYellow:
+		return "\x1b[33m"
+	case ColorGreen:
+		return "\x1b[32m"
+	default:
+		return ""
+	}
+}
+
+// Colorizer writes text with an optional color, honoring whether color output
+// is enabled for the destination stream.
+type Colorizer struct {
+	enabled bool
+}
+
+// NewColorizer returns a Colorizer that emits ANSI color codes only when
+// enabled is true.
+func NewColorizer(enabled bool) Colorizer {
+	return Colorizer{enabled: enabled}
+}
+
+func (z Colorizer) Write(w io.Writer, text string, color Option[Color]) error {
+	if c, ok := color.Get(); z.enabled && ok {
+		_, err := fmt.Fprint(w, c.ansi(), text, colorReset)
+		return err
+	}
+	_, err := fmt.Fprint(w, text)
+	return err
+}

--- a/misc/internal/go_test/event.go
+++ b/misc/internal/go_test/event.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package go_test models and renders the JSON records emitted by
+// `go test -json` and `go tool dist test -json`.
+package go_test
+
+// TestEvent is the union of JSON records emitted by go test -json and
+// go tool dist test -json.
+type TestEvent struct {
+	// Time is the RFC3339 timestamp for the event. It is omitted on build-output
+	// and build-fail events. Kept as encoded text because this package does not
+	// do time arithmetic.
+	Time string `json:"Time"`
+
+	// Action identifies the event kind: lifecycle, output, result, or metadata.
+	Action TestAction `json:"Action"`
+	// Package is the import path for the package being tested.
+	Package string `json:"Package"`
+	// Test is the test, example, benchmark, fuzz target, or subtest name, if any.
+	// Subtests use testing's slash-separated full name, such as "TestFoo/bar";
+	// parent and child subtests each get their own lifecycle/result events.
+	Test string `json:"Test"`
+	// Elapsed is the result duration in seconds, set for pass/fail/skip/bench events.
+	Elapsed *float64 `json:"Elapsed"`
+	// Output is stdout/stderr text for output events.
+	Output string `json:"Output"`
+	// OutputType classifies output events as regular, frame, or error output.
+	OutputType TestOutputType `json:"OutputType"`
+	// FailedBuild is the import path whose build failure caused a fail event.
+	FailedBuild string `json:"FailedBuild"`
+	// Key is the attribute key for events emitted on calls to [testing.T.Attr].
+	Key string `json:"Key"`
+	// Value is the attribute value for events emitted on calls to [testing.T.Attr].
+	Value string `json:"Value"`
+	// Path is the artifact directory path for artifacts events. For go test
+	// -artifacts, upstream testing emits an absolute directory under
+	// -outputdir/_artifacts.
+	Path string `json:"Path"`
+	// ImportPath is the package being built, set on build-output and build-fail
+	// events. Unlike Package, build events carry ImportPath rather than Package
+	// (see `go doc cmd/go`); it matches the FailedBuild of the eventual fail.
+	ImportPath string `json:"ImportPath"`
+}
+
+// Event is a shorthand alias for [TestEvent].
+type Event = TestEvent
+
+// TestAction is [TestEvent.Action].
+//
+// In addition to test lifecycle and output records, the supported producers
+// emit attr, artifacts, build-output, and build-fail records.
+type TestAction string
+
+// Action is a shorthand alias for [TestAction].
+type Action = TestAction
+
+const (
+	// Action_Start means the test binary is about to be executed.
+	Action_Start Action = "start"
+	// Action_Run means a test, example, benchmark, or subtest started.
+	Action_Run Action = "run"
+	// Action_Pause means a parallel test paused.
+	Action_Pause Action = "pause"
+	// Action_Cont means a paused parallel test continued running.
+	Action_Cont Action = "cont"
+	// Action_Pass means a test, benchmark, or package passed.
+	Action_Pass Action = "pass"
+	// Action_Bench means a benchmark printed log output but did not fail.
+	Action_Bench Action = "bench"
+	// Action_Fail means a test, benchmark, or package failed.
+	Action_Fail Action = "fail"
+	// Action_Output means Output contains test stdout/stderr text.
+	Action_Output Action = "output"
+	// Action_Skip means a test or package was skipped, or a package had no tests.
+	Action_Skip Action = "skip"
+	// Action_Attr records testing.T.Attr metadata; Key and Value are set.
+	Action_Attr Action = "attr"
+	// Action_Artifacts records testing.T.ArtifactDir metadata; Path is set.
+	Action_Artifacts Action = "artifacts"
+	// Action_BuildOutput carries a portion of the build's output (compiler or vet
+	// diagnostics) on ImportPath when a package fails to build.
+	Action_BuildOutput Action = "build-output"
+	// Action_BuildFail marks that the build for ImportPath failed.
+	Action_BuildFail Action = "build-fail"
+)
+
+func (a TestAction) Known() bool {
+	switch a {
+	case Action_Start, Action_Run, Action_Pause, Action_Cont,
+		Action_Pass, Action_Bench, Action_Fail, Action_Output,
+		Action_Skip, Action_Attr, Action_Artifacts,
+		Action_BuildOutput, Action_BuildFail:
+		return true
+	default:
+		return false
+	}
+}
+
+// TestOutputType classifies Action=output events.
+type TestOutputType string
+
+// OutputType is a shorthand alias for [TestOutputType].
+type OutputType = TestOutputType
+
+const (
+	// OutputType_Regular is ordinary test output.
+	OutputType_Regular OutputType = ""
+	// OutputType_Frame is output synthesized from test framing lines such as
+	// "=== RUN" or "--- FAIL:".
+	OutputType_Frame OutputType = "frame"
+	// OutputType_Error is output produced by Error, Errorf, Fatal, or Fatalf.
+	OutputType_Error OutputType = "error"
+	// OutputType_ErrorContinue continues a multi-line error output event.
+	OutputType_ErrorContinue OutputType = "error-continue"
+)
+
+func (typ TestOutputType) Known() bool {
+	switch typ {
+	case OutputType_Regular, OutputType_Frame, OutputType_Error, OutputType_ErrorContinue:
+		return true
+	default:
+		return false
+	}
+}

--- a/misc/internal/go_test/jsonl.go
+++ b/misc/internal/go_test/jsonl.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package go_test
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+
+	"code.kibou.tools/base/errorx"
+)
+
+// RawOutputMarker is the key added to a normalized JSONL event synthesized
+// from an input line that was not valid JSON.
+const RawOutputMarker = "_raw_output"
+
+type normalizedJSONLWriter struct {
+	writer   *bufio.Writer
+	lastTime string
+	pending  []string
+}
+
+func newNormalizedJSONLWriter(w io.Writer) *normalizedJSONLWriter {
+	if w == io.Discard {
+		return &normalizedJSONLWriter{writer: nil, lastTime: "", pending: nil}
+	}
+	return &normalizedJSONLWriter{writer: bufio.NewWriter(w), lastTime: "", pending: nil}
+}
+
+func (w *normalizedJSONLWriter) recordEvent(line []byte, eventTime string) error {
+	if w.writer == nil {
+		return nil
+	}
+	if w.lastTime == "" && eventTime != "" && len(w.pending) > 0 {
+		for _, raw := range w.pending {
+			if err := w.writeWrapped(raw, eventTime); err != nil {
+				return err
+			}
+		}
+		w.pending = nil
+	}
+	if eventTime != "" {
+		w.lastTime = eventTime
+	}
+	return w.writeLineBytes(line)
+}
+
+func (w *normalizedJSONLWriter) recordRaw(raw []byte) error {
+	if w.writer == nil {
+		return nil
+	}
+	rawString := string(raw)
+	if w.lastTime == "" {
+		w.pending = append(w.pending, rawString)
+		return nil
+	}
+	return w.writeWrapped(rawString, w.lastTime)
+}
+
+func (w *normalizedJSONLWriter) finish() error {
+	if w.writer == nil {
+		return nil
+	}
+	if len(w.pending) > 0 {
+		return errorx.Newf("nostack",
+			"jsonl output: stream produced no timestamped go test event to anchor %d leading output line(s)", len(w.pending))
+	}
+	return nil
+}
+
+func (w *normalizedJSONLWriter) flush() error {
+	if w.writer == nil {
+		return nil
+	}
+	return w.writer.Flush()
+}
+
+func (w *normalizedJSONLWriter) writeWrapped(raw string, eventTime string) error {
+	encoded, err := json.Marshal(map[string]any{
+		"Action":        string(Action_Output),
+		"Time":          eventTime,
+		"Output":        raw + "\n",
+		RawOutputMarker: true,
+	})
+	if err != nil {
+		return errorx.Wrapf("nostack", err, "marshal raw JSONL output")
+	}
+	return w.writeLine(string(encoded))
+}
+
+func (w *normalizedJSONLWriter) writeLine(line string) error {
+	return w.writeLineBytes([]byte(line))
+}
+
+func (w *normalizedJSONLWriter) writeLineBytes(line []byte) error {
+	if _, err := w.writer.Write(line); err != nil {
+		return errorx.Wrapf("nostack", err, "write JSONL output")
+	}
+	if err := w.writer.WriteByte('\n'); err != nil {
+		return errorx.Wrapf("nostack", err, "write JSONL output")
+	}
+	return nil
+}

--- a/misc/internal/go_test/render.go
+++ b/misc/internal/go_test/render.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package go_test
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"strings"
+
+	"code.kibou.tools/base/collections"
+	. "code.kibou.tools/base/core"
+	"code.kibou.tools/base/errorx"
+)
+
+type RenderOutputs struct {
+	Pretty io.Writer
+	JSONL  io.Writer
+}
+
+type Hooks struct {
+	OnNonJSONLine func(lineNumber int, raw []byte, err error) error
+	OnEvent       func(raw []byte, event TestEvent) error
+	BeforeSummary func(w io.Writer) error
+	OnFinish      func() error
+}
+
+func Render(r io.Reader, outputs RenderOutputs, z Colorizer, hooks Hooks) (retErr error) {
+	pretty := bufio.NewWriter(outputs.Pretty)
+	jsonl := newNormalizedJSONLWriter(outputs.JSONL)
+	defer func() {
+		retErr = errorx.Join(retErr, pretty.Flush(), jsonl.flush())
+	}()
+
+	reader := bufio.NewReader(r)
+	sum := summary{results: nil, passed: 0, skipped: 0}
+	renderer := NewPlainTextRenderer(pretty, z)
+	lineNumber := 0
+
+	for {
+		lineBytes, err := reader.ReadBytes('\n')
+		if len(lineBytes) > 0 {
+			lineNumber++
+			if lineBytes[len(lineBytes)-1] == '\n' {
+				lineBytes = lineBytes[:len(lineBytes)-1]
+			}
+			if len(lineBytes) > 0 && lineBytes[len(lineBytes)-1] == '\r' {
+				lineBytes = lineBytes[:len(lineBytes)-1]
+			}
+
+			var event TestEvent
+			if decodeErr := json.Unmarshal(lineBytes, &event); decodeErr != nil {
+				if hookErr := hooks.onNonJSONLine(lineNumber, lineBytes, decodeErr); hookErr != nil {
+					return hookErr
+				}
+				if jsonlErr := jsonl.recordRaw(lineBytes); jsonlErr != nil {
+					return jsonlErr
+				}
+				if _, writeErr := pretty.Write(lineBytes); writeErr != nil {
+					return writeErr
+				}
+				if _, writeErr := io.WriteString(pretty, "\n"); writeErr != nil {
+					return writeErr
+				}
+			} else {
+				if hookErr := hooks.onEvent(lineBytes, event); hookErr != nil {
+					return hookErr
+				}
+				if jsonlErr := jsonl.recordEvent(lineBytes, event.Time); jsonlErr != nil {
+					return jsonlErr
+				}
+				sum.record(event)
+				if renderErr := renderer.Handle(event); renderErr != nil {
+					return renderErr
+				}
+			}
+		}
+		if err == nil {
+			continue
+		}
+		if err == io.EOF {
+			if jsonlErr := jsonl.finish(); jsonlErr != nil {
+				return jsonlErr
+			}
+			if hookErr := hooks.onFinish(); hookErr != nil {
+				return hookErr
+			}
+			if err := renderer.Finish(); err != nil {
+				return err
+			}
+			if hookErr := hooks.beforeSummary(pretty); hookErr != nil {
+				return hookErr
+			}
+			return sum.write(pretty, z)
+		}
+		return errorx.Wrapf("nostack", err, "read go test JSONL")
+	}
+}
+
+func (h Hooks) onNonJSONLine(lineNumber int, raw []byte, err error) error {
+	if h.OnNonJSONLine == nil {
+		return nil
+	}
+	return h.OnNonJSONLine(lineNumber, raw, err)
+}
+
+func (h Hooks) onEvent(raw []byte, event TestEvent) error {
+	if h.OnEvent == nil {
+		return nil
+	}
+	return h.OnEvent(raw, event)
+}
+
+func (h Hooks) beforeSummary(w io.Writer) error {
+	if h.BeforeSummary == nil {
+		return nil
+	}
+	return h.BeforeSummary(w)
+}
+
+func (h Hooks) onFinish() error {
+	if h.OnFinish == nil {
+		return nil
+	}
+	return h.OnFinish()
+}
+
+type PlainTextRenderer struct {
+	writer    io.Writer
+	colorizer Colorizer
+	buffers   collections.OrderedMap[bufKey, []renderLine]
+}
+
+type bufKey struct {
+	pkg  string
+	test string
+}
+
+type renderLine struct {
+	text  string
+	color Option[Color]
+}
+
+func NewPlainTextRenderer(w io.Writer, z Colorizer) *PlainTextRenderer {
+	return &PlainTextRenderer{
+		writer:    w,
+		colorizer: z,
+		buffers:   collections.NewOrderedMap[bufKey, []renderLine](),
+	}
+}
+
+func (tr *PlainTextRenderer) Handle(event TestEvent) error {
+	switch event.Action {
+	case Action_BuildOutput:
+		return tr.colorizer.Write(tr.writer, event.Output, None[Color]())
+	case Action_Output:
+		tr.bufferOutput(event)
+		return nil
+	case Action_Pass, Action_Fail, Action_Skip, Action_Bench:
+		return tr.resolve(event)
+	case Action_Start, Action_Run, Action_Pause, Action_Cont,
+		Action_Attr, Action_Artifacts, Action_BuildFail:
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (tr *PlainTextRenderer) Finish() error {
+	for _, key := range tr.bufferKeys() {
+		if err := tr.dispose(key, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (tr *PlainTextRenderer) bufferOutput(event TestEvent) {
+	key := bufKey{pkg: event.Package, test: event.Test}
+	lines := []renderLine(nil)
+	if existing, ok := tr.buffers.Lookup(key).Get(); ok {
+		lines = existing
+	}
+	color := None[Color]()
+	if event.OutputType == OutputType_Error || event.OutputType == OutputType_ErrorContinue {
+		color = Some(ColorRed)
+	}
+	tr.buffers.InsertOrReplace(key, append(lines, renderLine{text: event.Output, color: color}))
+}
+
+func (tr *PlainTextRenderer) resolve(event TestEvent) error {
+	show := event.Action == Action_Fail || event.Action == Action_Bench
+	if event.Test != "" {
+		return tr.dispose(bufKey{pkg: event.Package, test: event.Test}, show)
+	}
+	for _, key := range tr.bufferKeys() {
+		if key.pkg != event.Package {
+			continue
+		}
+		if err := tr.dispose(key, show || key.test == ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (tr *PlainTextRenderer) bufferKeys() []bufKey {
+	keys := make([]bufKey, 0, tr.buffers.Len())
+	for key := range tr.buffers.Keys() {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func (tr *PlainTextRenderer) dispose(key bufKey, show bool) error {
+	lines, _ := tr.buffers.Delete(key).Get()
+	if !show {
+		return nil
+	}
+	for _, line := range lines {
+		if isHiddenFrame(line.text) {
+			continue
+		}
+		if err := tr.colorizer.Write(tr.writer, line.text, line.color); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isHiddenFrame(text string) bool {
+	t := strings.TrimSuffix(strings.TrimLeft(text, " "), "\n")
+	switch {
+	case strings.HasPrefix(t, "=== RUN"),
+		strings.HasPrefix(t, "=== PAUSE"),
+		strings.HasPrefix(t, "=== CONT"),
+		strings.HasPrefix(t, "=== NAME"),
+		strings.HasPrefix(t, "--- PASS:"),
+		strings.HasPrefix(t, "--- SKIP:"),
+		t == "PASS":
+		return true
+	default:
+		return false
+	}
+}

--- a/misc/internal/go_test/summary.go
+++ b/misc/internal/go_test/summary.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package go_test
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	. "code.kibou.tools/base/core"
+)
+
+// summary collects the failures (and a skip count) seen across the stream and
+// prints a "# go test summary" block at the end.
+type summary struct {
+	results []failure
+	passed  int
+	skipped int
+}
+
+func (s *summary) record(event TestEvent) {
+	switch event.Action {
+	case Action_Fail:
+		s.results = append(s.results, failure{
+			Action:      event.Action,
+			Package:     event.Package,
+			Test:        event.Test,
+			Elapsed:     event.Elapsed,
+			FailedBuild: event.FailedBuild,
+		})
+	case Action_Pass:
+		// event.Test is not set for package-level entries.
+		if event.Test != "" {
+			s.passed++
+		}
+	case Action_Skip:
+		// Count only test-level skips. Package-level skips ("no test files")
+		// are not actionable and, across a std-library run, would otherwise
+		// drown the failures they sit beside.
+		if event.Test != "" {
+			s.skipped++
+		}
+	case Action_Start, Action_Run, Action_Pause, Action_Cont,
+		Action_Bench, Action_Output, Action_Attr,
+		Action_Artifacts, Action_BuildOutput, Action_BuildFail:
+	default:
+	}
+}
+
+func (s *summary) write(w io.Writer, z Colorizer) error {
+	if len(s.results) == 0 && s.passed == 0 && s.skipped == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "# go test summary"); err != nil {
+		return err
+	}
+	for _, result := range s.results {
+		if err := z.Write(w, result.line(), Some(ColorRed)); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+	if s.passed > 0 {
+		if err := z.Write(w, fmt.Sprintf("(%d passed)", s.passed), Some(ColorGreen)); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+	if s.skipped > 0 {
+		if err := z.Write(w, fmt.Sprintf("(%d skipped)", s.skipped), Some(ColorYellow)); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// failure is one failure recorded for the summary.
+type failure struct {
+	Action      TestAction
+	Package     string
+	Test        string
+	Elapsed     *float64
+	FailedBuild string
+}
+
+func (r failure) line() string {
+	status := strings.ToUpper(string(r.Action))
+	if r.Test != "" {
+		return fmt.Sprintf("%s %s %s (%s)", status, r.Package, r.Test, formatElapsed(r.Elapsed, 2))
+	}
+	line := fmt.Sprintf("%s %s (%s)", status, r.Package, formatElapsed(r.Elapsed, 3))
+	if r.FailedBuild != "" {
+		line += " [build failed: " + r.FailedBuild + "]"
+	}
+	return line
+}
+
+func formatElapsed(elapsed *float64, precision int) string {
+	if elapsed == nil {
+		return "?s"
+	}
+	return fmt.Sprintf("%.*fs", precision, *elapsed)
+}


### PR DESCRIPTION
Adds a new misc/cmd/jsonl tool which can be used
to convert the output of `go test -json` to a more
normalized JSONL format.
