### PR TITLE
fix(go): Avoid reading system-wide git config in TestScript

### DIFF
--- a/go/src/cmd/go/script_test.go
+++ b/go/src/cmd/go/script_test.go
@@ -255,6 +255,7 @@ func scriptEnv(srv *vcstest.Server, srvCertFile string) ([]string, error) {
 		"goversion=" + gover.Local(),
 		"CMDGO_TEST_RUN_MAIN=true",
 		"HGRCPATH=",
+		"GIT_CONFIG_NOSYSTEM=1", // https://git-scm.com/docs/git-config#Documentation/git-config.txt-GITCONFIGNOSYSTEM
 		"GOTOOLCHAIN=auto",
 		"newline=\n",
 	}


### PR DESCRIPTION
`TestScript` is a top-level test which runs a lot of
subprocesses, including `git`. It tries to be hermetic,
but there was a gap where the `git` configuration could
be read from the system-wide git configuration.

On my Mac, this manifested as Keychain dialog boxes with running
`TestTransportProxyDialDoesNotMutateProxyConnectHeader`
which has this:

```
		u.User = url.UserPassword("aladdin", "opensesame")
```

This would go and read:

```
/opt/homebrew/etc/gitconfig:
      [credential]
          helper = osxkeychain
```

Leading to the dialog prompt. This patch sets an env var
to avoid consulting the system-wide git config.
