### PR TITLE
feat(base): Add limited.Counter type for limiting operations

### DIFF
--- a/base/core/limited/counter.go
+++ b/base/core/limited/counter.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package limited
+
+import (
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/core/op"
+)
+
+// Counter is a simple single-threaded counter value
+// which starts returning op.NoGo after the [Counter.Limit]
+// is hit.
+type Counter[U uint8 | uint16 | uint32 | uint64] struct {
+	limit U
+	hits  U
+}
+
+// NewCounter creates a new counter with the given limit.
+//
+// The limit cannot be modified after counter creation.
+func NewCounter[U uint8 | uint16 | uint32 | uint64](limit U) Counter[U] {
+	return Counter[U]{limit, 0}
+}
+
+// Inc increments the counter and returns whether it's
+// OK to do the operation guarded by this counter.
+//
+// Precondition: Inc must not be called more times
+// than the maximum value of the type U. In other words,
+// the counter panics on overflow.
+func (c *Counter[U]) Inc() op.Next {
+	c.hits++
+	if c.hits == 0 {
+		assert.Preconditionf(false, "counter of type %T incremented %d times", c.hits, c.hits-1)
+	}
+	if c.hits <= c.limit {
+		return op.KeepGoing
+	}
+	return op.NoGo
+}
+
+// Dropped returns the number of operations that were skipped.
+func (c *Counter[U]) Dropped() U {
+	if c.hits <= c.limit {
+		return 0
+	}
+	return c.hits - c.limit
+}
+
+// Hits returns the number of times the counter was incremented.
+func (c *Counter[U]) Hits() U {
+	return c.hits
+}
+
+// Limit returns the limit stored inside the counter.
+func (c *Counter[U]) Limit() U {
+	return c.limit
+}

--- a/base/core/limited/counter_test.go
+++ b/base/core/limited/counter_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package limited_test
+
+import (
+	"math"
+	"testing"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/check"
+	"code.kibou.tools/base/core/limited"
+	"code.kibou.tools/base/core/op"
+)
+
+func TestCounter(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	counter := limited.NewCounter[uint8](2)
+	h.Assertf(counter.Inc() == op.KeepGoing, "first hit should be allowed")
+	h.Assertf(counter.Inc() == op.KeepGoing, "second hit should be allowed")
+	h.Assertf(counter.Inc() == op.NoGo, "third hit should be dropped")
+	h.Assertf(counter.Hits() == 3, "hits should be 3")
+	h.Assertf(counter.Dropped() == 1, "dropped should be 1")
+
+	for i := uint16(counter.Hits()); i < math.MaxUint8; i++ {
+		counter.Inc()
+	}
+	h.AssertPanicsWith(assert.AssertionError{
+		Fmt:  "precondition violation: counter of type %T incremented %d times",
+		Args: []any{uint8(0), uint8(255)},
+	}, func() {
+		counter.Inc()
+	})
+}

--- a/base/core/op/op.go
+++ b/base/core/op/op.go
@@ -38,3 +38,15 @@ func (s PlatformSupport) IsSupported() bool {
 func (s PlatformSupport) IsUnsupported() bool {
 	return !bool(s)
 }
+
+// Next indicates what to do next for a caller.
+type Next bool
+
+const (
+	// KeepGoing indicates that the caller should proceed
+	// with the operation it was attempting to do.
+	KeepGoing Next = true
+	// NoGo indicates that the caller should not proceed
+	// with the operation it was attempting to do.
+	NoGo Next = false
+)


### PR DESCRIPTION
This has a corresponding op.KeepGoing/op.NoGo for
greater readability at usage sites.
