### PR TITLE
feat(base): Add new package for WTF-8 encoding

### DIFF
--- a/base/internal/unicode_impl/unicode.go
+++ b/base/internal/unicode_impl/unicode.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package unicode_impl contains shared implementation details for Unicode
+// encodings used by sibling packages.
+package unicode_impl
+
+import (
+	"strconv"
+	"strings"
+
+	"code.kibou.tools/base/ranges"
+)
+
+// IsContinuationByte reports whether b is a UTF-8 continuation byte.
+func IsContinuationByte(b byte) bool {
+	return 0x80 <= b && b <= 0xbf
+}
+
+// InvalidBytesPrefix copies the bytes covered by span into a fixed-size value.
+//
+// Precondition: span is within s and span.Length() is at most four.
+func InvalidBytesPrefix(s string, span ranges.Span[int]) [4]byte {
+	var prefix [4]byte
+	copy(prefix[:], s[span.Start():span.End()])
+	return prefix
+}
+
+// FormatTextParseError formats the first invalid byte span for an encoding.
+//
+// Precondition: span.Length() is within [1, 4], and invalidBytes contains the
+// bytes covered by span at its beginning.
+func FormatTextParseError(encodingName string, span ranges.Span[int], invalidBytes [4]byte) string {
+	length := span.Length().Unwrap()
+
+	var b strings.Builder
+	b.Grow(len("invalid ") + len(encodingName) + len(" bytes 0x") + 2*4 + len(" at byte span [") + 19 + len(", ") + 19 + len(")"))
+	b.WriteString("invalid ")
+	b.WriteString(encodingName)
+	if length == 1 {
+		b.WriteString(" byte 0x")
+		writeInvalidBytesHex(&b, invalidBytes, 1)
+		b.WriteString(" at byte offset ")
+		writeInt(&b, span.Start())
+		return b.String()
+	}
+
+	b.WriteString(" bytes 0x")
+	writeInvalidBytesHex(&b, invalidBytes, length)
+	b.WriteString(" at byte span [")
+	writeInt(&b, span.Start())
+	b.WriteString(", ")
+	writeInt(&b, span.End())
+	b.WriteByte(')')
+	return b.String()
+}
+
+// Precondition: length is within [0, len(bytes)].
+func writeInvalidBytesHex(b *strings.Builder, bytes [4]byte, length int) {
+	const uppercaseHexDigits = "0123456789ABCDEF"
+	for i := range length {
+		value := bytes[i]
+		b.WriteByte(uppercaseHexDigits[value>>4])
+		b.WriteByte(uppercaseHexDigits[value&0x0f])
+	}
+}
+
+func writeInt(b *strings.Builder, n int) {
+	var buf [20]byte
+	b.Write(strconv.AppendInt(buf[:0], int64(n), 10))
+}

--- a/base/utf8/text.go
+++ b/base/utf8/text.go
@@ -5,12 +5,11 @@
 package utf8
 
 import (
-	"strconv"
-	"strings"
 	stdutf8 "unicode/utf8"
 
 	"code.kibou.tools/base/assert"
 	. "code.kibou.tools/base/core/option"
+	"code.kibou.tools/base/internal/unicode_impl"
 	"code.kibou.tools/base/ranges"
 )
 
