### PR TITLE
refactor(go/cmd/dist): Speed up make.bash by parallelizing steps

### DIFF
--- a/docs/explanations/Bootstrapping.djot
+++ b/docs/explanations/Bootstrapping.djot
@@ -1,0 +1,202 @@
+:::
+references:
+  packages:
+    - cmd/dist
+:::
+
+# The Bootstrapping Process for the Go toolchain
+
+This document describes how the Go toolchain is bootstrapped.
+The corresponding code is in [cmd/dist/boostrap.go](/go/src/cmd/dist/boostrap.go).
+
+This doc is meant to describe both the original upstream
+process and the changes we've made to it.
+
+## Prerequisites
+
+First read the [Build Caching docs][build-caching] to make
+sure you have a good understanding of action IDs, content IDs
+and build IDs.
+This page uses some of the same notation to explain things.
+
+## Terminology
+
+- (Distributable) _Toolchain_: An archive or set of directories
+  consisting of:
+
+  - Low-level binaries such as `cmd/compile` (the gc compiler),
+    `cmd/link` etc. (see [dist.toolsIncludedInDistpack]{.sym}
+    for the full list).[^>not-all-cmd-bins]
+  - High-level binaries (meant to be invoked directly by users)
+    such as `cmd/go` (the compiler driver) and `cmd/gofmt`.
+  - The source code for the standard library and the runtime.
+  - Headers with C and assembly - These are used by the
+    assembly code in the runtime, and by CGO-generated code.
+  - (Optional) A VERSION file describing the toolchain version.
+
+- _Seed toolchain_: The minimal set of low-level binaries
+  required to compile Go code. As of July 2026, the list
+  consists of `cmd/compile`, `cmd/asm`, `cmd/cgo`, `cmd/link`
+  and `cmd/preprofile`. (see [dist.toolchain]{.sym} for
+  the up-to-date list).
+
+  Depending on the compiler toolchain (gccgo or gc),
+  the codegen toolchain will be different,
+  but the driver is shared.
+
+- `go_bootstrap`: A slimmed down version of `cmd/go`,
+  with reduced features based on the build tag `cmd_go_bootstrap`.
+
+  This acts as the compiler driver for several build phases.
+- _Baseline toolchain_: The distributable toolchain used to kick-start
+  the build process. This must generally be within 2 major
+  versions of the tree itself (i.e. 1.27-devel needs 1.25+).
+
+  In `cmd/dist`, this is also called the "bootstrap toolchain",
+  and it is placed under `GOROOT_BOOSTRAP`, but I've chosen
+  to avoid that term here since "bootstrap" is easily confused
+  with `go_bootstrap`.
+
+[^>not-all-cmd-bins]: Not all binaries in `cmd/` are part of this list.
+For example, `cmd/pprof` and `cmd/addr2line` are currently not built
+for distribution. Instead, they are compiled from source on first use.
+
+Confusingly, the term "toolchain" too is overloaded in the source code
+and docs. In `cmd/dist`, "toolchain" generally means "seed toolchain"
+not "distributable toolchain". For the sake of this document,
+we'll use "toolchain" to consistently mean "distributable toolchain"
+and specify "seed toolchain" where it applies.
+
+## Assumptions
+
+The baseline toolchain is assumed to have correct
+caching behavior, as well as no miscompiles affecting
+the build itself.
+
+The source tree is assumed to not have bugs leading
+to non-deterministic compilation contents.
+
+Standard assumptions about the filesystem being correct,
+not have other concurrent writes etc. also apply.
+
+## Goals
+
+The goal of the bootstrapping process is to start from
+a baseline Go toolchain[^>bootstrap-toolchain-confusion],
+and to produce a new Go toolchain
+corresponding to the source tree that is up-to-date.
+
+By up-to-date, we mean that a full build T followed
+by `$GOROOT=$T_DIR $T_DIR/bin/go install t`
+for any of the tools in T should not lead to rebuilds.
+
+### No rebuilds needs build ID convergence
+
+Consider that tool `T.t` has a build ID of the
+form `a_link/a_compile(t.a)/c_compile(t.a)/c_link`.[^>notation-confusion]
+Let's denote the prior toolchain which built T as P.
+Here, `a_link` will take `P.link`'s tool ID into account,
+and `a_compile(t.a)` will take `P.compile`'s tool ID into account.[^>other-toolIDs]
+
+[^>notation-confusion]: If you don't understand this notation,
+please read the [Build Caching docs][build-caching] first.
+
+[^>other-toolIDs]: Depending on the pipeline, other tool IDs may also be involved here.
+
+Let's say we were to trigger a build of a separate toolchain Z using T.
+The "no rebuilds" condition means that we must get
+cache hits for `a_link` and `a_compile`, which in
+turn means that we need `T.link.toolID == P.link.toolID`
+and `T.compile.toolID == P.compile.toolID`.
+
+So the convergence of tool ID convergence is necessary
+but not sufficient to ensure no-rebuilds. We also
+need to make sure that the rest of the environment
+is identical.
+
+### The cross-compilation complication
+
+Earlier in the doc, we defined up-to-date as:
+
+> By up-to-date, we mean that a full build T followed
+> by `$GOROOT=$T_DIR $T_DIR/bin/go install t`
+> for any of the tools in T should not lead to rebuilds.
+
+However, if the final toolchain T is for a target platform
+distinct from the host platform, this check cannot be
+run without using an emulator.
+
+So for the cross-compilation case, the final staleness
+check has to be done relative to the prior host toolchain P.
+However, this staleness check doesn't really buy much,
+because when T is copied over to a target machine,
+then the tools will be considered out-of-date
+when a "should this be rebuilt" check is done using T.
+
+## The actual bootstrapping flow
+
+When the upstream toolchain is built,
+the flow looks like: ([source code](https://github.com/golang/go/blob/master/src/cmd/dist/build.go#:~:text=cmdbootstrap))
+
+|Step | Toolchain | Build Driver | Produces | Other info |
+|---:|:---|:--|:---|:---|
+| 1 | Baseline | Baseline `cmd/go` | Seed toolchain 1 (Host) | |
+| 2 | Seed toolchain 1 | `cmd/dist` | `go_bootstrap` | |
+| 3 | Seed toolchain 1 | `go_bootstrap` | Seed toolchain 2 (Host) | No PGO |
+| 4 | Seed toolchain 2 | `go_bootstrap` | Seed toolchain 3 (Host) | With PGO |
+| 5 | Seed toolchain 3 | `go_bootstrap` | Stdlib (Target) | |
+| 6 | Seed toolchain 3 | `go_bootstrap`  | Full toolchain (Target) | |
+
+This is entirely serial as a pipeline. If we ignore build IDs, building stdlib
+or the full toolchain with seed toolchain 2 and 3 should lead to identical
+contents (assuming no non-determinism bugs in the compiler).
+
+Upstream code currently has the contract that the final stdlib and
+full toolchain are up-to-date relative to seed toolchain 3.
+To maintain the same contract when the stdlib and full toolchain
+are built by seed toolchain 2, we need to ensure that the tool IDs
+for seed toolchain 2 are identical to the tool IDs
+for seed toolchain 3. There are four cases here:
+
+1. Non-cross compilation × development build: In this case,
+   tool ID = content IDs for the tools. For the content IDs
+   to be equal, we need to turn on PGO for seed toolchain 2's build.
+2. Non-cross compilation × release build: In this case,
+   tool ID = Go version, so it will be equal for all of
+   seed toolchains 1, 2, and 3.
+3. Cross-compilation: Here, we can't assert convergence
+   of the stdlib or target-native full toolchain relative to itself,
+   and asserting convergence relative to seed toolchain 3
+   is not useful, because the tools will still appear outdated
+   from the POV of the target-native full toolchain anyway.
+
+So we make the following changes:
+
+| Step | Toolchain | Build Driver | Produces | Other info |
+|---:|:---|:--|:---|:---|
+| 1 | Baseline | Baseline `cmd/go` | Seed toolchain 1 | |
+| 2 | Seed toolchain 1 | `cmd/dist` | `go_bootstrap` | |
+| 3 | Seed toolchain 1 | `go_bootstrap` | Seed toolchain 2 (Host) | With PGO |
+| 4 | Seed toolchain 2 | `go_bootstrap` | Seed toolchain 3 (Target) | With PGO |
+| 4 | Seed toolchain 2 | `go_bootstrap` | Stdlib (Target) | |
+| 4 | Seed toolchain 2 | `go_bootstrap` | Non-seed tools (Target) | |
+| 4 | Seed toolchain 2 | `go_bootstrap` | cmd/go (Host) | |
+
+Few points worth noting:
+
+- For the cross-compilation case, this essentially avoids
+  a whole toolchain build: only `cmd/go` is needed.
+  (That too could be removed, at the cost of some more
+  complexity and fewer checks. See code comments for details.)
+- For the non-cross-compilation case, we have to be careful
+  to write the seed toolchain 3 to a separate directory
+  to avoid writing to paths where the binary is being used
+  to compile the stdlib and non-seed tools.
+
+After step 4, like upstream, we can check that the stdlib
+and the various non-seed tools are up-to-date relative to:
+
+- Seed toolchain 3's cmd/go (for the non-cross compilation case)
+- Host cmd/go (for the cross-compilation case)
+
+[build-caching]: ./build-caching

--- a/go/src/cmd/dist/build.go
+++ b/go/src/cmd/dist/build.go
@@ -50,9 +50,9 @@ var (
 	goexperiment     string
 	gofips140        string
 	workdir          string
+	// The directory GOROOT/pkg/tool/GOOS_GOARCH
+	// for the host platform.
 	tooldir          string
-	oldgoos          string
-	oldgoarch        string
 	oldgocache       string
 	exe              string
 	defaultcc        map[string]string
@@ -1509,8 +1509,8 @@ func cmdbootstrap() {
 	}
 
 	// For the main bootstrap, building for host os/arch.
-	oldgoos = goos
-	oldgoarch = goarch
+	oldgoos := goos
+	oldgoarch := goarch
 	goos = gohostos
 	goarch = gohostarch
 	os.Setenv("GOHOSTARCH", gohostarch)
@@ -1560,46 +1560,56 @@ func cmdbootstrap() {
 	os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
 	// Now that cmd/go is in charge of the build process, enable GOEXPERIMENT.
 	os.Setenv("GOEXPERIMENT", goexperiment)
-	// No need to enable PGO for toolchain2.
-	goInstall(toolenv(), goBootstrap, append([]string{"-pgo=off"}, toolchain...)...)
+	// NOTE(kibou): Upstream disables PGO here using -pgo=off. We keep PGO turned
+	// on, because:
+	//
+	// 1. Below, we want to build std+cmd using toolchain2, not toolchain3,
+	//    to unlock more parallelism in the build graph.
+	// 2. The build performs a check that the cache has no stale entries for
+	//    std+cmd based on toolchain3's build ID.
+	// 3. If toolchain3 is built with PGO and toolchain2 isn't, then they
+	//    end up having separate build IDs.
+	goInstall(toolenv(), goBootstrap, toolchain...)
 	if debug {
 		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
 		copyfile(pathf("%s/compile2", tooldir), pathf("%s/compile", tooldir), writeExec)
 	}
 
-	// Toolchain2 should be semantically equivalent to toolchain1,
-	// but it was built using the newly built compiler instead of the Go bootstrap compiler,
-	// so it should at the least run faster. Also, toolchain1 had no build IDs
-	// in the binaries, while toolchain2 does. In non-release builds, the
-	// toolchain's build IDs feed into constructing the build IDs of built targets,
-	// so in non-release builds, everything now looks out-of-date due to
-	// toolchain2 having build IDs - that is, due to the go command seeing
-	// that there are new compilers. In release builds, the toolchain's reported
-	// version is used in place of the build ID, and the go command does not
-	// see that change from toolchain1 to toolchain2, so in release builds,
-	// nothing looks out of date.
-	// To keep the behavior the same in both non-release and release builds,
-	// we force-install everything here.
+	// NOTE(kibou): toolchain2 should be semantically equivalent to toolchain1.
+	// Additionally, it should have the build IDs
 	//
-	//	toolchain3 = mk(new toolchain, toolchain2, go_bootstrap)
+	// - In release builds, the tool IDs for toolchain2 will report
+	//   something like `compile version go1.27.0`. So they've already
+	//   converged/further rebuilds don't buy anything.
+	// - In development builds, the tool IDs will report the content ID for
+	//   the binary. So if we recompile a new toolchain3 with the same set of
+	//   flags:
+	//   - The content IDs for toolchain3 binaries should be the same as toolchain2
+	//     (same flags, same toolchain source).
+	//   - The action IDs for toolchain3 binaries will be different because
+	//     toolchain3's actionIDs will take toolchain2's tool IDs into account,
+	//     toolchain2's actionIDs will take toolchain1's tool IDs into account.
 	//
-	timelog("build", "toolchain3")
+	// For consistency between release and development builds, build a separate
+	// toolchain3 using toolchain2.
+	timelog("build", "toolchain3+std+cmd")
 	if vflag > 0 {
 		xprintf("\n")
 	}
-	xprintf("Building Go toolchain3 using go_bootstrap and Go toolchain2.\n")
-	goInstall(toolenv(), goBootstrap, append([]string{"-a"}, toolchain...)...)
-	if debug {
-		run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
-		copyfile(pathf("%s/compile3", tooldir), pathf("%s/compile", tooldir), writeExec)
+	isCrossCompiling := goos != oldgoos || goarch != oldgoarch
+	if isCrossCompiling {
+		goos = oldgoos
+		goarch = oldgoarch
+		os.Setenv("GOOS", goos)
+		os.Setenv("GOARCH", goarch)
+		os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
 	}
+	xprintf("Building Go toolchain3+std+cmd for %s/%s using go_bootstrap and Go toolchain2.\n",
+		goos, goarch)
 
-	// Now that toolchain3 has been built from scratch, its compiler and linker
-	// should have accurate build IDs suitable for caching.
-	// Now prime the build cache with the rest of the standard library for
-	// testing, and so that the user can run 'go install std cmd' to quickly
-	// iterate on local changes without waiting for a full rebuild.
-	if _, err := os.Stat(pathf("%s/VERSION", goroot)); err == nil {
+	if _, err := os.Stat(pathf("%s/VERSION", goroot)); os.IsNotExist(err) {
+		os.Setenv("GOCACHE", oldgocache)
+	} else if err == nil {
 		// If we have a VERSION file, then we use the Go version
 		// instead of build IDs as a cache key, and there is no guarantee
 		// that code hasn't changed since the last time we ran a build
@@ -1607,42 +1617,76 @@ func cmdbootstrap() {
 		// on a release branch). We must not fall back to the shared build cache
 		// in this case. Leave $GOCACHE alone.
 	} else {
-		os.Setenv("GOCACHE", oldgocache)
+		fatalf("error on accessing %s/VERSION: %v", goroot, err)
 	}
 
-	if goos == oldgoos && goarch == oldgoarch {
-		// Common case - not setting up for cross-compilation.
-		timelog("build", "toolchain")
-		if vflag > 0 {
-			xprintf("\n")
-		}
-		xprintf("Building packages and commands for %s/%s.\n", goos, goarch)
-	} else {
-		// GOOS/GOARCH does not match GOHOSTOS/GOHOSTARCH.
-		// Finish GOHOSTOS/GOHOSTARCH installation and then
-		// run GOOS/GOARCH installation.
-		timelog("build", "host toolchain")
-		if vflag > 0 {
-			xprintf("\n")
-		}
-		xprintf("Building commands for host, %s/%s.\n", goos, goarch)
-		goInstall(toolenv(), goBootstrap, toolsToInstall...)
-		checkNotStale(toolenv(), goBootstrap, toolsToInstall...)
-		checkNotStale(toolenv(), gorootBinGo, toolsToInstall...)
-
-		timelog("build", "target toolchain")
-		if vflag > 0 {
-			xprintf("\n")
-		}
-		goos = oldgoos
-		goarch = oldgoarch
-		os.Setenv("GOOS", goos)
-		os.Setenv("GOARCH", goarch)
-		os.Setenv("CC", compilerEnvLookup("CC", defaultcc, goos, goarch))
-		xprintf("Building packages and commands for target, %s/%s.\n", goos, goarch)
+	var wg sync.WaitGroup
+	var toolchain3TmpDir string
+	defer func() { os.RemoveAll(toolchain3TmpDir) }()
+	if isCrossCompiling {
+		wg.Go(func() {
+			// HACK: Also build cmd/go for the host anyway because:
+			//
+			// 1. clean.bash expects bin/go to be present.
+			// 2. We have some sanity checks below for staleness similar to
+			//    upstream. Upstream builds the full toolchain for the host,
+			//    but technically only cmd/go is needed.
+			hostToolEnv := append(toolenv(),
+				fmt.Sprintf("GOOS=%s", gohostos),
+				fmt.Sprintf("GOARCH=%s", gohostarch),
+				fmt.Sprintf("CC=%s", compilerEnvLookup("CC", defaultcc, gohostos, gohostarch)))
+			goInstall(hostToolEnv, goBootstrap, "cmd/go")
+		})
 	}
-	goInstall(nil, goBootstrap, "std")
-	goInstall(toolenv(), goBootstrap, toolsToInstall...)
+	wg.Go(func() {
+		// When toolchain3 is compiled for the host, if we did goInstall,
+		// that would lead to this goroutine overwriting binaries in use
+		// by other goroutines.
+		//
+		// For simplicity, always write the binaries to a separate directory.
+		toolchain3TmpDir, err = os.MkdirTemp(tooldir, "toolchain3")
+		if err != nil {
+			fatalf("error creating tempdir: %v", err)
+		}
+		goCmd(toolenv(), goBootstrap, "build",
+			append([]string{"-o", toolchain3TmpDir + "/", "-a"}, toolchain...)...)
+	})
+	wg.Go(func() {
+		goInstall(nil, goBootstrap, "std")
+	})
+	wg.Go(func() {
+		var nonSeedTools []string
+		for _, t := range toolsToInstall {
+			if !slices.Contains(toolchain, t) {
+				nonSeedTools = append(nonSeedTools, t)
+			}
+		}
+		goInstall(toolenv(), goBootstrap, nonSeedTools...)
+	})
+	wg.Wait()
+	for _, t := range toolchain {
+		name := filepath.Base(t) + exe
+		tmpBinPath := pathf("%s/%s", toolchain3TmpDir, name)
+		var finalBinPath string
+		if isCrossCompiling {
+			finalBinPath = pathf("%s/pkg/tool/%s_%s/%s", goroot, goos, goarch, name)
+		} else { // tooldir only applies for the host
+			finalBinPath = pathf("%s/%s", tooldir, name)
+		}
+		if err := os.Rename(tmpBinPath, finalBinPath); err != nil {
+			fatalf("when copying back toolchain binary from %s to %s: %v", tmpBinPath, finalBinPath, err)
+		}
+	}
+
+	if debug {
+		if !isCrossCompiling {
+			run("", ShowOutput|CheckExit, pathf("%s/compile", tooldir), "-V=full")
+		}
+		copyfile(pathf("%s/compile3", tooldir), pathf("%s/compile", tooldir), writeExec)
+	}
+
+	// NOTE(kibou): This line is technically redundant with the toolsToInstall
+	// one below, as the latter is a superset of toolchain.
 	checkNotStale(toolenv(), goBootstrap, toolchain...)
 	checkNotStale(nil, goBootstrap, "std")
 	checkNotStale(toolenv(), goBootstrap, toolsToInstall...)

--- a/go/src/cmd/dist/buildtool.go
+++ b/go/src/cmd/dist/buildtool.go
@@ -59,6 +59,7 @@ var bootstrapDirs = []string{
 	"cmd/internal/telemetry/counter",
 	"cmd/link",
 	"cmd/link/internal/...",
+	"cmd/preprofile",
 	"compress/flate",
 	"compress/zlib",
 	"container/heap",

--- a/go/src/cmd/go/internal/work/buildid.go
+++ b/go/src/cmd/go/internal/work/buildid.go
@@ -23,6 +23,7 @@ import (
 	"cmd/internal/telemetry/counter"
 )
 
+// NOTE(id: buildID-official-docs):
 // Build IDs
 //
 // Go packages and binaries are stamped with build IDs that record both

--- a/misc/cmd/kido/benchmark.go
+++ b/misc/cmd/kido/benchmark.go
@@ -1,0 +1,238 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"maps"
+	"runtime"
+	"slices"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/cmdx"
+	. "code.kibou.tools/base/core"
+	"code.kibou.tools/base/core/pathx"
+	"code.kibou.tools/base/envx"
+	"code.kibou.tools/base/errorx"
+	"code.kibou.tools/base/fsx"
+	"code.kibou.tools/base/logx"
+	"code.kibou.tools/base/timex"
+)
+
+type BenchmarkName string
+
+const (
+	Benchmark_MakeBash BenchmarkName = "make.bash"
+)
+
+func AllBenchmarks() []BenchmarkName {
+	return []BenchmarkName{Benchmark_MakeBash}
+}
+
+func (b BenchmarkName) DefaultIters() int {
+	switch b {
+	case Benchmark_MakeBash:
+		return 1
+	default:
+		return assert.PanicUnknownCase[int](b)
+	}
+}
+
+type VCS string
+
+const (
+	JJ  VCS = "jj"
+	Git VCS = "git"
+)
+
+type RevSet struct {
+	VCS  VCS
+	Spec string
+}
+
+func NewRevSet(vcs VCS, spec string) RevSet {
+	assert.Precondition(spec != "", "spec must be non-empty")
+	switch vcs {
+	case JJ, Git:
+		return RevSet{vcs, spec}
+	default:
+		return assert.PanicUnknownCase[RevSet](vcs)
+	}
+}
+
+type BenchmarkOptions struct {
+	// None => automatic selection
+	Iters    Option[int]
+	Config   BenchmarkConfig
+	Baseline Option[RevSet]
+}
+
+type BenchmarkSetup struct {
+	Root  pathx.RelPath
+	Label string
+}
+
+func (ws *Workspace) Benchmark(logCtx logx.LogCtx, clock timex.MonotonicClock, out io.Writer, options BenchmarkOptions) error {
+	setups := []BenchmarkSetup{}
+	if baseline, ok := options.Baseline.Get(); ok {
+		tempDir, err := ws.FS.MkdirTemp(pathx.MustParseRelPath(".cache"), "benchmark-wt")
+		if err != nil {
+			return err
+		}
+		defer func() { _ = ws.FS.RemoveAll(tempDir) }()
+		// Create new workspace or worktree + defer the cleanup
+		switch baseline.VCS {
+		case JJ:
+			err := runJJ(logCtx, ws.Runner, ws.FS.Root(), "workspace", "add",
+				"--revision", baseline.Spec, "--name", "benchmark-baseline", tempDir.String())
+			if err != nil {
+				return err
+			}
+			defer func() {
+				_ = runJJ(logCtx, ws.Runner, ws.FS.Root(), "workspace", "forget", "benchmark-baseline")
+			}()
+		case Git:
+			err := runGit(logCtx, ws.Runner, ws.FS.Root(), "worktree", "add", tempDir.String(), baseline.Spec)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				_ = runGit(logCtx, ws.Runner, ws.FS.Root(), "worktree", "remove", tempDir.String())
+			}()
+		}
+
+		setups = append(setups, BenchmarkSetup{tempDir, "baseline"})
+	}
+	setups = append(setups, BenchmarkSetup{pathx.Dot(), "latest"})
+
+	_, _ = fmt.Fprintf(out, "Benchmarking %v\n", string(options.Config.Name()))
+	for _, setup := range setups {
+		iters := options.Iters.ValueOr(options.Config.Name().DefaultIters())
+		for i := 1; i <= iters; i++ {
+			cacheDir, err := ws.FS.MkdirTemp(pathx.MustParseRelPath(".cache"), "gocache")
+			if err != nil {
+				return err
+			}
+			err = func() error {
+				defer func() { _ = ws.FS.RemoveAll(cacheDir) }()
+				duration, err := options.Config.Run(logCtx, ws, cacheDir, setup.Root, clock)
+				if err != nil {
+					return err
+				}
+				_, _ = fmt.Fprintf(out, "%v (iter = %d): t = %v\n", setup.Label, i, duration)
+				return nil
+			}()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+type BenchmarkConfig interface {
+	Add(key string, value string) error
+	Run(_ cmdx.RunCtx, _ *Workspace, cacheDir, root pathx.RelPath, _ timex.MonotonicClock) (timex.Duration, error)
+	Name() BenchmarkName
+}
+
+func NewBenchmarkConfig(name BenchmarkName) BenchmarkConfig {
+	switch name {
+	case Benchmark_MakeBash:
+		return &MakeBashBenchmark{TargetGOOS: runtime.GOOS, TargetGOARCH: runtime.GOARCH}
+	default:
+		return assert.PanicUnknownCase[BenchmarkConfig](name)
+	}
+}
+
+type MakeBashBenchmark struct {
+	TargetGOOS   string
+	TargetGOARCH string
+}
+
+func (m *MakeBashBenchmark) Add(key string, value string) error {
+	allowedOSes := []string{"linux", "darwin", "windows"}
+	allowedArchs := []string{"amd64", "arm64"}
+	allowedKeys := map[string]Pair[[]string, *string]{
+		"TARGET_GOOS":   NewPair(allowedOSes, &m.TargetGOOS),
+		"TARGET_GOARCH": NewPair(allowedArchs, &m.TargetGOARCH),
+	}
+	if want, ok := allowedKeys[key]; ok {
+		if slices.Contains(want.First, value) {
+			*want.Second = value
+			return nil
+		}
+		return errorx.Newf("nostack", "unsupported value for %s: %s (expected one of %v)", key, value, allowedOSes)
+	}
+	return errorx.Newf("nostack", "unsupported key: %s (expected one of %v)",
+		key, slices.Sorted(maps.Keys(allowedKeys)))
+}
+
+func (m *MakeBashBenchmark) Name() BenchmarkName {
+	return Benchmark_MakeBash
+}
+
+func (m *MakeBashBenchmark) Run(
+	ctx cmdx.RunCtx,
+	ws *Workspace,
+	cacheDir pathx.RelPath,
+	root pathx.RelPath,
+	clock timex.MonotonicClock,
+) (timex.Duration, error) {
+	ext := ".bash"
+	if runtime.GOOS == "windows" {
+		ext = ".bat"
+	}
+	fs := ws.FS
+	runner := ws.Runner
+	srcDir := fs.Root().Join(root).Join(pathx.MustParseRelPath("go/src"))
+
+	statOptions := fsx.StatOptions{FollowFinalSymlink: false, OnErrorTraverseParents: true}
+	if _, err := fs.Stat(root.Join(pathx.MustParseRelPath("go/bin/go")), statOptions); err == nil {
+		output, err := runner.Run(ctx, cmdx.New("./clean"+ext).In(srcDir), commandOpts())
+		ctx.Debug("clean output", "stdout", output.Stdout, "stderr", output.Stderr)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	opts := commandOpts()
+	opts.TransformEnv = func(env envx.Env) envx.Env {
+		env, _ = env.InsertOrReplace("GOOS", m.TargetGOOS)
+		env, _ = env.InsertOrReplace("GOARCH", m.TargetGOARCH)
+		env, _ = env.InsertOrReplace("GOCACHE", fs.Root().Join(cacheDir).String())
+		return env
+	}
+	start := clock.GetInstant()
+	output, err := runner.Run(ctx, cmdx.New("./make"+ext).In(srcDir), opts)
+	elapsed := clock.GetInstant().Sub(start)
+	ctx.Debug("make output", "stdout", output.Stdout, "stderr", output.Stderr)
+	if err != nil {
+		return 0, err
+	}
+
+	return elapsed, nil
+}
+
+func runJJ(ctx cmdx.RunCtx, runner cmdx.BaseRunner, dir pathx.AbsPath, args ...string) error {
+	output, err := runner.Run(ctx,
+		cmdx.New(append([]string{"jj"}, args...)...).In(dir),
+		commandOpts())
+	ctx.Debug("jj output", "stdout", output.Stdout, "stderr", output.Stderr)
+	return err
+}
+
+func runGit(ctx cmdx.RunCtx, runner cmdx.BaseRunner, dir pathx.AbsPath, args ...string) error {
+	output, err := runner.Run(ctx,
+		cmdx.New(append([]string{"git"}, args...)...).In(dir),
+		commandOpts())
+	ctx.Debug("git output", "stdout", output.Stdout, "stderr", output.Stderr)
+	return err
+}
+
+func commandOpts() cmdx.RunOptions {
+	return cmdx.RunOptionsDefault().WithCaptureStdout().WithCaptureStderr()
+}

--- a/misc/cmd/kido/main.go
+++ b/misc/cmd/kido/main.go
@@ -160,6 +160,89 @@ func main() {
 					return ws.List(logger, os.Stdout, ListOptions{Type: type_, Provenance: provenance})
 				},
 			},
+			{
+				Name:  "benchmark",
+				Usage: "Run some benchmark for the workspace",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name: "name", Required: true,
+						Usage: "Possible values: make.bash",
+					},
+					&cli.IntFlag{
+						Name: "iters", Required: false,
+						Usage: "Number of iterations. 0 implies automatic selection.",
+					},
+					&cli.StringSliceFlag{
+						Name: "config", Required: false,
+						Usage: "Benchmark specific config option as key=value (repeatable).",
+					},
+					&cli.StringFlag{
+						Name: "baseline-rev", Required: false,
+						Usage: "jj:<revset> or git:<sha>",
+					},
+				},
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					ws, err := getWorkspace()
+					if err != nil {
+						return err
+					}
+					var name BenchmarkName
+					switch cmd.String("name") {
+					case "make.bash":
+						name = "make.bash"
+					default:
+						return errorx.Newf("nostack",
+							"unknown --name %q, want one of %v", cmd.String("name"),
+							AllBenchmarks())
+					}
+					var iters Option[int]
+					if cmd.IsSet("iters") {
+						val := cmd.Int("iters")
+						if val < 0 {
+							return errorx.Newf("nostack", "negative --iters %d, wanted value >= 0", val)
+						}
+						if val > 0 {
+							iters = Some(val)
+						}
+					}
+					config := NewBenchmarkConfig(name)
+					for _, kv := range cmd.StringSlice("config") {
+						before, after, ok := strings.Cut(kv, "=")
+						if !ok {
+							return errorx.Newf("nostack", "invalid --config %q; missing = separator", kv)
+						}
+						if before == "" {
+							return errorx.Newf("nostack", "invalid --config %q; missing key before =", kv)
+						}
+						if after == "" {
+							return errorx.Newf("nostack", "invalid --config %q; missing value after =", kv)
+						}
+						if err := config.Add(before, after); err != nil {
+							return err
+						}
+					}
+					var baseline Option[RevSet]
+					if cmd.IsSet("baseline-rev") {
+						val := cmd.String("baseline-rev")
+						before, after, ok := strings.Cut(val, ":")
+						if !ok {
+							return errorx.Newf("nostack", "invalid --baseline-rev %q; missing : separator", val)
+						}
+						if before != "jj" && before != "git" {
+							return errorx.Newf("nostack", "invalid --baseline-rev %q; expected jj: or git: prefix", val)
+						}
+						if after == "" {
+							return errorx.Newf("nostack", "invalid --baseline-rev %q; missing rev spec after :", val)
+						}
+						baseline = Some(NewRevSet(VCS(before), after))
+					}
+					tok, cancel := withTimeout(cancel.Never(), 10*timex.Minute, cmd.Name)
+					defer cancel()
+					logCtx := logx.NewLogCtx(tok, logger)
+					clock := syscaps.MonotonicClock()
+					return ws.Benchmark(logCtx, clock, os.Stdout, BenchmarkOptions{iters, config, baseline})
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
This patch introduces a few different things:

1. Hopefully clearer documentation about the bootstrapping process,
   because the code (while heavily commented in places) felt quite
   hard to understand because of lack of docs about the intended
   design, the dependencies between different stages (were they
   deliberate or implicit), heavy use of global variables and os.Setenv,
   and lack of doc comments on said global variables.

   This covers both the upstream bootstrapping flow and our flow.

   Part of the confusion is due to the non-standard use of the
   word "toolchain" to actually mean what the new docs call the
   "seed toolchain".

2. A more parallel flow when building the final seed toolchain,
   stdlib and non-seed tools (e.g. cmd/go, cmd/vet, which are not
   needed to build the seed toolchain itself).

3. A benchmarking subcommand for kido for measuring the performance
   improvement. On a 16 core Ryzen 5950X, I see make.bash
   wall time go from (with cold GOCACHE):

   - Host compilation: 1m22s before vs 1m2s (-25%).
   - Cross compilation for arm64 macOS: 1m42s before vs 1m5s after (-36%).
