### PR TITLE
chore(ci): Bump Go version to 1.26.x for toolchain & lint jobs

### DIFF
--- a/.github/actions/build-toolchain/action.yml
+++ b/.github/actions/build-toolchain/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
         # setup-go does caching by default, and issues a warning due to being
         # unable to locate a 'go.sum' for this build. Since we manage caching explicitly,
         # disable setup-go's automatic caching.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -135,7 +135,7 @@ jobs:
           version: 1.25.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           # setup-go cache warns when GOCACHE is customized; we manage caching explicitly.
           cache: false
       - name: Run golangci-lint
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         if: matrix.go-toolchain == 'stable'
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           # setup-go cache warns when GOCACHE is customized; we manage caching explicitly.
           # See https://github.com/kibou-tools/kibou/actions/runs/20907489161/job/60063662688
           cache: false

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: false
 
       - name: Configure git identity

--- a/delve/pkg/proc/core/core_test.go
+++ b/delve/pkg/proc/core/core_test.go
@@ -507,8 +507,18 @@ func procdump(t *testing.T, exePath string) string {
 	exeDir := filepath.Dir(exePath)
 	cmd := exec.Command("procdump64", "-accepteula", "-ma", "-n", "1", "-s", "3", "-x", exeDir, exePath, "quit")
 	out, err := cmd.CombinedOutput() // procdump exits with non-zero status on success, so we have to ignore the error here
-	if !strings.Contains(string(out), "Dump count reached.") {
-		t.Fatalf("possible error running procdump64, output: %q, error: %v", string(out), err)
+	// NOTE(kibou): The Procdump release on July 9, 2026 seems to have
+	// changed the output byte encoding to UTF-16LE instead of UTF-8,
+	// causing a failure in this logic in CI. Sysinternals doesn't seem
+	// to allow downloading older releases of binaries, so try decoding
+	// the output both ways. 😮‍💨
+	want := "Dump count reached."
+	wantUTF16LE := make([]byte, 0, len(want)*2)
+	for i := 0; i < len(want); i++ {
+		wantUTF16LE = append(wantUTF16LE, want[i], 0)
+	}
+	if !bytes.Contains(out, []byte(want)) && !bytes.Contains(out, wantUTF16LE) {
+		t.Fatalf("possible error running procdump64, output: %q, error: %v", out, err)
 	}
 
 	fis, err := os.ReadDir(exeDir)

--- a/delve/pkg/proc/stepping_test.go
+++ b/delve/pkg/proc/stepping_test.go
@@ -1123,7 +1123,7 @@ func TestRangeOverFuncNext(t *testing.T) {
 		// depends on the toolchain version used to compile the
 		// fixtures, not the toolchain version used to compile
 		// delve's own test packages.
-		if goversion.ProducerAfterOrEqual(p.BinInfo().Producer(), 1, 26) && !goversion.ProducerAfterOrEqual(p.BinInfo().Producer(), 1, 28) && runtime.GOARCH == "arm64" {
+		if goversion.ProducerAfterOrEqual(p.BinInfo().Producer(), 1, 27) && !goversion.ProducerAfterOrEqual(p.BinInfo().Producer(), 1, 28) && runtime.GOARCH == "arm64" {
 			t.Run("TestGotoA1", func(t *testing.T) {
 				testseq2intl(t, fixture, grp, p, nil, []seqTest{
 					funcBreak(t, "main.TestGotoA1"),


### PR DESCRIPTION
gotip requires Go 1.26 or higher to build, so let's
bump that toolchain version. For consistency, bumping
the versions in all other places as well.

One of the lower commits fixes Delve CI.

~~Trying both of these together to fix both CI issues,
because just fixing one doesn't seem to work.~~
Switching to Go 1.26 uncovered a bug in the Delve tests,
where a test was wrong for the Go 1.26 release,
but it was correct for an earlier part of the dev
cycle.