@@ -34,7 +33,7 @@ func (t Text) GetByte(i int) byte {
 // ParseText validates s as UTF-8 text.
 func ParseText(s string) (Text, *TextParseError) {
 	if span, ok := firstInvalidSpan(s).Get(); ok {
-		firstInvalidBytes := invalidBytesPrefix(s, span)
+		firstInvalidBytes := unicode_impl.InvalidBytesPrefix(s, span)
 		length := span.Length().Unwrap()
 		return Text{}, NewTextParseError(len(s), span, firstInvalidBytes[:length])
 	}
@@ -145,49 +144,5 @@ func (e *TextParseError) FirstInvalidSpan() ranges.Span[int] {
 }
 
 func (e *TextParseError) Error() string {
-	span := e.firstInvalidSpan
-	length := span.Length().Unwrap()
-
-	var b strings.Builder
-	b.Grow(maxTextParseErrorStringLen)
-	if length == 1 {
-		b.WriteString("invalid UTF-8 byte 0x")
-		writeInvalidBytesHex(&b, e.firstInvalidBytes, 1)
-		b.WriteString(" at byte offset ")
-		writeInt(&b, span.Start())
-		return b.String()
-	}
-
-	b.WriteString("invalid UTF-8 bytes ")
-	b.WriteString("0x")
-	writeInvalidBytesHex(&b, e.firstInvalidBytes, length)
-	b.WriteString(" at byte span [")
-	writeInt(&b, span.Start())
-	b.WriteString(", ")
-	writeInt(&b, span.End())
-	b.WriteByte(')')
-	return b.String()
-}
-
-const maxTextParseErrorStringLen = len("invalid UTF-8 bytes 0x") + 2*4 + len(" at byte span [") + 19 + len(", ") + 19 + len(")")
-
-func invalidBytesPrefix(s string, span ranges.Span[int]) [4]byte {
-	var prefix [4]byte
-	copy(prefix[:], s[span.Start():span.End()])
-	return prefix
-}
-
-// Precondition: length ∈ [0, len(bytes)].
-func writeInvalidBytesHex(b *strings.Builder, bytes [4]byte, length int) {
-	const hexDigits = "0123456789ABCDEF"
-	for i := range length {
-		value := bytes[i]
-		b.WriteByte(hexDigits[value>>4])
-		b.WriteByte(hexDigits[value&0x0f])
-	}
-}
-
-func writeInt(b *strings.Builder, n int) {
-	var buf [20]byte
-	b.Write(strconv.AppendInt(buf[:0], int64(n), 10))
+	return unicode_impl.FormatTextParseError("UTF-8", e.firstInvalidSpan, e.firstInvalidBytes)
 }

--- a/base/utf8/utf8.go
+++ b/base/utf8/utf8.go
@@ -10,6 +10,7 @@ import (
 
 	"code.kibou.tools/base/assert"
 	. "code.kibou.tools/base/core/option"
+	"code.kibou.tools/base/internal/unicode_impl"
 	"code.kibou.tools/base/ranges"
 )
 
@@ -122,7 +123,7 @@ func invalidUTF8SpanAt(text string, start int) ranges.Span[int] {
 	if len(text) <= start+2 {
 		return ranges.NewSpan(start, len(text))
 	}
-	if !isContinuationByte(text[start+2]) {
+	if !unicode_impl.IsContinuationByte(text[start+2]) {
 		return ranges.NewSpan(start, start+3)
 	}
 	if width == 3 {
@@ -132,7 +133,7 @@ func invalidUTF8SpanAt(text string, start int) ranges.Span[int] {
 	if len(text) <= start+3 {
 		return ranges.NewSpan(start, len(text))
 	}
-	if !isContinuationByte(text[start+3]) {
+	if !unicode_impl.IsContinuationByte(text[start+3]) {
 		return ranges.NewSpan(start, start+4)
 	}
 	assert.Invariant(false, "DecodeRuneInString reported invalid UTF-8 for a complete four-byte encoding")
@@ -176,10 +177,4 @@ func utf8LeadByteInfo(b byte) (width int, secondMin byte, secondMax byte, ok boo
 	default:
 		return 0, 0, 0, false
 	}
-}
-
-// isContinuationByte implements the UTF8-tail check described in
-// the doc comment for utf8LeadByteInfo.
-func isContinuationByte(b byte) bool {
-	return 0x80 <= b && b <= 0xbf
 }

--- a/base/wtf8/text.go
+++ b/base/wtf8/text.go
@@ -1,0 +1,389 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+// Package wtf8 provides support for WTF-8 encoded strings.
+//
+// From [the specification](https://wtf-8.codeberg.page/):
+//
+// > WTF-8 (Wobbly Transformation Format − 8-bit) is a superset of UTF-8
+// > that encodes surrogate code points if they are not in a pair.
+// > It represents, in a way compatible with UTF-8, text from systems
+// > such as JavaScript and Windows that use UTF-16 internally
+// > but don’t enforce the well-formedness invariant that surrogates
+// > must be paired.
+//
+// The data types in this package are meant to be used within a program,
+// and not across serialization boundaries.
+package wtf8
+
+import (
+	"fmt"
+	"strings"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/internal/unicode_impl"
+	"code.kibou.tools/base/ranges"
+	"code.kibou.tools/base/utf8"
+)
+
+// Text is a string known to contain valid WTF-8.
+//
+// WTF-8 has the following representation:
+//
+//   - Any valid UTF-8 is also valid WTF-8.
+//   - Since UTF-8 does not use surrogate code points,
+//     WTF-8 provides a 3-byte form for surrogates,
+//     to allow losslessly representing unpaired surrogates.
+//
+// The presence of a high surrogate followed by a low surrogate
+// in encoded form (i.e. 6 consecutive bytes) is forbidden.
+// Since the pairing already corresponds to a dedicated
+// code point in UTF-8, represented using 4 bytes, the
+// 4 byte representation is used.
+type Text struct {
+	text string
+}
+
+var _ fmt.Formatter = Text{text: ""}
+
+// FromUTF8 converts valid UTF-8 text to WTF-8.
+//
+// This is total and allocation-free: UTF-8 is a subset of WTF-8, so no
+// validation or re-encoding is required.
+func FromUTF8(t utf8.Text) Text {
+	return Text{text: t.String()}
+}
+
+// ParseText parses the input as WTF-8 encoded text.
+//
+// CAUTION: In most cases, you shouldn't need to use this function
+// directly. It is primarily meant for internal use in the base
+// libraries, to convert paths obtained from the Go standard
+// library (which uses WTF-8 on Windows) to a specific
+// type which correctly encodes the relevant guarantees.
+func ParseText(s string) (Text, *TextParseError) {
+	previousWasHighSurrogate := false
+	for i := 0; i < len(s); {
+		r, size, ok := decodeFirstWTF8Rune(s[i:])
+		if !ok {
+			// Include up to three immediately following continuation bytes.
+			end := i + 1
+			for end < len(s) && end < i+4 && unicode_impl.IsContinuationByte(s[end]) {
+				end++
+			}
+			return Text{}, newTextParseErrorAt(s, i, end)
+		}
+		if size == 3 { // unlikely branch; separate out
+			if previousWasHighSurrogate && isLowSurrogate(r) {
+				return Text{}, newTextParseErrorAt(s, i, i+size)
+			}
+			previousWasHighSurrogate = isHighSurrogate(r)
+		} else {
+			previousWasHighSurrogate = false
+		}
+		i += size
+	}
+	return Text{text: s}, nil
+}
+
+// MustParseText validates s as WTF-8 text and panics if validation fails.
+func MustParseText(s string) Text {
+	text, err := ParseText(s)
+	if err != nil {
+		assert.Preconditionf(false, "%v", err)
+	}
+	return text
+}
+
+// Len returns the byte length of t.
+func (t Text) Len() int {
+	return len(t.text)
+}
+
+// GetByte gets the i-th byte for this Text value.
+//
+// Precondition: 0 <= i < t.Len().
+func (t Text) GetByte(i int) byte {
+	return t.text[i]
+}
+
+// Slice returns a subslice of t by byte offsets.
+//
+// Precondition: start and end are WTF-8 code point boundaries and
+// 0 <= start <= end <= t.Len().
+func (t Text) Slice(start, end int) Text {
+	if start < 0 || end < start || len(t.text) < end ||
+		(start < len(t.text) && unicode_impl.IsContinuationByte(t.text[start])) ||
+		(end < len(t.text) && unicode_impl.IsContinuationByte(t.text[end])) {
+		assert.Preconditionf(false, "invalid WTF-8 slice [%d, %d) for text of length %d", start, end, len(t.text))
+	}
+	return Text{text: t.text[start:end]}
+}
+
+// String returns the underlying valid WTF-8 string.
+//
+// NOTE: Generally, this method shouldn't need to be used outside of tests.
+func (t Text) String() string {
+	return t.text
+}
+
+// Format implements fmt.Formatter. For %v, unpaired surrogates are rendered as
+// visible \u escapes; other verbs format the underlying WTF-8 bytes directly.
+func (t Text) Format(state fmt.State, verb rune) {
+	if verb != 'v' || state.Flag('#') {
+		_, _ = fmt.Fprintf(state, fmt.FormatString(state, verb), t.text)
+		return
+	}
+
+	const lowerHexDigits = "0123456789abcdef"
+	var result strings.Builder
+	escaped := false
+	start := 0
+	for i := 0; i < len(t.text); {
+		r, size, ok := decodeFirstWTF8Rune(t.text[i:])
+		assert.Invariant(ok, "wtf8.Text contains invalid WTF-8")
+		if isHighSurrogate(r) || isLowSurrogate(r) {
+			if !escaped {
+				result.Grow(len(t.text))
+			}
+			escaped = true
+			result.WriteString(t.text[start:i])
+			result.WriteString(`\u`)
+			result.WriteByte(lowerHexDigits[(r>>12)&0xf])
+			result.WriteByte(lowerHexDigits[(r>>8)&0xf])
+			result.WriteByte(lowerHexDigits[(r>>4)&0xf])
+			result.WriteByte(lowerHexDigits[r&0xf])
+			start = i + size
+		}
+		i += size
+	}
+	if !escaped {
+		_, _ = fmt.Fprintf(state, fmt.FormatString(state, verb), t.text)
+		return
+	}
+	result.WriteString(t.text[start:])
+	_, _ = fmt.Fprintf(state, fmt.FormatString(state, 's'), result.String())
+}
+
+// TextBuilder incrementally assembles a Text. The zero value is ready to use.
+type TextBuilder struct {
+	buf []byte
+}
+
+// NewTextBuilder returns a TextBuilder with space preallocated for capacity
+// bytes. Writing more than capacity bytes still works; the buffer grows.
+func NewTextBuilder(capacity int) TextBuilder {
+	return TextBuilder{buf: make([]byte, 0, capacity)}
+}
+
+// WriteText appends t.
+//
+// This follows the concatenation algorithm in
+// https://wtf-8.codeberg.page/#concatenating.
+func (b *TextBuilder) WriteText(t Text) {
+	left := b.buf
+	right := t.text
+	if right == "" {
+		return
+	}
+	// From https://wtf-8.codeberg.page/#concatenating:
+	//
+	// > To concatenate two WTF-8 strings, run these steps:
+	// >
+	// > 1. If the left input string ends with a [high] surrogate byte sequence and the right input string starts with a [low] surrogate byte sequence, run these substeps:
+	// >    - Let [high] and [low] be two code points, the respective results of decoding from WTF-8 these two surrogate byte sequences.
+	// >    - Let supplementary be the encoding to WTF-8 of a single code point of value 0x10000 + (([high] - 0xd800) << 10) + ([low] - 0xdc00)
+	// >    - Let left be substring of the left input string that removes the three final bytes.
+	// >    - Let right be substring of the right input string that removes the three initial bytes.
+	// >    - Return the concatenation of left, supplementary, and right.
+	// > 2. Otherwise, return the concatenation of the two input byte sequences
+	//
+	// A high surrogate is always the 3-byte sequence 0xed 0xa0-0xaf 0x80-0xbf,
+	// and 0xed can only start a 3-byte sequence, so the final three bytes are the
+	// last code point whenever the buffer ends in 0xed.
+	if n := len(left); n >= 3 && left[n-3] == 0xed {
+		high := decodeThreeByteRune(left[n-3], left[n-2], left[n-1])
+		// right is non-empty valid WTF-8 because it comes from a Text.
+		low, lowSize, ok := decodeFirstWTF8Rune(right)
+		assert.Invariant(ok, "TextBuilder.WriteText input contains invalid WTF-8")
+		if isHighSurrogate(high) && isLowSurrogate(low) {
+			supplementary := 0x10000 + (high-0xd800)<<10 + (low - 0xdc00)
+			left = append(left[:n-3],
+				byte(0xf0|supplementary>>18),
+				byte(0x80|(supplementary>>12)&0x3f),
+				byte(0x80|(supplementary>>6)&0x3f),
+				byte(0x80|supplementary&0x3f),
+			)
+			right = right[lowSize:]
+		}
+	}
+	b.buf = append(left, right...)
+}
+
+// WriteASCIIByte appends a single ASCII byte.
+//
+// Precondition: c < 0x80. An ASCII byte is valid WTF-8 on its own and cannot be
+// part of a surrogate, so it needs no boundary handling.
+func (b *TextBuilder) WriteASCIIByte(c byte) {
+	if 0x80 <= c {
+		assert.Preconditionf(false, "wtf8.TextBuilder.WriteASCIIByte: 0x%02x is not ASCII", c)
+	}
+	b.buf = append(b.buf, c)
+}
+
+// Text returns the accumulated Text.
+func (b *TextBuilder) Text() Text {
+	return Text{text: string(b.buf)}
+}
+
+// TextParseError reports invalid WTF-8 found while parsing a Text.
+type TextParseError struct {
+	// firstInvalidSpan is the first non-empty byte span at which WTF-8 parsing
+	// fails, after a valid WTF-8 prefix of the input. Length() ∈ [1, 4].
+	firstInvalidSpan ranges.Span[int]
+	// firstInvalidBytes stores the first firstInvalidSpan.Length() bytes from
+	// firstInvalidSpan. Remaining entries are zero and ignored.
+	firstInvalidBytes [4]byte
+}
+
+// FirstInvalidSpan returns the first span of consecutive invalid WTF-8 bytes.
+func (e *TextParseError) FirstInvalidSpan() ranges.Span[int] {
+	return e.firstInvalidSpan
+}
+
+func (e *TextParseError) Error() string {
+	return unicode_impl.FormatTextParseError("WTF-8", e.firstInvalidSpan, e.firstInvalidBytes)
+}
+
+// decodeFirstWTF8Rune decodes one generalized UTF-8 code point.
+//
+// The return values are:
+//   - (r, size, true) if s starts with a well-formed generalized UTF-8
+//     sequence; r is the decoded code point, which may be a surrogate, and
+//     size is in [1, 4].
+//   - (0, 0, false) if s starts with an ill-formed or incomplete sequence.
+//
+// The accepted byte sequences are defined by the table in
+// https://wtf-8.codeberg.page/#generalized-utf-8.
+//
+// Precondition: s is non-empty.
+func decodeFirstWTF8Rune(s string) (rune, int, bool) {
+	// See "Table 3. Well-formed byte sequences representing a single code point"
+	// in the link above for the implementation.
+	b0 := s[0]
+	// For a code point in [U+0000, U+007f], b0 ∈ [00, 7f].
+	if b0 < 0x80 {
+		return rune(b0), 1, true
+	}
+	// For a code point in [U+0080, U+07ff], b0 ∈ [c2, df] and b1 ∈ [80, bf].
+	if 0xc2 <= b0 && b0 <= 0xdf {
+		if len(s) < 2 || !unicode_impl.IsContinuationByte(s[1]) {
+			return 0, 0, false
+		}
+		return decodeTwoByteRune(s[0], s[1]), 2, true
+	}
+	// For a code point in [U+0800, U+0fff], b0 = e0, b1 ∈ [a0, bf], and b2 ∈ [80, bf].
+	if b0 == 0xe0 {
+		if len(s) < 3 || s[1] < 0xa0 || 0xbf < s[1] || !unicode_impl.IsContinuationByte(s[2]) {
+			return 0, 0, false
+		}
+		return decodeThreeByteRune(s[0], s[1], s[2]), 3, true
+	}
+	// For a code point in [U+1000, U+ffff], b0 ∈ [e1, ef] and b1, b2 ∈ [80, bf].
+	// Unlike UTF-8, generalized UTF-8 allows b1 ∈ [0xa0, 0xbf] when
+	// b0 = 0xed. This admits high and low surrogate code points.
+	if 0xe1 <= b0 && b0 <= 0xef {
+		if len(s) < 3 || !unicode_impl.IsContinuationByte(s[1]) || !unicode_impl.IsContinuationByte(s[2]) {
+			return 0, 0, false
+		}
+		return decodeThreeByteRune(s[0], s[1], s[2]), 3, true
+	}
+	// For a code point in [U+10000, U+3ffff], b0 = f0, b1 ∈ [90, bf], and b2, b3 ∈ [80, bf].
+	if b0 == 0xf0 {
+		if len(s) < 4 || s[1] < 0x90 || 0xbf < s[1] || !unicode_impl.IsContinuationByte(s[2]) || !unicode_impl.IsContinuationByte(s[3]) {
+			return 0, 0, false
+		}
+		return decodeFourByteRune(s[0], s[1], s[2], s[3]), 4, true
+	}
+	// For a code point in [U+40000, U+fffff], b0 ∈ [f1, f3] and b1, b2, b3 ∈ [80, bf].
+	if 0xf1 <= b0 && b0 <= 0xf3 {
+		if len(s) < 4 || !unicode_impl.IsContinuationByte(s[1]) || !unicode_impl.IsContinuationByte(s[2]) || !unicode_impl.IsContinuationByte(s[3]) {
+			return 0, 0, false
+		}
+		return decodeFourByteRune(s[0], s[1], s[2], s[3]), 4, true
+	}
+	// For a code point in [U+100000, U+10ffff], b0 = f4, b1 ∈ [80, 8f], and b2, b3 ∈ [80, bf].
+	if b0 == 0xf4 {
+		if len(s) < 4 || s[1] < 0x80 || 0x8f < s[1] || !unicode_impl.IsContinuationByte(s[2]) || !unicode_impl.IsContinuationByte(s[3]) {
+			return 0, 0, false
+		}
+		return decodeFourByteRune(s[0], s[1], s[2], s[3]), 4, true
+	}
+	// No other first byte begins a well-formed generalized UTF-8 sequence.
+	return 0, 0, false
+}
+
+// decodeTwoByteRune decodes a well-formed two-byte generalized UTF-8 sequence.
+//
+// Precondition: b0 ∈ [0xc2, 0xdf] and b1 ∈ [0x80, 0xbf].
+//
+// From https://wtf-8.codeberg.page/#decoding-wtf-8:
+//
+// > [Return] a code point of value
+// > ((B & 0x1f) << 6) + (B2 & 0x3f).
+func decodeTwoByteRune(b0, b1 byte) rune {
+	return rune(b0&0x1f)<<6 + rune(b1&0x3f)
+}
+
+// decodeThreeByteRune decodes a well-formed three-byte generalized UTF-8 sequence.
+//
+// Precondition: b0 ∈ [0xe0, 0xef], b1 and b2 are in [0x80, 0xbf], and
+// b1 ∈ [0xa0, 0xbf] when b0 = 0xe0.
+//
+// From https://wtf-8.codeberg.page/#decoding-wtf-8:
+//
+// > [Return] a code point of value
+// > ((B & 0x0f) << 12) + ((B2 & 0x3f) << 6) + (B3 & 0x3f).
+func decodeThreeByteRune(b0, b1, b2 byte) rune {
+	return rune(b0&0x0f)<<12 + rune(b1&0x3f)<<6 + rune(b2&0x3f)
+}
+
+// decodeFourByteRune decodes a well-formed four-byte generalized UTF-8 sequence.
+//
+// Precondition: b0 ∈ [0xf0, 0xf4] and b1, b2, and b3 are in [0x80, 0xbf].
+// Additionally, b1 ∈ [0x90, 0xbf] when b0 = 0xf0, and b1 ∈ [0x80, 0x8f]
+// when b0 = 0xf4.
+//
+// From https://wtf-8.codeberg.page/#decoding-wtf-8:
+//
+// > [Return] a code point of value ((B & 0x07) << 18) +
+// > ((B2 & 0x3f) << 12) + ((B3 & 0x3f) << 6) + (B4 & 0x3f).
+func decodeFourByteRune(b0, b1, b2, b3 byte) rune {
+	return rune(b0&0x07)<<18 + rune(b1&0x3f)<<12 + rune(b2&0x3f)<<6 + rune(b3&0x3f)
+}
+
+// From https://wtf-8.codeberg.page/#surrogates-code-points
+//
+// > A lead surrogate code point or high surrogate code point
+// > is a code point in the range from U+D800 to U+DBFF.
+func isHighSurrogate(r rune) bool {
+	return 0xd800 <= r && r <= 0xdbff
+}
+
+// From https://wtf-8.codeberg.page/#surrogates-code-points
+//
+// > A trail surrogate code point or low surrogate code point
+// > is a code point in the range from U+DC00 to U+DFFF.
+func isLowSurrogate(r rune) bool {
+	return 0xdc00 <= r && r <= 0xdfff
+}
+
+// Precondition: 0 <= start < end <= len(s).
+func newTextParseErrorAt(s string, start, end int) *TextParseError {
+	span := ranges.NewSpan(start, end)
+	return &TextParseError{
+		firstInvalidSpan:  span,
+		firstInvalidBytes: unicode_impl.InvalidBytesPrefix(s, span),
+	}
+}

--- a/base/wtf8/text_test.go
+++ b/base/wtf8/text_test.go
@@ -1,0 +1,431 @@
+// Copyright 2026 Varun Gandhi
+//
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+package wtf8_test
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+	"unicode/utf16"
+	stdutf8 "unicode/utf8"
+
+	"pgregory.net/rapid"
+
+	"code.kibou.tools/base/assert"
+	"code.kibou.tools/base/check"
+	baseutf8 "code.kibou.tools/base/utf8"
+	"code.kibou.tools/base/wtf8"
+)
+
+func TestFromUTF8(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	input := baseutf8.MustParseText("aé😀")
+	got := wtf8.FromUTF8(input)
+	check.AssertSame(h, input.String(), got.String(), "converted text")
+}
+
+func TestParseText(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("unit", testParseTextUnit)
+	h.Run("property", func(h check.Harness) {
+		h.Run("valid input", testParseTextValidProperty)
+		h.Run("invalid input", testParseTextInvalidProperty)
+	})
+}
+
+func testParseTextUnit(h check.Harness) {
+	h.Parallel()
+
+	validCases := [][]byte{
+		{},
+		[]byte("aé😀"),
+		{0xc2, 0x80},
+		{0xe0, 0xa0, 0x80},
+		{0xe1, 0x80, 0x80},
+		{0xed, 0xa0, 0x80}, // lone high surrogate
+		{0xed, 0xb0, 0x80}, // lone low surrogate
+		{0xed, 0xa0, 0x80, 'x', 0xed, 0xb0, 0x80},
+		{0xf0, 0x90, 0x80, 0x80},
+		{0xf1, 0x80, 0x80, 0x80},
+		{0xf4, 0x80, 0x80, 0x80},
+	}
+	for _, bytes := range validCases {
+		got, err := wtf8.ParseText(string(bytes))
+		h.Assertf(err == nil, "ParseText(% x) returned error: %v", bytes, err)
+		check.AssertSame(h, string(bytes), got.String(), "parsed text")
+	}
+
+	invalidCases := []struct {
+		bytes   []byte
+		start   int
+		end     int
+		message string
+	}{
+		{
+			bytes:   []byte{0xff},
+			start:   0,
+			end:     1,
+			message: "invalid WTF-8 byte 0xFF at byte offset 0",
+		},
+		{
+			bytes:   []byte{0xc2, 'A'},
+			start:   0,
+			end:     1,
+			message: "invalid WTF-8 byte 0xC2 at byte offset 0",
+		},
+		{
+			bytes:   []byte{0xe2, 0x82},
+			start:   0,
+			end:     2,
+			message: "invalid WTF-8 bytes 0xE282 at byte span [0, 2)",
+		},
+		{
+			// A surrogate pair must use the ordinary four-byte UTF-8 encoding
+			// rather than two three-byte surrogate encodings.
+			bytes:   []byte{0xed, 0xa0, 0x80, 0xed, 0xb0, 0x80},
+			start:   3,
+			end:     6,
+			message: "invalid WTF-8 bytes 0xEDB080 at byte span [3, 6)",
+		},
+	}
+	for _, tc := range invalidCases {
+		_, err := wtf8.ParseText(string(tc.bytes))
+		h.Assertf(err != nil, "ParseText(% x) succeeded unexpectedly", tc.bytes)
+		span := err.FirstInvalidSpan()
+		check.AssertSame(h, tc.start, span.Start(), "invalid span start")
+		check.AssertSame(h, tc.end, span.End(), "invalid span end")
+		check.AssertSame(h, tc.message, err.Error(), "error message")
+	}
+}
+
+func testParseTextValidProperty(h check.Harness) {
+	h.Parallel()
+
+	gen := validWTF8BytesGen()
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		bytes := gen.Draw(t, "bytes")
+
+		got, err := wtf8.ParseText(string(bytes))
+		h.Assertf(err == nil, "ParseText(% x) returned error: %v", bytes, err)
+		check.AssertSame(h, string(bytes), got.String(), "parsed text")
+	})
+}
+
+func testParseTextInvalidProperty(h check.Harness) {
+	h.Parallel()
+
+	validGen := validWTF8BytesGen()
+	invalidGen := invalidWTF8FragmentGen()
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		prefix := validGen.Draw(t, "validPrefix")
+		invalid := invalidGen.Draw(t, "invalidFragment")
+		input := append(append([]byte(nil), prefix...), invalid...)
+
+		_, err := wtf8.ParseText(string(input))
+		h.Assertf(err != nil, "ParseText(% x) succeeded unexpectedly", input)
+		check.AssertSame(h, len(prefix), err.FirstInvalidSpan().Start(), "invalid span start")
+	})
+}
+
+func TestMustParseText(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	got := wtf8.MustParseText("aé😀")
+	check.AssertSame(h, "aé😀", got.String(), "parsed text")
+
+	panicked := false
+	func() {
+		defer func() { panicked = recover() != nil }()
+		_ = wtf8.MustParseText(string([]byte{0xff}))
+	}()
+	h.Assertf(panicked, "MustParseText should panic for invalid WTF-8")
+}
+
+func TestText_Len(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	text := wtf8.MustParseText("aé😀")
+	check.AssertSame(h, len("aé😀"), text.Len(), "byte length")
+}
+
+func TestText_GetByte(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	input := "aé😀"
+	text := wtf8.MustParseText(input)
+	for i := range len(input) {
+		check.AssertSame(h, input[i], text.GetByte(i), fmt.Sprintf("byte %d", i))
+	}
+}
+
+func TestText_Slice(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	text := wtf8.MustParseText("aé😀")
+	cases := []struct {
+		start int
+		end   int
+		want  string
+	}{
+		{start: 0, end: 0, want: ""},
+		{start: 0, end: 1, want: "a"},
+		{start: 1, end: 3, want: "é"},
+		{start: 3, end: 7, want: "😀"},
+		{start: 7, end: 7, want: ""},
+	}
+	for _, tc := range cases {
+		got := text.Slice(tc.start, tc.end)
+		check.AssertSame(h, tc.want, got.String(), "slice")
+	}
+
+	invalidCases := [][2]int{{-1, 0}, {1, 0}, {2, 3}, {1, 2}, {0, 8}}
+	for _, bounds := range invalidCases {
+		start, end := bounds[0], bounds[1]
+		h.AssertPanicsWith(
+			assert.AssertionError{
+				Fmt:  "precondition violation: invalid WTF-8 slice [%d, %d) for text of length %d",
+				Args: []any{start, end, 7},
+			},
+			func() { _ = text.Slice(start, end) },
+		)
+	}
+}
+
+func TestText_String(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	cases := []struct {
+		name        string
+		text        string
+		wantDefault string
+		wantQuoted  string
+	}{
+		{name: "ordinary", text: "aé", wantDefault: "aé", wantQuoted: `"aé"`},
+		{name: "high surrogate", text: "\xed\xa0\x80", wantDefault: `\ud800`, wantQuoted: `"\xed\xa0\x80"`},
+		{name: "low surrogate", text: "\xed\xb0\x80", wantDefault: `\udc00`, wantQuoted: `"\xed\xb0\x80"`},
+		{name: "surrogate with ASCII", text: "a\xed\xa0\x80b", wantDefault: `a\ud800b`, wantQuoted: `"a\xed\xa0\x80b"`},
+		{name: "separated surrogates", text: "\xed\xa0\x80x\xed\xb0\x80", wantDefault: `\ud800x\udc00`, wantQuoted: `"\xed\xa0\x80x\xed\xb0\x80"`},
+	}
+	for _, tc := range cases {
+		text := wtf8.MustParseText(tc.text)
+		check.AssertSame(h, tc.wantDefault, fmt.Sprintf("%v", text), tc.name+" %v")
+		check.AssertSame(h, tc.wantQuoted, fmt.Sprintf("%q", text), tc.name+" %q")
+		check.AssertSame(h, tc.wantQuoted, fmt.Sprintf("%#v", text), tc.name+" %#v")
+	}
+}
+
+func TestTextBuilder_WriteText(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	h.Run("unit", testTextBuilder_WriteTextUnit)
+	h.Run("property", testTextBuilder_WriteTextProperty)
+}
+
+func testTextBuilder_WriteTextUnit(h check.Harness) {
+	h.Parallel()
+
+	high := string([]byte{0xed, 0xa0, 0x80})
+	low := string([]byte{0xed, 0xb0, 0x80})
+	nonHighED := string([]byte{0xed, 0x80, 0x80})
+	afterLowRange := string([]byte{0xee, 0x80, 0x80})
+	supplementary := string([]byte{0xf0, 0x90, 0x80, 0x80})
+	cases := []struct {
+		name  string
+		left  string
+		right string
+		want  string
+	}{
+		{name: "ordinary", left: "foo", right: "bar", want: "foobar"},
+		{name: "empty right", left: "foo", right: "", want: "foo"},
+		{name: "high then low", left: high, right: low, want: supplementary},
+		{name: "high then ASCII", left: high, right: "x", want: high + "x"},
+		{name: "low then ASCII", left: low, right: "x", want: low + "x"},
+		{name: "non-high ed sequence", left: nonHighED, right: "x", want: nonHighED + "x"},
+		{name: "high then code point above low range", left: high, right: afterLowRange, want: high + afterLowRange},
+	}
+	for _, tc := range cases {
+		builder := wtf8.NewTextBuilder(len(tc.left) + len(tc.right))
+		builder.WriteText(mustParseBytes(h, []byte(tc.left)))
+		builder.WriteText(mustParseBytes(h, []byte(tc.right)))
+		check.AssertSame(h, tc.want, builder.Text().String(), tc.name)
+	}
+}
+
+func testTextBuilder_WriteTextProperty(h check.Harness) {
+	h.Parallel()
+
+	gen := generalizedCodePointGen()
+	rapid.Check(h.T(), func(t *rapid.T) {
+		h := check.NewBasic(t)
+		leftCodePoint := gen.Draw(t, "left")
+		rightCodePoint := gen.Draw(t, "right")
+		leftBytes := appendGeneralizedUTF8(nil, leftCodePoint)
+		rightBytes := appendGeneralizedUTF8(nil, rightCodePoint)
+		left := mustParseBytes(h, leftBytes)
+		right := mustParseBytes(h, rightBytes)
+
+		var builder wtf8.TextBuilder
+		builder.WriteText(left)
+		builder.WriteText(right)
+		got := builder.Text().String()
+		_, gotErr := wtf8.ParseText(got)
+		h.Assertf(gotErr == nil, "WriteText produced invalid WTF-8: % x: %v", []byte(got), gotErr)
+
+		if supplementary := utf16.DecodeRune(leftCodePoint, rightCodePoint); supplementary != stdutf8.RuneError {
+			want := string(stdutf8.AppendRune(nil, supplementary))
+			check.AssertSame(h, want, got, "joined surrogate pair")
+		} else {
+			want := string(slices.Concat(leftBytes, rightBytes))
+			check.AssertSame(h, want, got, "ordinary concatenation")
+		}
+	})
+}
+
+func TestTextBuilder_WriteASCIIByte(t *testing.T) {
+	h := check.New(t)
+	h.Parallel()
+
+	var builder wtf8.TextBuilder
+	builder.WriteASCIIByte(0)
+	builder.WriteASCIIByte(0x7f)
+	check.AssertSame(h, string([]byte{0, 0x7f}), builder.Text().String(), "ASCII bytes")
+
+	h.AssertPanicsWith(
+		assert.AssertionError{
+			Fmt:  "precondition violation: wtf8.TextBuilder.WriteASCIIByte: 0x%02x is not ASCII",
+			Args: []any{byte(0x80)},
+		},
+		func() { builder.WriteASCIIByte(0x80) },
+	)
+}
+
+// mustParseBytes parses raw WTF-8 bytes into a Text.
+func mustParseBytes(h check.BasicHarness, bytes []byte) wtf8.Text {
+	text, err := wtf8.ParseText(string(bytes))
+	h.Assertf(err == nil, "ParseText(% x) returned error: %v", bytes, err)
+	return text
+}
+
+type codePointRange struct {
+	min int32
+	max int32
+}
+
+// generalizedCodePointGen samples the code-point ranges corresponding to the
+// byte-sequence classes in Table 3 of the generalized UTF-8 specification.
+// Explicit ranges keep the smaller classes from being overwhelmed by the
+// supplementary code-point range.
+func generalizedCodePointGen() *rapid.Generator[rune] {
+	rangeGen := rapid.SampledFrom([]codePointRange{
+		// One-byte, two-byte, and e0 three-byte sequences.
+		{min: 0, max: 0x7f},
+		{min: 0x80, max: 0x7ff},
+		{min: 0x800, max: 0xfff},
+
+		// The e1–ef class.
+		{min: 0x1000, max: 0xd7ff},
+		{min: 0xd800, max: 0xdbff}, // high surrogates
+		{min: 0xdc00, max: 0xdfff}, // low surrogates
+		{min: 0xe000, max: 0xffff},
+
+		// The three four-byte sequence classes.
+		{min: 0x10000, max: 0x3ffff},
+		{min: 0x40000, max: 0xfffff},
+		{min: 0x100000, max: 0x10ffff},
+	})
+	return rapid.Custom(func(t *rapid.T) rune {
+		bounds := rangeGen.Draw(t, "range")
+		return rapid.Int32Range(bounds.min, bounds.max).Draw(t, "value")
+	})
+}
+
+func validWTF8BytesGen() *rapid.Generator[[]byte] {
+	codePointsGen := rapid.SliceOfN(generalizedCodePointGen(), 0, 64)
+	return rapid.Custom(func(t *rapid.T) []byte {
+		codePoints := codePointsGen.Draw(t, "codePoints")
+		bytes := make([]byte, 0, 4*len(codePoints))
+		for i, codePoint := range codePoints {
+			bytes = appendGeneralizedUTF8(bytes, codePoint)
+			if i+1 < len(codePoints) {
+				// Separating generated code points prevents a high-low surrogate pair.
+				bytes = append(bytes, 0)
+			}
+		}
+		return bytes
+	})
+}
+
+func invalidWTF8FragmentGen() *rapid.Generator[[]byte] {
+	return rapid.SampledFrom([][]byte{
+		// Invalid first bytes: a continuation byte, the highest overlong two-byte
+		// prefix, and a prefix above the maximum valid code point. The trailing
+		// ASCII byte in the last case exercises the four-byte invalid-span limit.
+		{0x80},
+		{0xc1},
+		{0xf5, 0x80, 0x80, 0x80, 'x'},
+
+		// Truncated two-byte sequence.
+		{0xc2},
+
+		// e0 sequence: truncated input, second byte below or above its restricted
+		// range, and an invalid third byte.
+		{0xe0},
+		{0xe0, 0x9f, 0x80},
+		{0xe0, 0xc0, 0x80},
+		{0xe0, 0xa0, 0x7f},
+
+		// e1–ef sequence: each invalid continuation position. Truncation is
+		// already covered by the unit cases.
+		{0xe1, 0x7f, 0x80},
+		{0xe1, 0x80, 0x7f},
+
+		// f0 sequence: truncated input, second byte below or above its restricted
+		// range, and each remaining invalid continuation position.
+		{0xf0},
+		{0xf0, 0x8f, 0x80, 0x80},
+		{0xf0, 0xc0, 0x80, 0x80},
+		{0xf0, 0x90, 0x7f, 0x80},
+		{0xf0, 0x90, 0x80, 0x7f},
+
+		// f1–f3 sequence: truncated input and each invalid continuation position.
+		{0xf1},
+		{0xf1, 0x7f, 0x80, 0x80},
+		{0xf1, 0x80, 0x7f, 0x80},
+		{0xf1, 0x80, 0x80, 0x7f},
+
+		// f4 sequence: truncated input, second byte below or above its restricted
+		// range, and each remaining invalid continuation position.
+		{0xf4},
+		{0xf4, 0x7f, 0x80, 0x80},
+		{0xf4, 0x90, 0x80, 0x80},
+		{0xf4, 0x80, 0x7f, 0x80},
+		{0xf4, 0x80, 0x80, 0x7f},
+	})
+}
+
+// appendGeneralizedUTF8 appends the generalized UTF-8 encoding of codePoint.
+func appendGeneralizedUTF8(bytes []byte, codePoint rune) []byte {
+	// The standard library handles scalar values; only surrogates need encoding here.
+	if !utf16.IsSurrogate(codePoint) {
+		return stdutf8.AppendRune(bytes, codePoint)
+	}
+	return append(bytes,
+		byte(0xe0|codePoint>>12),
+		byte(0x80|(codePoint>>6)&0x3f),
+		byte(0x80|codePoint&0x3f),
+	)
+}


### PR DESCRIPTION
WTF-8 is a superset of UTF-8 which allows for unpaired surrogates.
This is useful for internal representation of strings which are
usually well-formed Unicode (hence, could be represented as either
UTF-8, UTF-16, UTF-32 or something else), but can sometimes have
unpaired surrogates because they come from a UTF-16 based system
which does not enforce well-formedness.

This involves allocations at the boundaries, but allows cheaper
interconversion between UTF-8 and WTF-8 internally within the
application.

The Go and Rust stdlibs already use this representation for
filepaths on Windows. That's also one of the main use cases that
we care about.
